### PR TITLE
fix: add NODE_AUTH_TOKEN to release workflow for npm auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- `setup-node` creates `.npmrc` expecting `${NODE_AUTH_TOKEN}`, but only `NPM_TOKEN` was set in the env
- npm returns 404 (not 401) on scoped package PUTs when auth is missing — causing all `@basenative/*` publishes to fail
- Adds `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to bridge the gap

## Test plan
- [ ] Verify `NPM_TOKEN` secret is set on the repo
- [ ] Verify `@basenative` org exists on npmjs.com
- [ ] Merge and confirm release workflow publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)