### PR TITLE
Add components page with modern UI library

### DIFF
--- a/examples/express/public/styles.css
+++ b/examples/express/public/styles.css
@@ -139,6 +139,68 @@
     /* Container query breakpoints */
     --cq-compact: 20rem;
     --cq-medium: 30rem;
+
+    /* Inset surfaces */
+    --surface-inset: #08080a;
+
+    /* Track (range, progress) */
+    --track-bg: #2a2a38;
+    --track-fill: var(--accent);
+    --track-height: 0.375rem;
+    --thumb-size: 1.125rem;
+
+    /* Meter */
+    --meter-low: var(--danger);
+    --meter-mid: var(--accent);
+    --meter-high: var(--success);
+
+    /* Mark */
+    --mark-bg: #e8a44a22;
+    --mark-text: var(--accent);
+
+    /* Kbd */
+    --kbd-bg: var(--surface-3);
+    --kbd-border: var(--border-accent);
+    --kbd-shadow: 0 2px 0 var(--border);
+
+    /* Blockquote */
+    --blockquote-border: var(--accent-dim);
+
+    /* Table */
+    --table-stripe: #ffffff06;
+    --table-header-bg: var(--surface-2);
+
+    /* Details */
+    --details-marker: var(--accent);
+
+    /* Dialog */
+    --dialog-bg: var(--surface-1);
+    --dialog-border: var(--border-accent);
+    --dialog-backdrop: #0a0a0ccc;
+    --dialog-shadow: 0 16px 64px -16px #000a;
+
+    /* Popover */
+    --popover-bg: var(--surface-2);
+    --popover-border: var(--border-accent);
+    --popover-shadow: 0 8px 32px -8px #000a;
+    --popover-radius: var(--radius-md);
+    --anchor-offset: var(--space-sm);
+
+    /* Tooltip */
+    --tooltip-bg: var(--surface-3);
+    --tooltip-text: var(--text-0);
+    --tooltip-font-size: var(--font-size-xs);
+
+    /* Select */
+    --select-bg: var(--surface-0);
+    --select-option-hover: var(--surface-3);
+
+    /* Checkbox / Radio */
+    --control-size: 1.125rem;
+    --control-bg: var(--surface-0);
+    --control-border: var(--border);
+    --control-checked-bg: var(--accent);
+    --control-checked-border: var(--accent);
   }
 }
 
@@ -459,6 +521,246 @@
   input[type="text"]:focus { border-color: var(--accent); box-shadow: var(--shadow-input), var(--shadow-btn); }
   input[type="text"]::placeholder { color: var(--text-2); }
 
