### PR TITLE
Downgrade GitHub Actions dependencies to previous versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - run: pnpm build:pages
 
       - id: deploy
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         run: pnpm exec nx run-many --target=test
 
       - name: Create Release Pull Request or Publish
-        uses: changesets/action@v2
+        uses: changesets/action@v1
         with:
           publish: pnpm exec changeset publish
           version: pnpm exec changeset version


### PR DESCRIPTION
## Summary

Downgrade two GitHub Actions dependencies to earlier versions:
- `cloudflare/wrangler-action` from v4 to v3
- `changesets/action` from v2 to v1

These changes affect the CI/CD workflows for deployment and release processes.

## Tests

N/A - These are workflow configuration changes. Verification will occur when the workflows execute during the next deployment and release cycles.

## Browser support impact

None

## Docs updated

No

https://claude.ai/code/session_01S73jSYLxPVUj1BcLVGBPHh