+  /* -- Textarea -- */
+  textarea {
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    font-size: var(--font-size-base);
+    line-height: var(--line-height-code);
+    padding: var(--space-sm) var(--space-md);
+    background: var(--surface-0);
+    color: var(--text-0);
+    border: var(--border-width) solid var(--border);
+    border-radius: var(--radius-sm);
+    outline: none;
+    resize: vertical;
+    field-sizing: content;
+    min-block-size: 4lh;
+    transition: border-color var(--duration-med), box-shadow var(--duration-med);
+  }
+  textarea:focus { border-color: var(--accent); box-shadow: var(--shadow-input), var(--shadow-btn); }
+  textarea::placeholder { color: var(--text-2); }
+
+  /* -- Checkbox -- */
+  input[type="checkbox"] {
+    appearance: none;
+    inline-size: var(--control-size);
+    block-size: var(--control-size);
+    background: var(--control-bg);
+    border: var(--border-width) solid var(--control-border);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    position: relative;
+    flex-shrink: 0;
+    transition: background var(--duration-fast), border-color var(--duration-fast), box-shadow var(--duration-fast);
+  }
+  input[type="checkbox"]:checked {
+    background: var(--control-checked-bg);
+    border-color: var(--control-checked-border);
+  }
+  input[type="checkbox"]:checked::after {
+    content: '';
+    position: absolute;
+    inset-block-start: 0.125rem;
+    inset-inline-start: 0.3125rem;
+    inline-size: 0.3125rem;
+    block-size: 0.5625rem;
+    border: solid var(--surface-0);
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+  }
+  input[type="checkbox"]:focus-visible { outline: var(--border-inline-width) solid var(--accent); outline-offset: var(--border-inline-width); }
+
+  /* -- Radio -- */
+  input[type="radio"] {
+    appearance: none;
+    inline-size: var(--control-size);
+    block-size: var(--control-size);
+    background: var(--control-bg);
+    border: var(--border-width) solid var(--control-border);
+    border-radius: 50%;
+    cursor: pointer;
+    position: relative;
+    flex-shrink: 0;
+    transition: background var(--duration-fast), border-color var(--duration-fast);
+  }
+  input[type="radio"]:checked {
+    border-color: var(--control-checked-border);
+  }
+  input[type="radio"]:checked::after {
+    content: '';
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-start: 50%;
+    inline-size: 0.5rem;
+    block-size: 0.5rem;
+    background: var(--control-checked-bg);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+  }
+  input[type="radio"]:focus-visible { outline: var(--border-inline-width) solid var(--accent); outline-offset: var(--border-inline-width); }
+
+  /* -- Range -- */
+  input[type="range"] {
+    appearance: none;
+    inline-size: 100%;
+    block-size: var(--track-height);
+    background: linear-gradient(to right, var(--track-fill) calc(var(--range-pct, 50) * 1%), var(--track-bg) calc(var(--range-pct, 50) * 1%));
+    border-radius: var(--radius-pill);
+    outline: none;
+    cursor: pointer;
+  }
+  input[type="range"]::-webkit-slider-thumb {
+    appearance: none;
+    inline-size: var(--thumb-size);
+    block-size: var(--thumb-size);
+    background: var(--accent);
+    border: var(--border-inline-width) solid var(--surface-0);
+    border-radius: 50%;
+    box-shadow: 0 0 8px var(--accent-glow);
+    transition: box-shadow var(--duration-fast), scale var(--duration-fast);
+  }
+  input[type="range"]::-webkit-slider-thumb:hover { scale: 1.15; box-shadow: 0 0 16px var(--accent-glow-strong); }
+  input[type="range"]:focus-visible { outline: var(--border-inline-width) solid var(--accent); outline-offset: var(--space-xs); }
+
+  /* -- Date input -- */
+  input[type="date"] {
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    font-size: var(--font-size-base);
+    padding: var(--space-sm) var(--space-md);
+    background: var(--surface-0);
+    color: var(--text-0);
+    border: var(--border-width) solid var(--border);
+    border-radius: var(--radius-sm);
+    outline: none;
+    color-scheme: dark;
+    transition: border-color var(--duration-med), box-shadow var(--duration-med);
+  }
+  input[type="date"]:focus { border-color: var(--accent); box-shadow: var(--shadow-input), var(--shadow-btn); }
+  input[type="date"]::-webkit-calendar-picker-indicator { filter: invert(0.7); cursor: pointer; }
+
+  /* -- Select (base-select) -- */
+  select {
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    font-size: var(--font-size-base);
+    padding: var(--space-sm) var(--space-md);
+    padding-inline-end: var(--space-xl);
+    background: var(--select-bg);
+    color: var(--text-0);
+    border: var(--border-width) solid var(--border);
+    border-radius: var(--radius-sm);
+    outline: none;
+    cursor: pointer;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%23e8a44a' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right var(--space-sm) center;
+    background-size: 0.625rem;
+    transition: border-color var(--duration-med), box-shadow var(--duration-med);
+  }
+  select:focus { border-color: var(--accent); box-shadow: var(--shadow-input), var(--shadow-btn); }
+
+  @supports (appearance: base-select) {
+    select,
+    select::picker(select) {
+      appearance: base-select;
+    }
+
+    select {
+      padding-inline-end: var(--space-md);
+      background-image: none;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    select::picker-icon {
+      content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8' width='10' height='7'%3E%3Cpath d='M1.5 1.5l4.5 4.5 4.5-4.5' stroke='%23e8a44a' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+      margin-inline-start: auto;
+      transition: rotate var(--duration-fast);
+    }
+    select:open::picker-icon {
+      rotate: 180deg;
+    }
+
+    select::picker(select) {
+      background: var(--popover-bg);
+      border: var(--border-width) solid var(--popover-border);
+      border-radius: var(--popover-radius);
+      box-shadow: var(--popover-shadow);
+      padding: var(--space-xs);
+      transition: opacity var(--duration-fast), scale var(--duration-fast);
+      transition-behavior: allow-discrete;
+      opacity: 1;
+      scale: 1;
+    }
+
+    @starting-style {
+      select::picker(select) {
+        opacity: 0;
+        scale: 0.96;
+      }
+    }
+
+    select option {
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-base);
+      padding: var(--space-sm) var(--space-md);
+      border-radius: var(--radius-sm);
+      color: var(--text-0);
+      transition: background var(--duration-fast);
+    }
+    select option:hover { background: var(--select-option-hover); }
+    select option:checked { color: var(--accent); font-weight: var(--font-weight-semibold); }
+
+    select option::checkmark {
+      color: var(--accent);
+      margin-inline-end: var(--space-sm);
+    }
+
+    select optgroup {
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-xs);
+      color: var(--text-2);
+      text-transform: uppercase;
+      letter-spacing: var(--letter-spacing-wider);
+      padding: var(--space-sm) var(--space-md);
+    }
+  }
+
+  /* -- Progress -- */
+  progress {
+    appearance: none;
+    inline-size: 100%;
+    block-size: var(--track-height);
+    border: none;
+    border-radius: var(--radius-pill);
+    overflow: hidden;
+    background: var(--track-bg);
+  }
+  progress::-webkit-progress-bar { background: var(--track-bg); border-radius: var(--radius-pill); }
+  progress::-webkit-progress-value { background: var(--track-fill); border-radius: var(--radius-pill); transition: inline-size var(--duration-med); }
+  progress::-moz-progress-bar { background: var(--track-fill); border-radius: var(--radius-pill); }
+
+  /* -- Meter -- */
+  meter {
+    appearance: none;
+    inline-size: 100%;
+    block-size: var(--track-height);
+    border: none;
+    border-radius: var(--radius-pill);
+    overflow: hidden;
+    background: var(--track-bg);
+  }
+  meter::-webkit-meter-bar { background: var(--track-bg); border-radius: var(--radius-pill); border: none; block-size: var(--track-height); }
+  meter::-webkit-meter-optimum-value { background: var(--meter-high); border-radius: var(--radius-pill); }
+  meter::-webkit-meter-suboptimum-value { background: var(--meter-mid); border-radius: var(--radius-pill); }
+  meter::-webkit-meter-even-less-good-value { background: var(--meter-low); border-radius: var(--radius-pill); }
+
   /* -- Controls nav -- */
   nav[data-controls] { display: flex; gap: var(--space-sm); flex-wrap: wrap; margin-block-start: var(--space-md); }
 
@@ -470,6 +772,14 @@
     font-size: var(--font-size-sm);
     color: var(--text-1);
     margin-block-end: var(--space-md);
+  }
+
+  /* Inline output inside labels */
+  abbr output {
+    display: inline;
+    margin: 0;
+    font-size: inherit;
+    color: inherit;
   }
 
   /* -- Code blocks -- */
@@ -565,6 +875,525 @@
     margin-block-end: var(--space-md);
   }
 
+  /* -- Fieldset / Legend -- */
+  fieldset {
+    border: var(--border-width) solid var(--border);
+    border-radius: var(--radius-md);
+    padding: var(--space-lg);
+    margin-block-end: var(--space-md);
+  }
+
+  legend {
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--accent);
+    letter-spacing: var(--letter-spacing-wider);
+    text-transform: uppercase;
+    padding-inline: var(--space-sm);
+  }
+
+  fieldset > label + label { margin-block-start: var(--space-md); }
+
+  /* -- Inline label (for checkbox/radio rows) -- */
+  label:has(input[type="checkbox"]),
+  label:has(input[type="radio"]) {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-sm);
+    cursor: pointer;
+    font-size: var(--font-size-base);
+    color: var(--text-1);
+  }
+
+  /* -- Table -- */
+  table {
+    inline-size: 100%;
+    border-collapse: collapse;
+    font-size: var(--font-size-base);
+  }
+
+  thead {
+    position: sticky;
+    inset-block-start: 0;
+    z-index: 1;
+  }
+
+  th {
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    color: var(--text-2);
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-wider);
+    text-align: start;
+    padding: var(--space-sm) var(--space-md);
+    background: var(--table-header-bg);
+    border-block-end: var(--border-width) solid var(--border-accent);
+  }
+
+  td {
+    padding: var(--space-sm) var(--space-md);
+    border-block-end: var(--border-width) solid var(--border);
+    color: var(--text-1);
+  }
+
+  tbody tr:nth-child(even) { background: var(--table-stripe); }
+  tbody tr { transition: background var(--duration-fast); }
+  tbody tr:hover { background: var(--surface-2); }
+
+  /* -- Blockquote -- */
+  blockquote {
+    font-family: var(--font-family);
+    font-stretch: var(--font-serif);
+    font-size: var(--font-size-lg);
+    font-style: italic;
+    color: var(--text-1);
+    border-inline-start: var(--border-code-width) solid var(--blockquote-border);
+    padding-inline-start: var(--space-lg);
+    padding-block: var(--space-sm);
+    margin-block: var(--space-md);
+  }
+
+  blockquote footer {
+    font-stretch: var(--font-mono);
+    font-style: normal;
+    font-size: var(--font-size-sm);
+    color: var(--text-2);
+    margin-block-start: var(--space-sm);
+    border: none;
+    padding: 0;
+    text-align: start;
+  }
+
+  /* -- Kbd -- */
+  kbd {
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    font-size: 0.85em;
+    padding: 0.1em 0.4em;
+    background: var(--kbd-bg);
+    border: var(--border-width) solid var(--kbd-border);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--kbd-shadow);
+    color: var(--text-0);
+    white-space: nowrap;
+  }
+
+  /* -- Mark -- */
+  mark {
+    background: var(--mark-bg);
+    color: var(--mark-text);
+    padding-inline: 0.2em;
+    border-radius: 0.15em;
+  }
+
+  /* -- Abbr -- */
+  abbr[title] {
+    text-decoration: underline dotted var(--text-2);
+    text-underline-offset: 0.2em;
+    cursor: help;
+  }
+
+  /* -- Details / Summary -- */
+  details {
+    border: var(--border-width) solid var(--border);
+    border-radius: var(--radius-md);
+    margin-block-end: var(--space-sm);
+    interpolate-size: allow-keywords;
+  }
+
+  summary {
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--text-0);
+    padding: var(--space-sm) var(--space-md);
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    transition: background var(--duration-fast), color var(--duration-fast);
+    border-radius: var(--radius-md);
+  }
+  summary:hover { background: var(--surface-2); color: var(--accent); }
+  summary::-webkit-details-marker { display: none; }
+
+  summary::before {
+    content: '▸';
+    color: var(--details-marker);
+    font-size: 0.85em;
+    transition: rotate var(--duration-fast);
+  }
+  details[open] > summary::before { rotate: 90deg; }
+  details[open] > summary { margin-block-end: 0; }
+
+  details > :not(summary) {
+    padding: var(--space-sm) var(--space-md) var(--space-md);
+    color: var(--text-1);
+    font-size: var(--font-size-base);
+  }
+
+  /* -- Dialog -- */
+  dialog {
+    margin: auto;
+    background: var(--dialog-bg);
+    color: var(--text-0);
+    border: var(--border-width) solid var(--dialog-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-xl);
+    max-inline-size: min(90vi, 28rem);
+    box-shadow: var(--dialog-shadow);
+    transition: opacity var(--duration-med), scale var(--duration-med), overlay var(--duration-med), display var(--duration-med);
+    transition-behavior: allow-discrete;
+  }
+
+  dialog::backdrop {
+    background: var(--dialog-backdrop);
+    transition: opacity var(--duration-med), overlay var(--duration-med), display var(--duration-med);
+    transition-behavior: allow-discrete;
+  }
+
+  dialog[open] { opacity: 1; scale: 1; }
+
+  @starting-style {
+    dialog[open] { opacity: 0; scale: 0.95; }
+    dialog[open]::backdrop { opacity: 0; }
+  }
+
+  dialog > header {
+    margin-block-end: var(--space-md);
+    padding-block-end: var(--space-md);
+    border-block-end: var(--border-width) solid var(--border);
+  }
+
+  dialog > header h3 {
+    font-family: var(--font-family);
+    font-stretch: var(--font-serif);
+    font-size: var(--font-size-xl);
+    font-weight: var(--font-weight-normal);
+  }
+
+  dialog > footer {
+    margin-block-start: var(--space-lg);
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-sm);
+    border: none;
+    padding: 0;
+    text-align: start;
+  }
+
+  /* -- Popover -- */
+  [popover] {
+    margin: 0;
+    padding: var(--space-md);
+    background: var(--popover-bg);
+    color: var(--text-0);
+    border: var(--border-width) solid var(--popover-border);
+    border-radius: var(--popover-radius);
+    box-shadow: var(--popover-shadow);
+    inset: unset;
+    transition: opacity var(--duration-fast), scale var(--duration-fast), overlay var(--duration-fast), display var(--duration-fast);
+    transition-behavior: allow-discrete;
+    opacity: 1;
+    scale: 1;
+  }
+
+  [popover]::backdrop { background: transparent; }
+
+  @starting-style {
+    [popover]:popover-open { opacity: 0; scale: 0.96; }
+  }
+
+  /* Tooltip variant */
+  output[popover] {
+    display: none;
+    padding: var(--space-xs) var(--space-sm);
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    font-size: var(--tooltip-font-size);
+    background: var(--tooltip-bg);
+    color: var(--tooltip-text);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--popover-shadow);
+    max-inline-size: 20rem;
+    pointer-events: none;
+  }
+  output[popover]:popover-open { display: block; }
+
+  /* Dropdown menu variant */
+  nav[popover] {
+    display: none;
+    flex-direction: column;
+    gap: 0;
+    padding: var(--space-xs);
+    min-inline-size: 10rem;
+  }
+  nav[popover]:popover-open { display: flex; }
+
+  nav[popover] a,
+  nav[popover] button {
+    display: block;
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    font-size: var(--font-size-sm);
+    padding: var(--space-sm) var(--space-md);
+    color: var(--text-1);
+    text-decoration: none;
+    border-radius: var(--radius-sm);
+    border: none;
+    background: transparent;
+    text-align: start;
+    inline-size: 100%;
+    cursor: pointer;
+    transition: background var(--duration-fast), color var(--duration-fast);
+  }
+
+  nav[popover] a:hover,
+  nav[popover] button:hover {
+    background: var(--surface-3);
+    color: var(--accent);
+    box-shadow: none;
+  }
+
+  nav[popover] hr {
+    border: none;
+    border-block-start: var(--border-width) solid var(--border);
+    margin-block: var(--space-xs);
+  }
+
+  /* Popover card variant */
+  article[popover] {
+    container-type: normal;
+    inline-size: 20rem;
+    padding: var(--space-lg);
+  }
+
+  /* -- Anchor positioning -- */
+  @supports (anchor-name: --x) {
+    [popover] {
+      position: fixed;
+      position-try-fallbacks: flip-block, flip-inline;
+    }
+  }
+
+  /* -- Datepicker trigger (calendar icon button) -- */
+  [data-datepicker-trigger] {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--font-size-base);
+    color: var(--text-2);
+    cursor: pointer;
+    transition: color var(--duration-fast), background var(--duration-fast);
+  }
+  [data-datepicker-trigger]:hover { color: var(--accent); background: var(--surface-3); box-shadow: none; }
+  [data-datepicker-trigger] svg { display: block; }
+
+  /* -- Datepicker popover -- */
+  [data-datepicker] {
+    padding: var(--space-md);
+    min-inline-size: 18rem;
+  }
+
+  [data-datepicker-header] {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-block-end: var(--space-sm);
+    padding: 0;
+    border: none;
+  }
+
+  [data-datepicker-header] strong {
+    font-family: var(--font-family);
+    font-stretch: var(--font-serif);
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-normal);
+    color: var(--text-0);
+  }
+
+  [data-datepicker-header] button {
+    padding: var(--space-xs) var(--space-sm);
+    font-size: var(--font-size-sm);
+    background: transparent;
+    border: var(--border-width) solid var(--border);
+  }
+  [data-datepicker-header] button:hover {
+    background: var(--surface-3);
+    color: var(--accent);
+    border-color: var(--accent-dim);
+    box-shadow: none;
+  }
+
+  [data-datepicker-grid] {
+    inline-size: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+  }
+
+  [data-datepicker-grid] th {
+    font-size: var(--font-size-xs);
+    padding: var(--space-xs);
+    text-align: center;
+    color: var(--text-2);
+    background: transparent;
+    border: none;
+  }
+
+  [data-datepicker-grid] td {
+    padding: 0;
+    text-align: center;
+    border: none;
+  }
+
+  [data-datepicker-grid] td button {
+    inline-size: 2.25rem;
+    block-size: 2.25rem;
+    padding: 0;
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-sm);
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    background: transparent;
+    border: var(--border-width) solid transparent;
+    color: var(--text-1);
+    cursor: pointer;
+    transition: background var(--duration-fast), color var(--duration-fast), border-color var(--duration-fast);
+  }
+
+  [data-datepicker-grid] td button:hover {
+    background: var(--surface-3);
+    color: var(--text-0);
+    border-color: var(--border);
+    box-shadow: none;
+  }
+
+  [data-datepicker-grid] td button[data-today] {
+    border-color: var(--accent-dim);
+    color: var(--accent);
+  }
+
+  [data-datepicker-grid] td button[data-selected] {
+    background: var(--accent);
+    color: var(--surface-0);
+    border-color: var(--accent);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  /* -- Tasks page -- */
+  [data-hydrate] > h3 { margin-block-end: var(--space-md); }
+  [data-hydrate] > nav[data-controls] { margin-block-end: var(--space-md); }
+  [data-hydrate] > output { margin-block: var(--space-sm) var(--space-md); }
+
+  [data-hydrate] ul[role="list"] { gap: var(--space-sm); }
+  [data-hydrate] ul[role="list"] li {
+    padding: var(--space-md) var(--space-lg);
+    border-radius: var(--radius-md);
+    gap: var(--space-md);
+  }
+
+  /* -- Datepicker input group -- */
+  [data-datepicker-input] {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    background: var(--surface-0);
+    border: var(--border-width) solid var(--border);
+    border-radius: var(--radius-sm);
+    padding-inline-start: var(--space-md);
+    transition: border-color var(--duration-med), box-shadow var(--duration-med);
+  }
+  [data-datepicker-input]:focus-within {
+    border-color: var(--accent);
+    box-shadow: var(--shadow-input), var(--shadow-btn);
+  }
+
+  [data-datepicker-input] input {
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    font-size: var(--font-size-base);
+    background: transparent;
+    color: var(--text-0);
+    border: none;
+    outline: none;
+    padding: var(--space-sm) 0;
+    text-align: center;
+  }
+  [data-datepicker-input] input[data-date-month],
+  [data-datepicker-input] input[data-date-day] { inline-size: 2ch; }
+  [data-datepicker-input] input[data-date-year] { inline-size: 4ch; }
+  [data-datepicker-input] input::placeholder { color: var(--text-2); }
+
+  [data-datepicker-input] > span {
+    color: var(--text-2);
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    font-size: var(--font-size-base);
+    user-select: none;
+  }
+
+  [data-datepicker-input] > button {
+    margin-inline-start: auto;
+    align-self: stretch;
+    border: none;
+    border-inline-start: var(--border-width) solid var(--border);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+    background: var(--surface-2);
+    padding-inline: var(--space-md);
+  }
+
+  /* -- Datepicker month/year picker -- */
+  [data-datepicker-title-btn] {
+    background: transparent;
+    border: none;
+    font-family: var(--font-family);
+    font-stretch: var(--font-serif);
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-normal);
+    color: var(--text-0);
+    cursor: pointer;
+    padding: var(--space-xs) var(--space-sm);
+    border-radius: var(--radius-sm);
+    transition: background var(--duration-fast), color var(--duration-fast);
+  }
+  [data-datepicker-title-btn]:hover {
+    background: var(--surface-3);
+    color: var(--accent);
+    box-shadow: none;
+  }
+
+  [data-datepicker-months] {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-xs);
+    padding-block-start: var(--space-sm);
+  }
+
+  [data-datepicker-months] button {
+    padding: var(--space-sm);
+    font-size: var(--font-size-sm);
+    background: transparent;
+    border: var(--border-width) solid transparent;
+    border-radius: var(--radius-sm);
+    color: var(--text-1);
+    cursor: pointer;
+    transition: background var(--duration-fast), color var(--duration-fast), border-color var(--duration-fast);
+  }
+  [data-datepicker-months] button:hover {
+    background: var(--surface-3);
+    color: var(--text-0);
+    box-shadow: none;
+  }
+  [data-datepicker-months] button[data-current] {
+    border-color: var(--accent-dim);
+    color: var(--accent);
+  }
+
   /* -- Docs page -- */
   [data-code-preview] article + article {
     margin-block-start: var(--space-md);
@@ -619,6 +1448,18 @@
       align-items: start;
       gap: var(--space-xs);
     }
+  }
+
+  /* Table: horizontal scroll on narrow containers */
+  @container card (max-width: 24rem) {
+    table { font-size: var(--font-size-sm); }
+    th, td { padding: var(--space-xs) var(--space-sm); }
+  }
+
+  /* Fieldset: tighter spacing on narrow containers */
+  @container card (max-width: 20rem) {
+    fieldset { padding: var(--space-md); }
+    fieldset > label + label { margin-block-start: var(--space-sm); }
   }
 
   /* Viewport fallback for elements outside containers (header/footer) */

--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -24,7 +24,7 @@ let tasks = [
 ];
 
 // -- Layout helper --
-const navPages = ['home', 'tasks', 'playground', 'docs'];
+const navPages = ['home', 'tasks', 'playground', 'docs', 'components'];
 
 function renderPage(viewFile, ctx, { title, scripts = '', activePage = '' }) {
   const layout = read('views/layout.html');
@@ -92,6 +92,29 @@ app.get('/playground', (req, res) => {
 
 app.get('/docs', (req, res) => {
   const html = renderPage('docs.html', {}, { title: 'API Docs', activePage: 'docs' });
+  res.send(html);
+});
+
+app.get('/components', (req, res) => {
+  const ctx = {
+    tableData: [
+      { feature: '@if / @else', type: 'Directive', status: 'stable', since: '0.1.0' },
+      { feature: '@for / @empty', type: 'Directive', status: 'stable', since: '0.1.0' },
+      { feature: '@switch / @case', type: 'Directive', status: 'stable', since: '0.1.0' },
+      { feature: 'signal()', type: 'Reactive', status: 'stable', since: '0.1.0' },
+      { feature: 'computed()', type: 'Reactive', status: 'stable', since: '0.1.0' },
+      { feature: 'effect()', type: 'Reactive', status: 'stable', since: '0.1.0' },
+      { feature: 'Popover API', type: 'Platform', status: 'new', since: '0.2.0' },
+      { feature: 'Anchor Positioning', type: 'Platform', status: 'new', since: '0.2.0' },
+    ],
+    selectOptions: [
+      { value: 'signal', label: 'signal()' },
+      { value: 'computed', label: 'computed()' },
+      { value: 'effect', label: 'effect()' },
+      { value: 'hydrate', label: 'hydrate()' },
+    ],
+  };
+  const html = renderPage('components.html', ctx, { title: 'Components', activePage: 'components' });
   res.send(html);
 });
 

--- a/examples/express/views/components.html
+++ b/examples/express/views/components.html
@@ -1,0 +1,584 @@
+<section>
+  <h2>Component <em>Library</em></h2>
+  <p>Every element styled with CSS custom properties, cascade layers, and modern platform APIs. No div, no span, no build step.</p>
+</section>
+
+<!-- ═══════════════════════════════════════════ -->
+<!-- FORM CONTROLS                              -->
+<!-- ═══════════════════════════════════════════ -->
+
+<section>
+  <h2>Form <em>Controls</em></h2>
+
+  <article>
+    <header><h3>Text &amp; Textarea</h3></header>
+    <fieldset>
+      <legend>Contact</legend>
+      <label>
+        <abbr>Name</abbr>
+        <input type="text" placeholder="Jane Doe">
+      </label>
+      <label>
+        <abbr>Email</abbr>
+        <input type="text" placeholder="jane@example.com">
+      </label>
+      <label>
+        <abbr>Message</abbr>
+        <textarea placeholder="Write something..."></textarea>
+      </label>
+    </fieldset>
+  </article>
+
+  <article>
+    <header><h3>Checkbox &amp; Radio</h3></header>
+    <fieldset>
+      <legend>Preferences</legend>
+      <label>
+        <input type="checkbox" checked> Enable dark mode
+      </label>
+      <label>
+        <input type="checkbox"> Send notifications
+      </label>
+      <label>
+        <input type="checkbox" checked> Auto-save drafts
+      </label>
+    </fieldset>
+    <fieldset>
+      <legend>Framework</legend>
+      <label>
+        <input type="radio" name="framework" value="basenative" checked> BaseNative
+      </label>
+      <label>
+        <input type="radio" name="framework" value="other"> Something else
+      </label>
+      <label>
+        <input type="radio" name="framework" value="none"> Vanilla only
+      </label>
+    </fieldset>
+  </article>
+
+  <article>
+    <header><h3>Range</h3></header>
+    <p>Drag a slider to update its value in real time via signals.</p>
+    <fieldset>
+      <legend>Settings</legend>
+      <label>
+        <abbr>Volume — <output data-volume-value>65</output>%</abbr>
+        <input type="range" min="0" max="100" value="65" data-volume-input>
+      </label>
+      <label>
+        <abbr>Brightness — <output data-brightness-value>40</output>%</abbr>
+        <input type="range" min="0" max="100" value="40" data-brightness-input>
+      </label>
+    </fieldset>
+  </article>
+
+  <article>
+    <header><h3>Date Picker</h3></header>
+    <p>A custom popover-based date picker built with signals, <code>popover</code>, and CSS Anchor Positioning. Tab through month, day, and year fields or click the calendar to pick visually.</p>
+    <fieldset>
+      <legend>Schedule</legend>
+      <label>
+        <abbr>Start date</abbr>
+        <nav data-datepicker-input style="anchor-name: --datepicker">
+          <input type="text" data-date-month placeholder="MM" maxlength="2" inputmode="numeric" aria-label="Month">
+          <span>/</span>
+          <input type="text" data-date-day placeholder="DD" maxlength="2" inputmode="numeric" aria-label="Day">
+          <span>/</span>
+          <input type="text" data-date-year placeholder="YYYY" maxlength="4" inputmode="numeric" aria-label="Year">
+          <button type="button" data-datepicker-trigger aria-label="Open calendar"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg></button>
+        </nav>
+      </label>
+      <section popover id="datepicker-popover" style="position-anchor: --datepicker; position-area: bottom span-right; margin-block-start: var(--anchor-offset);" data-datepicker>
+        <header data-datepicker-header>
+          <button data-datepicker-prev aria-label="Previous">&larr;</button>
+          <button type="button" data-datepicker-title-btn></button>
+          <button data-datepicker-next aria-label="Next">&rarr;</button>
+        </header>
+        <table data-datepicker-grid>
+          <thead>
+            <tr>
+              <th>Su</th><th>Mo</th><th>Tu</th><th>We</th><th>Th</th><th>Fr</th><th>Sa</th>
+            </tr>
+          </thead>
+          <tbody data-datepicker-body></tbody>
+        </table>
+        <nav data-datepicker-months style="display:none"></nav>
+      </section>
+    </fieldset>
+  </article>
+
+  <article>
+    <header><h3>Select Menu</h3></header>
+    <p>Using <code>appearance: base-select</code> for fully styleable dropdowns. Falls back gracefully in older browsers.</p>
+    <fieldset>
+      <legend>API</legend>
+      <label>
+        <abbr>Function</abbr>
+        <select>
+          <option value="">Choose...</option>
+          <template @for="opt of selectOptions; track opt.value">
+            <option :value="opt.value">{{ opt.label }}</option>
+          </template>
+        </select>
+      </label>
+      <label>
+        <abbr>Category</abbr>
+        <select>
+          <option value="">All categories</option>
+          <optgroup label="Reactivity">
+            <option value="signals">Signals</option>
+            <option value="computed">Computed</option>
+            <option value="effects">Effects</option>
+          </optgroup>
+          <optgroup label="Rendering">
+            <option value="ssr">Server-side</option>
+            <option value="hydration">Hydration</option>
+          </optgroup>
+        </select>
+      </label>
+    </fieldset>
+  </article>
+</section>
+
+<!-- ═══════════════════════════════════════════ -->
+<!-- FEEDBACK                                   -->
+<!-- ═══════════════════════════════════════════ -->
+
+<section>
+  <h2><em>Feedback</em></h2>
+
+  <article>
+    <header><h3>Progress &amp; Meter</h3></header>
+    <fieldset>
+      <legend>Build status</legend>
+      <label>
+        <abbr>Bundle progress</abbr>
+        <progress max="100" value="72"></progress>
+      </label>
+      <label>
+        <abbr>Test coverage</abbr>
+        <progress max="100" value="95"></progress>
+      </label>
+      <label>
+        <abbr>Memory usage (healthy)</abbr>
+        <meter min="0" max="100" low="25" high="75" optimum="50" value="42"></meter>
+      </label>
+      <label>
+        <abbr>CPU load (warning)</abbr>
+        <meter min="0" max="100" low="25" high="75" optimum="25" value="78"></meter>
+      </label>
+      <label>
+        <abbr>Disk space (critical)</abbr>
+        <meter min="0" max="100" low="25" high="75" optimum="25" value="92"></meter>
+      </label>
+    </fieldset>
+  </article>
+
+  <article>
+    <header><h3>Status Badges</h3></header>
+    <p>
+      <mark data-status="active">active</mark>
+      <mark data-status="idle">idle</mark>
+      <mark data-status="error">error</mark>
+      <mark data-status="pending">pending</mark>
+      <mark data-status="done">done</mark>
+    </p>
+  </article>
+</section>
+
+<!-- ═══════════════════════════════════════════ -->
+<!-- CONTENT ELEMENTS                           -->
+<!-- ═══════════════════════════════════════════ -->
+
+<section>
+  <h2>Content <em>Elements</em></h2>
+
+  <article>
+    <header><h3>Blockquote</h3></header>
+    <blockquote>
+      <p>The best interface is no interface. The best framework is the platform itself.</p>
+      <footer>-- BaseNative philosophy</footer>
+    </blockquote>
+  </article>
+
+  <article>
+    <header><h3>Table</h3></header>
+    <table>
+      <thead>
+        <tr>
+          <th>Feature</th>
+          <th>Type</th>
+          <th>Status</th>
+          <th>Since</th>
+        </tr>
+      </thead>
+      <tbody>
+        <template @for="row of tableData; track row.feature">
+          <tr>
+            <td>{{ row.feature }}</td>
+            <td>{{ row.type }}</td>
+            <td><mark data-status="{{ row.status === 'new' ? 'idle' : 'active' }}">{{ row.status }}</mark></td>
+            <td>{{ row.since }}</td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+  </article>
+
+  <article>
+    <header><h3>Details &amp; Summary</h3></header>
+    <details>
+      <summary>What is BaseNative?</summary>
+      <p>A lightweight component library built on native HTML templates and signals-based reactivity. Zero dependencies, zero build steps, ~120 lines of runtime.</p>
+    </details>
+    <details>
+      <summary>How does font-stretch switching work?</summary>
+      <p>A single <code>BaseNative</code> font family maps three typefaces to different <code>font-stretch</code> values: <kbd>normal</kbd> for sans-serif, <kbd>expanded</kbd> for serif, and <kbd>ultra-condensed</kbd> for monospace.</p>
+    </details>
+    <details open>
+      <summary>Is this production-ready?</summary>
+      <p>It is a proof of concept demonstrating what is possible with the modern web platform. Use it as a foundation and adapt it to your needs.</p>
+    </details>
+  </article>
+
+  <article>
+    <header><h3>Keyboard &amp; Inline Elements</h3></header>
+    <p>Press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> to open the command palette. Use <mark>semantic HTML</mark> with <abbr title="Cascading Style Sheets">CSS</abbr> custom properties for a <abbr title="User Interface">UI</abbr> that respects the platform.</p>
+  </article>
+
+  <article>
+    <header><h3>Fieldset</h3></header>
+    <fieldset>
+      <legend>Account</legend>
+      <label>
+        <abbr>Username</abbr>
+        <input type="text" placeholder="@handle">
+      </label>
+      <label>
+        <abbr>Bio</abbr>
+        <textarea placeholder="Tell us about yourself..."></textarea>
+      </label>
+    </fieldset>
+  </article>
+</section>
+
+<!-- ═══════════════════════════════════════════ -->
+<!-- OVERLAYS                                   -->
+<!-- ═══════════════════════════════════════════ -->
+
+<section>
+  <h2><em>Overlays</em></h2>
+
+  <article>
+    <header><h3>Dialog</h3></header>
+    <p>Native <code>&lt;dialog&gt;</code> with <code>@starting-style</code> entrance animation and styled <code>::backdrop</code>.</p>
+    <nav data-controls>
+      <button data-open-dialog="demo-dialog">Open Dialog</button>
+    </nav>
+    <dialog id="demo-dialog">
+      <header>
+        <h3>Confirm Action</h3>
+      </header>
+      <p>This dialog uses the native <code>&lt;dialog&gt;</code> element with CSS-only entrance animation via <code>@starting-style</code> and <code>transition-behavior: allow-discrete</code>.</p>
+      <footer>
+        <button data-variant="outline" data-close-dialog>Cancel</button>
+        <button data-close-dialog>Confirm</button>
+      </footer>
+    </dialog>
+  </article>
+
+  <article>
+    <header><h3>Tooltips</h3></header>
+    <p>Hover to reveal. Uses <code>popover</code> with CSS Anchor Positioning for placement.</p>
+    <nav data-controls>
+      <button data-tooltip="Creates a reactive value that notifies dependents on change." style="anchor-name: --tip-signal" popovertarget="tip-signal">signal()</button>
+      <button data-tooltip="Derives a read-only value from other signals." style="anchor-name: --tip-computed" popovertarget="tip-computed">computed()</button>
+      <button data-tooltip="Runs a function and re-runs when dependencies change." style="anchor-name: --tip-effect" popovertarget="tip-effect">effect()</button>
+    </nav>
+    <output popover="manual" id="tip-signal" style="position-anchor: --tip-signal; position-area: top; margin-block-end: var(--anchor-offset);">Creates a reactive value that notifies dependents on change.</output>
+    <output popover="manual" id="tip-computed" style="position-anchor: --tip-computed; position-area: top; margin-block-end: var(--anchor-offset);">Derives a read-only value from other signals.</output>
+    <output popover="manual" id="tip-effect" style="position-anchor: --tip-effect; position-area: top; margin-block-end: var(--anchor-offset);">Runs a function and re-runs when dependencies change.</output>
+  </article>
+
+  <article>
+    <header><h3>Dropdown Menu</h3></header>
+    <p>Click to open. Uses <code>popover="auto"</code> with anchor positioning — clicking one closes the other.</p>
+    <nav data-controls>
+      <button style="anchor-name: --menu-actions" popovertarget="menu-actions">Actions</button>
+      <button style="anchor-name: --menu-view" popovertarget="menu-view">View</button>
+    </nav>
+    <nav popover id="menu-actions" style="position-anchor: --menu-actions; position-area: bottom span-right; margin-block-start: var(--anchor-offset);">
+      <button>Edit</button>
+      <button>Duplicate</button>
+      <button>Move to folder</button>
+      <hr>
+      <button>Delete</button>
+    </nav>
+    <nav popover id="menu-view" style="position-anchor: --menu-view; position-area: bottom span-right; margin-block-start: var(--anchor-offset);">
+      <button>Compact</button>
+      <button>Comfortable</button>
+      <button>Spacious</button>
+    </nav>
+  </article>
+
+  <article>
+    <header><h3>Popover Card</h3></header>
+    <p>A richer popover with article-card styling for previews and info panels.</p>
+    <nav data-controls>
+      <button style="anchor-name: --card-preview" popovertarget="card-preview">Preview Card</button>
+    </nav>
+    <article popover id="card-preview" style="position-anchor: --card-preview; position-area: bottom; margin-block-start: var(--anchor-offset);">
+      <header><h3>BaseNative Runtime</h3></header>
+      <p>~120 lines of client-side JavaScript providing signals, computed values, effects, and template hydration. Zero dependencies.</p>
+      <p><mark data-status="active">stable</mark></p>
+    </article>
+  </article>
+
+  <article>
+    <header><h3>Dialog + Form</h3></header>
+    <p>Open a dialog, submit a form, and see the result rendered by signals.</p>
+    <nav data-controls>
+      <button data-open-dialog="form-dialog">Add Item</button>
+    </nav>
+    <output data-form-result>No items added yet.</output>
+    <dialog id="form-dialog">
+      <header><h3>New Item</h3></header>
+      <fieldset>
+        <legend>Details</legend>
+        <label>
+          <abbr>Item name</abbr>
+          <input type="text" placeholder="Enter a name..." data-form-input>
+        </label>
+      </fieldset>
+      <footer>
+        <button data-variant="outline" data-close-dialog>Cancel</button>
+        <button data-form-submit>Add</button>
+      </footer>
+    </dialog>
+  </article>
+</section>
+
+<script type="module">
+  import { signal, computed, effect } from '/basenative.js';
+
+  // ── Dialog open/close + backdrop dismiss ───
+  document.querySelectorAll('[data-open-dialog]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.getElementById(btn.dataset.openDialog).showModal();
+    });
+  });
+  document.querySelectorAll('[data-close-dialog]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      btn.closest('dialog').close();
+    });
+  });
+  document.querySelectorAll('dialog').forEach(d => {
+    d.addEventListener('click', (e) => {
+      if (e.target === d) d.close();
+    });
+  });
+
+  // ── Tooltips (hover to show/hide) ──────────
+  document.querySelectorAll('[data-tooltip]').forEach(btn => {
+    const id = btn.getAttribute('popovertarget');
+    const tip = document.getElementById(id);
+    if (!tip) return;
+    btn.addEventListener('mouseenter', () => tip.showPopover());
+    btn.addEventListener('mouseleave', () => tip.hidePopover());
+    btn.addEventListener('focus', () => tip.showPopover());
+    btn.addEventListener('blur', () => tip.hidePopover());
+  });
+
+  // ── Range binding ──────────────────────────
+  function updateRangeFill(input) {
+    const pct = ((input.value - input.min) / (input.max - input.min)) * 100;
+    input.style.setProperty('--range-pct', pct);
+  }
+  function bindRange(inputSel, valueSel) {
+    const input = document.querySelector(inputSel);
+    const output = document.querySelector(valueSel);
+    if (!input) return;
+    updateRangeFill(input);
+    const val = signal(parseInt(input.value, 10));
+    input.addEventListener('input', () => {
+      val.set(parseInt(input.value, 10));
+      updateRangeFill(input);
+    });
+    effect(() => { if (output) output.textContent = val(); });
+  }
+  bindRange('[data-volume-input]', '[data-volume-value]');
+  bindRange('[data-brightness-input]', '[data-brightness-value]');
+
+  // ── Dialog form demo ───────────────────────
+  const formInput = document.querySelector('[data-form-input]');
+  const formSubmit = document.querySelector('[data-form-submit]');
+  const formResult = document.querySelector('[data-form-result]');
+  const formDialog = document.querySelector('#form-dialog');
+
+  if (formSubmit && formInput) {
+    const items = signal([]);
+    formSubmit.addEventListener('click', () => {
+      const name = formInput.value.trim();
+      if (name) {
+        items.set([...items(), name]);
+        formInput.value = '';
+        formDialog.close();
+      }
+    });
+    effect(() => {
+      const list = items();
+      formResult.textContent = list.length
+        ? list.join(', ')
+        : 'No items added yet.';
+    });
+  }
+
+  // ── Custom Date Picker ─────────────────────
+  const MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+  const MONTHS_SHORT = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  const popover = document.querySelector('#datepicker-popover');
+  const titleBtn = document.querySelector('[data-datepicker-title-btn]');
+  const bodyEl = document.querySelector('[data-datepicker-body]');
+  const gridEl = document.querySelector('[data-datepicker-grid]');
+  const monthsEl = document.querySelector('[data-datepicker-months]');
+  const prevBtn = document.querySelector('[data-datepicker-prev]');
+  const nextBtn = document.querySelector('[data-datepicker-next]');
+  const triggerBtn = document.querySelector('[data-datepicker-trigger]');
+
+  const monthInput = document.querySelector('[data-date-month]');
+  const dayInput = document.querySelector('[data-date-day]');
+  const yearInput = document.querySelector('[data-date-year]');
+
+  if (popover && triggerBtn) {
+    const today = new Date();
+    const viewYear = signal(today.getFullYear());
+    const viewMonth = signal(today.getMonth());
+    const selected = signal(null);
+    const showMonths = signal(false);
+
+    triggerBtn.addEventListener('click', () => popover.togglePopover());
+
+    // Auto-advance on input
+    function autoAdvance(el, next, maxLen) {
+      el.addEventListener('input', () => {
+        el.value = el.value.replace(/\D/g, '');
+        if (el.value.length >= maxLen && next) next.focus();
+      });
+    }
+    autoAdvance(monthInput, dayInput, 2);
+    autoAdvance(dayInput, yearInput, 2);
+    autoAdvance(yearInput, null, 4);
+
+    // Commit typed date on blur or Enter
+    function commitTypedDate() {
+      const m = parseInt(monthInput.value, 10);
+      const d = parseInt(dayInput.value, 10);
+      const y = parseInt(yearInput.value, 10);
+      if (m >= 1 && m <= 12 && d >= 1 && d <= 31 && y >= 1900 && y <= 2100) {
+        const date = new Date(y, m - 1, d);
+        if (date.getMonth() === m - 1) {
+          selected.set(date);
+          viewYear.set(y);
+          viewMonth.set(m - 1);
+        }
+      }
+    }
+    [monthInput, dayInput, yearInput].forEach(el => {
+      el.addEventListener('blur', commitTypedDate);
+      el.addEventListener('keydown', (e) => { if (e.key === 'Enter') commitTypedDate(); });
+    });
+
+    // Fill inputs from selected date
+    function fillInputs(date) {
+      if (!date) return;
+      monthInput.value = String(date.getMonth() + 1).padStart(2, '0');
+      dayInput.value = String(date.getDate()).padStart(2, '0');
+      yearInput.value = String(date.getFullYear());
+    }
+
+    // Toggle month picker vs day grid
+    titleBtn.addEventListener('click', () => showMonths.set(!showMonths()));
+
+    prevBtn.addEventListener('click', () => {
+      if (showMonths()) {
+        viewYear.set(viewYear() - 1);
+      } else {
+        if (viewMonth() === 0) { viewMonth.set(11); viewYear.set(viewYear() - 1); }
+        else viewMonth.set(viewMonth() - 1);
+      }
+    });
+
+    nextBtn.addEventListener('click', () => {
+      if (showMonths()) {
+        viewYear.set(viewYear() + 1);
+      } else {
+        if (viewMonth() === 11) { viewMonth.set(0); viewYear.set(viewYear() + 1); }
+        else viewMonth.set(viewMonth() + 1);
+      }
+    });
+
+    // Render month picker
+    effect(() => {
+      const show = showMonths();
+      const y = viewYear();
+      const m = viewMonth();
+      gridEl.style.display = show ? 'none' : '';
+      monthsEl.style.display = show ? 'grid' : 'none';
+      titleBtn.textContent = show ? String(y) : `${MONTHS[m]} ${y}`;
+
+      if (show) {
+        monthsEl.innerHTML = MONTHS_SHORT.map((name, i) =>
+          `<button type="button" data-month-idx="${i}" ${i === m ? 'data-current' : ''}>${name}</button>`
+        ).join('');
+      }
+    });
+
+    monthsEl.addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-month-idx]');
+      if (!btn) return;
+      viewMonth.set(parseInt(btn.dataset.monthIdx, 10));
+      showMonths.set(false);
+    });
+
+    // Render day grid
+    effect(() => {
+      if (showMonths()) return;
+      const y = viewYear();
+      const m = viewMonth();
+      const firstDay = new Date(y, m, 1).getDay();
+      const daysInMonth = new Date(y, m + 1, 0).getDate();
+      const sel = selected();
+      let html = '';
+      let day = 1;
+
+      for (let row = 0; row < 6 && day <= daysInMonth; row++) {
+        html += '<tr>';
+        for (let col = 0; col < 7; col++) {
+          if ((row === 0 && col < firstDay) || day > daysInMonth) {
+            html += '<td></td>';
+          } else {
+            const d = day;
+            const isToday = d === today.getDate() && m === today.getMonth() && y === today.getFullYear();
+            const isSelected = sel && sel.getDate() === d && sel.getMonth() === m && sel.getFullYear() === y;
+            const cls = isSelected ? 'data-selected' : isToday ? 'data-today' : '';
+            html += `<td><button type="button" data-day="${d}" ${cls}>${d}</button></td>`;
+            day++;
+          }
+        }
+        html += '</tr>';
+      }
+      bodyEl.innerHTML = html;
+    });
+
+    bodyEl.addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-day]');
+      if (!btn) return;
+      const d = parseInt(btn.dataset.day, 10);
+      const date = new Date(viewYear(), viewMonth(), d);
+      selected.set(date);
+      fillInputs(date);
+      popover.hidePopover();
+    });
+  }
+</script>

--- a/examples/express/views/layout.html
+++ b/examples/express/views/layout.html
@@ -16,6 +16,7 @@
         <li><a href="/tasks" <!--TASKS_ARIA-->>Tasks</a></li>
         <li><a href="/playground" <!--PLAYGROUND_ARIA-->>Playground</a></li>
         <li><a href="/docs" <!--DOCS_ARIA-->>Docs</a></li>
+        <li><a href="/components" <!--COMPONENTS_ARIA-->>Components</a></li>
       </ul>
     </nav>
   </header>

--- a/examples/express/views/tasks.html
+++ b/examples/express/views/tasks.html
@@ -21,7 +21,7 @@
 
 <section data-hydrate>
   <h3>Interactive Controls</h3>
-  <p>Loading interactive controls...</p>
+  <p>Loading...</p>
 </section>
 
 <script type="application/json" data-initial-tasks>


### PR DESCRIPTION
## Summary
- Add a full **Components** showcase page with modern platform APIs: Popover API, CSS Anchor Positioning, `appearance: base-select`, `@starting-style` animations, and `transition-behavior: allow-discrete`
- Custom **datepicker** with tabbed MM/DD/YYYY inputs, calendar popover, and month/year picker — no native `input[type="date"]`
- Styled form controls (range with filled track, checkbox, radio, textarea with `field-sizing: content`), feedback elements (progress, meter, status badges), content elements (blockquote, table, details/summary, kbd/mark/abbr), and overlays (dialog with centered backdrop dismiss, tooltips, dropdown menus, popover cards)
- ~60 new CSS custom properties in `@layer tokens`, all values via custom properties — zero magic numbers, semantic HTML only

## Test plan
- [ ] Navigate to `/components` and verify all sections render
- [ ] Drag range sliders — filled track and value label update in real time
- [ ] Tab through MM/DD/YYYY date inputs, type a date, verify it commits on blur
- [ ] Click calendar icon, pick a date, verify inputs fill
- [ ] Click month/year title in datepicker to switch to month grid, pick a month
- [ ] Open selects — verify styled dropdown with `base-select` (falls back in older browsers)
- [ ] Open Dialog — verify centered with backdrop; click backdrop to dismiss
- [ ] Hover tooltip buttons — tooltip appears anchored above
- [ ] Click Actions/View dropdown menus — clicking outside or the other button closes them
- [ ] Click Preview Card — verify 20rem-wide popover card appears
- [ ] Check progress/meter bars have consistent height
- [ ] Verify Tasks page has improved spacing between controls and list

🤖 Generated with [Claude Code](https://claude.com/claude-code)