### PR TITLE
feat: unified design system with component showcase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v5
 
@@ -39,6 +41,8 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     needs: test
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 

--- a/examples/enterprise-v2/public/styles.css
+++ b/examples/enterprise-v2/public/styles.css
@@ -1,0 +1,59 @@
+/* Enterprise v2 — local overrides */
+
+/* User area in topbar */
+.user-area {
+  display: flex;
+  align-items: center;
+  gap: var(--bn-space-3);
+  font-size: var(--bn-font-size-sm);
+}
+
+/* Notification bell */
+.notification-bell {
+  position: relative;
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+.notification-bell .badge-count {
+  position: absolute;
+  top: -4px;
+  right: -6px;
+  background: var(--bn-color-error-600);
+  color: var(--bn-color-white);
+  font-size: 0.6rem;
+  padding: 1px 4px;
+  border-radius: var(--bn-radius-full);
+}
+
+/* Stat value (dashboard) */
+.stat-value {
+  font-size: var(--bn-font-size-4xl);
+  font-weight: var(--bn-font-weight-bold);
+}
+.stat-label {
+  font-size: var(--bn-font-size-xs);
+  color: var(--bn-color-text-muted);
+}
+
+/* Feature flag dots */
+.flag-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--bn-radius-full);
+  margin-right: var(--bn-space-2);
+}
+.flag-dot.on { background: var(--bn-color-success-600); }
+.flag-dot.off { background: var(--bn-color-gray-400); }
+
+/* Activity list */
+.activity-list {
+  list-style: none;
+  padding: 0;
+}
+.activity-list li {
+  padding: var(--bn-space-2) 0;
+  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+  font-size: var(--bn-font-size-sm);
+}
+.activity-list li:last-child { border-bottom: none; }

--- a/examples/enterprise-v2/server.js
+++ b/examples/enterprise-v2/server.js
@@ -46,6 +46,7 @@ import { createUploadHandler, createLocalStorage } from '@basenative/upload';
 // Setup
 // ---------------------------------------------------------------------------
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(__dirname, '..', '..');
 const read = (file) => readFileSync(join(__dirname, file), 'utf-8');
 
 // -- Config --
@@ -158,6 +159,8 @@ const app = express();
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 app.use('/uploads', express.static(uploadDir));
+app.use('/bn-css', express.static(join(pkgRoot, 'packages', 'components', 'src')));
+app.use(express.static(join(__dirname, 'public')));
 
 // Convert BaseNative pipeline to Express middleware
 app.use(toExpressMiddleware(pipeline));
@@ -463,9 +466,9 @@ app.get('/flags', async (req, res) => {
 
   const viewHtml = `
 <h1>${i18n.t('flags.title')}</h1>
-<div class="card">
-  <div class="card-body" style="overflow-x:auto">
-    <table class="data-table">
+<div data-bn="card">
+  <div data-bn="card-body" style="overflow-x:auto">
+    <table data-bn="table">
       <thead>
         <tr>
           <th>Flag</th>

--- a/examples/enterprise-v2/views/dashboard.html
+++ b/examples/enterprise-v2/views/dashboard.html
@@ -1,33 +1,33 @@
 <h1>{{ welcomeMessage }}</h1>
 
-<div class="stats-grid">
-  <div class="card">
-    <div class="card-header">Users</div>
-    <div class="card-body">
+<div data-bn="stats-grid">
+  <div data-bn="card">
+    <div data-bn="card-header">Users</div>
+    <div data-bn="card-body">
       <div class="stat-value">{{ usersCount }}</div>
       <div class="stat-label">{{ usersLabel }}</div>
     </div>
   </div>
-  <div class="card">
-    <div class="card-header">Notifications</div>
-    <div class="card-body">
+  <div data-bn="card">
+    <div data-bn="card-header">Notifications</div>
+    <div data-bn="card-body">
       <div class="stat-value">{{ notificationsCount }}</div>
       <div class="stat-label">{{ notificationsLabel }}</div>
     </div>
   </div>
-  <div class="card">
-    <div class="card-header">Feature Flags</div>
-    <div class="card-body">
+  <div data-bn="card">
+    <div data-bn="card-header">Feature Flags</div>
+    <div data-bn="card-body">
       <div class="stat-value">{{ flagsCount }}</div>
       <div class="stat-label">active flags</div>
     </div>
   </div>
 </div>
 
-<div class="card" style="margin-bottom:var(--bn-space-6)">
-  <div class="card-header">Tenant Information</div>
-  <div class="card-body">
-    <table class="data-table">
+<div data-bn="card" style="margin-bottom:var(--bn-space-6)">
+  <div data-bn="card-header">Tenant Information</div>
+  <div data-bn="card-body">
+    <table data-bn="table">
       <tbody>
         <tr><td style="font-weight:500">Tenant ID</td><td>{{ tenantId }}</td></tr>
         <tr><td style="font-weight:500">Locale</td><td>{{ locale }}</td></tr>
@@ -37,9 +37,9 @@
   </div>
 </div>
 
-<div class="card" style="margin-bottom:var(--bn-space-6)">
-  <div class="card-header">Feature Flag Status</div>
-  <div class="card-body">
+<div data-bn="card" style="margin-bottom:var(--bn-space-6)">
+  <div data-bn="card-header">Feature Flag Status</div>
+  <div data-bn="card-body">
     <template @for="flag of flags">
       <div style="display:flex;align-items:center;padding:var(--bn-space-1) 0">
         <span class="flag-dot {{ flag.dotClass }}"></span>
@@ -50,9 +50,9 @@
   </div>
 </div>
 
-<div class="card">
-  <div class="card-header">Recent Activity</div>
-  <div class="card-body">
+<div data-bn="card">
+  <div data-bn="card-header">Recent Activity</div>
+  <div data-bn="card-body">
     <ul class="activity-list">
       <template @for="item of activity">
         <li>{{ item }}</li>

--- a/examples/enterprise-v2/views/layout.html
+++ b/examples/enterprise-v2/views/layout.html
@@ -4,89 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ title }} — BaseNative Enterprise v2</title>
-  <style>
-    *, *::before, *::after { box-sizing: border-box; margin: 0; }
-    :root {
-      --bn-color-white: #ffffff;
-      --bn-color-gray-50: #fafafa; --bn-color-gray-100: #f4f4f5;
-      --bn-color-gray-200: #e4e4e7; --bn-color-gray-300: #d4d4d8;
-      --bn-color-gray-400: #a1a1aa; --bn-color-gray-500: #71717a;
-      --bn-color-gray-600: #52525b; --bn-color-gray-700: #3f3f46;
-      --bn-color-gray-800: #27272a; --bn-color-gray-900: #18181b;
-      --bn-color-primary-50: #eff6ff; --bn-color-primary-100: #dbeafe;
-      --bn-color-primary-500: #3b82f6; --bn-color-primary-600: #2563eb;
-      --bn-color-primary-700: #1d4ed8;
-      --bn-color-surface: var(--bn-color-white);
-      --bn-color-surface-subtle: var(--bn-color-gray-50);
-      --bn-color-surface-muted: var(--bn-color-gray-100);
-      --bn-color-text: var(--bn-color-gray-900);
-      --bn-color-text-muted: var(--bn-color-gray-500);
-      --bn-color-border: var(--bn-color-gray-200);
-      --bn-color-success-600: #16a34a;
-      --bn-color-error-600: #dc2626;
-      --bn-font-family: system-ui, -apple-system, sans-serif;
-      --bn-font-size-sm: 0.875rem; --bn-font-size-base: 1rem;
-      --bn-font-size-xs: 0.75rem; --bn-font-size-lg: 1.125rem;
-      --bn-font-weight-medium: 500; --bn-font-weight-semibold: 600;
-      --bn-space-1: 0.25rem; --bn-space-2: 0.5rem; --bn-space-3: 0.75rem;
-      --bn-space-4: 1rem; --bn-space-6: 1.5rem; --bn-space-8: 2rem;
-      --bn-radius-md: 0.375rem; --bn-radius-lg: 0.5rem; --bn-radius-full: 9999px;
-      --bn-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-      --bn-focus-ring: 0 0 0 2px var(--bn-color-surface), 0 0 0 4px var(--bn-color-primary-500);
-    }
-    body { font-family: var(--bn-font-family); color: var(--bn-color-text); background: var(--bn-color-surface-subtle); min-height: 100vh; display: flex; flex-direction: column; }
-    header.topbar { display: flex; align-items: center; justify-content: space-between; padding: var(--bn-space-3) var(--bn-space-8); background: var(--bn-color-surface); border-bottom: 1px solid var(--bn-color-border); }
-    header.topbar .brand { font-size: var(--bn-font-size-lg); font-weight: var(--bn-font-weight-semibold); color: var(--bn-color-primary-700); text-decoration: none; }
-    header.topbar nav { display: flex; gap: var(--bn-space-4); }
-    header.topbar nav a { font-size: var(--bn-font-size-sm); color: var(--bn-color-text-muted); text-decoration: none; padding: var(--bn-space-1) var(--bn-space-2); border-radius: var(--bn-radius-md); }
-    header.topbar nav a:hover { color: var(--bn-color-text); background: var(--bn-color-surface-muted); }
-    header.topbar .user-area { display: flex; align-items: center; gap: var(--bn-space-3); font-size: var(--bn-font-size-sm); }
-    header.topbar .user-area .avatar { width: 28px; height: 28px; border-radius: var(--bn-radius-full); background: var(--bn-color-primary-100); display: flex; align-items: center; justify-content: center; font-weight: var(--bn-font-weight-medium); color: var(--bn-color-primary-700); font-size: var(--bn-font-size-xs); overflow: hidden; }
-    header.topbar .user-area .avatar img { width: 100%; height: 100%; object-fit: cover; }
-    header.topbar .notification-bell { position: relative; cursor: pointer; font-size: 1.1rem; }
-    header.topbar .notification-bell .badge-count { position: absolute; top: -4px; right: -6px; background: var(--bn-color-error-600); color: white; font-size: 0.6rem; padding: 1px 4px; border-radius: var(--bn-radius-full); }
-    .role-badge { display: inline-block; padding: 1px 6px; font-size: var(--bn-font-size-xs); font-weight: var(--bn-font-weight-medium); border-radius: var(--bn-radius-full); background: var(--bn-color-surface-muted); color: var(--bn-color-gray-600); }
-    main.content { flex: 1; padding: var(--bn-space-8); max-width: 1024px; width: 100%; margin: 0 auto; }
-    main.content h1 { font-size: 1.5rem; margin-bottom: var(--bn-space-6); }
-    footer.site-footer { padding: var(--bn-space-4) var(--bn-space-8); text-align: center; font-size: var(--bn-font-size-xs); color: var(--bn-color-text-muted); border-top: 1px solid var(--bn-color-border); background: var(--bn-color-surface); }
-    .card { background: var(--bn-color-surface); border: 1px solid var(--bn-color-border); border-radius: var(--bn-radius-lg); overflow: hidden; }
-    .card-header { padding: var(--bn-space-3) var(--bn-space-4); border-bottom: 1px solid var(--bn-color-border); font-weight: var(--bn-font-weight-semibold); font-size: var(--bn-font-size-sm); }
-    .card-body { padding: var(--bn-space-4); }
-    .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: var(--bn-space-4); margin-bottom: var(--bn-space-6); }
-    .stat-value { font-size: 2rem; font-weight: 700; }
-    .stat-label { font-size: var(--bn-font-size-xs); color: var(--bn-color-text-muted); }
-    .form-grid { display: grid; gap: var(--bn-space-4); max-width: 420px; }
-    .form-actions { display: flex; gap: var(--bn-space-2); margin-top: var(--bn-space-4); }
-    .field { display: flex; flex-direction: column; gap: var(--bn-space-1); }
-    .field label { font-size: var(--bn-font-size-sm); font-weight: var(--bn-font-weight-medium); }
-    .field input { padding: var(--bn-space-2) var(--bn-space-3); border: 1px solid var(--bn-color-border); border-radius: var(--bn-radius-md); font-size: var(--bn-font-size-base); font-family: var(--bn-font-family); }
-    .field input:focus { border-color: var(--bn-color-primary-500); box-shadow: var(--bn-focus-ring); outline: none; }
-    .btn { display: inline-flex; align-items: center; gap: var(--bn-space-2); padding: var(--bn-space-2) var(--bn-space-3); font-family: var(--bn-font-family); font-size: var(--bn-font-size-sm); font-weight: var(--bn-font-weight-medium); border: 1px solid transparent; border-radius: var(--bn-radius-md); cursor: pointer; text-decoration: none; }
-    .btn-primary { background: var(--bn-color-primary-600); color: white; }
-    .btn-primary:hover { background: var(--bn-color-primary-700); }
-    .btn-secondary { background: var(--bn-color-surface); color: var(--bn-color-text); border-color: var(--bn-color-border); }
-    .btn-link { background: none; color: var(--bn-color-primary-600); border: none; padding: 0; }
-    .alert { padding: var(--bn-space-3) var(--bn-space-4); border-radius: var(--bn-radius-md); font-size: var(--bn-font-size-sm); margin-bottom: var(--bn-space-4); border: 1px solid; }
-    .alert-error { background: #fef2f2; border-color: #fecaca; color: #991b1b; }
-    .alert-success { background: #f0fdf4; border-color: #bbf7d0; color: #166534; }
-    .data-table { width: 100%; border-collapse: collapse; font-size: var(--bn-font-size-sm); }
-    .data-table th { text-align: left; padding: var(--bn-space-3) var(--bn-space-4); font-weight: var(--bn-font-weight-medium); color: var(--bn-color-text-muted); border-bottom: 1px solid var(--bn-color-border); }
-    .data-table td { padding: var(--bn-space-3) var(--bn-space-4); border-bottom: 1px solid var(--bn-color-border); }
-    .data-table tbody tr:hover { background: var(--bn-color-surface-subtle); }
-    .flag-dot { display: inline-block; width: 8px; height: 8px; border-radius: var(--bn-radius-full); margin-right: var(--bn-space-2); }
-    .flag-dot.on { background: var(--bn-color-success-600); }
-    .flag-dot.off { background: var(--bn-color-gray-400); }
-    .activity-list { list-style: none; padding: 0; }
-    .activity-list li { padding: var(--bn-space-2) 0; border-bottom: 1px solid var(--bn-color-border); font-size: var(--bn-font-size-sm); }
-    .activity-list li:last-child { border-bottom: none; }
-    .center-card { max-width: 420px; margin: var(--bn-space-8) auto; }
-  </style>
+  <link rel="stylesheet" href="/bn-css/index.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
-<body>
-  <header class="topbar">
-    <a class="brand" href="/">BaseNative</a>
+<body data-bn="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <header data-bn="topbar">
+    <a data-bn="brand" href="/">BaseNative</a>
     <template @if="user">
-      <nav>
+      <nav aria-label="Main navigation">
         <a href="/">Dashboard</a>
         <a href="/users">Users</a>
         <a href="/flags">Flags</a>
@@ -98,31 +24,32 @@
             <span class="badge-count">{{ notificationCount }}</span>
           </template>
         </span>
-        <div class="avatar">
+        <div data-bn="avatar" data-size="sm">
           <template @if="user.avatar_url">
-            <img src="{{ user.avatar_url }}" alt="">
+            <img data-bn="avatar-img" src="{{ user.avatar_url }}" alt="">
           </template>
           <template @if="!user.avatar_url">
-            {{ userInitial }}
+            <span data-bn="avatar-initials">{{ userInitial }}</span>
           </template>
         </div>
         <span>{{ user.username }}</span>
-        <span class="role-badge">{{ user.role }}</span>
+        <span data-bn="badge" data-variant="default">{{ user.role }}</span>
         <form method="POST" action="/logout" style="margin:0">
-          <button type="submit" class="btn btn-link">Logout</button>
+          <button data-bn="button" data-variant="ghost" type="submit">Logout</button>
         </form>
       </div>
     </template>
     <template @if="!user">
-      <nav>
+      <nav aria-label="Main navigation">
         <a href="/login">Sign In</a>
         <a href="/register">Register</a>
       </nav>
     </template>
   </header>
-  <main class="content">
+  <main data-bn="content" id="main-content">
+    <div role="status" aria-live="polite" class="visually-hidden"></div>
     {{ content }}
   </main>
-  <footer class="site-footer">BaseNative Enterprise v2 Demo</footer>
+  <footer data-bn="footer">BaseNative Enterprise v2 Demo</footer>
 </body>
 </html>

--- a/examples/enterprise-v2/views/login.html
+++ b/examples/enterprise-v2/views/login.html
@@ -1,24 +1,24 @@
-<div class="center-card">
-  <div class="card">
-    <div class="card-header">Sign In</div>
-    <div class="card-body">
+<div data-bn="center-card">
+  <div data-bn="card">
+    <div data-bn="card-header">Sign In</div>
+    <div data-bn="card-body">
       <p style="font-size:var(--bn-font-size-sm);color:var(--bn-color-text-muted);margin-bottom:var(--bn-space-4)">Enter your credentials to continue.</p>
       <template @if="error">
-        <div class="alert alert-error">{{ error }}</div>
+        <div data-bn="alert" data-variant="error">{{ error }}</div>
       </template>
-      <form method="POST" action="/login" class="form-grid">
+      <form method="POST" action="/login" data-bn="form-grid">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-        <div class="field">
+        <div data-bn="field">
           <label for="username">Username</label>
-          <input id="username" name="username" type="text" required autocomplete="username">
+          <input data-bn="input" id="username" name="username" type="text" required autocomplete="username">
         </div>
-        <div class="field">
+        <div data-bn="field">
           <label for="password">Password</label>
-          <input id="password" name="password" type="password" required autocomplete="current-password">
+          <input data-bn="input" id="password" name="password" type="password" required autocomplete="current-password">
         </div>
-        <div class="form-actions">
-          <button type="submit" class="btn btn-primary">Sign In</button>
-          <a href="/register" class="btn btn-secondary">Register</a>
+        <div data-bn="form-actions">
+          <button data-bn="button" data-variant="primary" type="submit">Sign In</button>
+          <a data-bn="button" data-variant="secondary" href="/register">Register</a>
         </div>
       </form>
     </div>

--- a/examples/enterprise-v2/views/register.html
+++ b/examples/enterprise-v2/views/register.html
@@ -1,32 +1,32 @@
-<div class="center-card">
-  <div class="card">
-    <div class="card-header">Create Account</div>
-    <div class="card-body">
+<div data-bn="center-card">
+  <div data-bn="card">
+    <div data-bn="card-header">Create Account</div>
+    <div data-bn="card-body">
       <p style="font-size:var(--bn-font-size-sm);color:var(--bn-color-text-muted);margin-bottom:var(--bn-space-4)">Fill in the details below to register.</p>
       <template @if="error">
-        <div class="alert alert-error">{{ error }}</div>
+        <div data-bn="alert" data-variant="error">{{ error }}</div>
       </template>
-      <form method="POST" action="/register" class="form-grid">
+      <form method="POST" action="/register" data-bn="form-grid">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-        <div class="field">
+        <div data-bn="field">
           <label for="username">Username</label>
-          <input id="username" name="username" type="text" required autocomplete="username">
+          <input data-bn="input" id="username" name="username" type="text" required autocomplete="username">
         </div>
-        <div class="field">
+        <div data-bn="field">
           <label for="email">Email</label>
-          <input id="email" name="email" type="email" required autocomplete="email">
+          <input data-bn="input" id="email" name="email" type="email" required autocomplete="email">
         </div>
-        <div class="field">
+        <div data-bn="field">
           <label for="password">Password</label>
-          <input id="password" name="password" type="password" required minlength="6" autocomplete="new-password">
+          <input data-bn="input" id="password" name="password" type="password" required minlength="6" autocomplete="new-password">
         </div>
-        <div class="field">
+        <div data-bn="field">
           <label for="confirm_password">Confirm Password</label>
-          <input id="confirm_password" name="confirm_password" type="password" required minlength="6" autocomplete="new-password">
+          <input data-bn="input" id="confirm_password" name="confirm_password" type="password" required minlength="6" autocomplete="new-password">
         </div>
-        <div class="form-actions">
-          <button type="submit" class="btn btn-primary">Create Account</button>
-          <a href="/login" class="btn btn-secondary">Sign In</a>
+        <div data-bn="form-actions">
+          <button data-bn="button" data-variant="primary" type="submit">Create Account</button>
+          <a data-bn="button" data-variant="secondary" href="/login">Sign In</a>
         </div>
       </form>
     </div>

--- a/examples/enterprise-v2/views/users.html
+++ b/examples/enterprise-v2/views/users.html
@@ -1,9 +1,9 @@
 <h1>User Management</h1>
 
 <template @if="user.role === 'admin'">
-  <div class="card">
-    <div class="card-body" style="overflow-x:auto">
-      <table class="data-table">
+  <div data-bn="card">
+    <div data-bn="card-body" style="overflow-x:auto">
+      <table data-bn="table">
         <thead>
           <tr>
             <th>ID</th>
@@ -19,7 +19,7 @@
               <td>{{ row.id }}</td>
               <td>{{ row.username }}</td>
               <td>{{ row.email }}</td>
-              <td><span class="role-badge">{{ row.role }}</span></td>
+              <td><span data-bn="badge" data-variant="default">{{ row.role }}</span></td>
               <td>{{ row.created_at }}</td>
             </tr>
           </template>
@@ -33,5 +33,5 @@
 </template>
 
 <template @if="user.role !== 'admin'">
-  <div class="alert alert-error">You do not have permission to view this page.</div>
+  <div data-bn="alert" data-variant="error">You do not have permission to view this page.</div>
 </template>

--- a/examples/enterprise/public/styles.css
+++ b/examples/enterprise/public/styles.css
@@ -1,0 +1,20 @@
+/* Enterprise example — local overrides */
+[data-bn="content"] {
+  max-inline-size: 960px;
+}
+
+[data-bn="stats-grid"] {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  gap: var(--bn-space-4);
+  margin-bottom: var(--bn-space-6);
+}
+
+.detail-actions {
+  display: flex;
+  gap: var(--bn-space-2);
+}

--- a/examples/enterprise/server.js
+++ b/examples/enterprise/server.js
@@ -22,6 +22,9 @@ const app = express();
 app.use(express.json());
 app.use(express.static(join(__dirname, 'public')));
 
+const pkgRoot = join(__dirname, '..', '..');
+app.use('/bn-css', express.static(join(pkgRoot, 'packages', 'components', 'src')));
+
 // -- In-memory data store --
 let nextId = 4;
 let users = [

--- a/examples/enterprise/views/dashboard.html
+++ b/examples/enterprise/views/dashboard.html
@@ -1,5 +1,5 @@
 <h1>Dashboard</h1>
-<div class="stats-grid">
+<div data-bn="stats-grid">
   {{ statsCard1 }}
   {{ statsCard2 }}
   {{ statsCard3 }}

--- a/examples/enterprise/views/layout.html
+++ b/examples/enterprise/views/layout.html
@@ -4,94 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title><!--TITLE--> — BaseNative Enterprise</title>
-  <style>
-    *, *::before, *::after { box-sizing: border-box; margin: 0; }
-    :root {
-      --bn-color-white: #ffffff;
-      --bn-color-black: #09090b;
-      --bn-color-gray-50: #fafafa; --bn-color-gray-100: #f4f4f5;
-      --bn-color-gray-200: #e4e4e7; --bn-color-gray-300: #d4d4d8;
-      --bn-color-gray-400: #a1a1aa; --bn-color-gray-500: #71717a;
-      --bn-color-gray-600: #52525b; --bn-color-gray-700: #3f3f46;
-      --bn-color-gray-800: #27272a; --bn-color-gray-900: #18181b;
-      --bn-color-primary-50: #eff6ff; --bn-color-primary-100: #dbeafe;
-      --bn-color-primary-200: #bfdbfe; --bn-color-primary-500: #3b82f6;
-      --bn-color-primary-600: #2563eb; --bn-color-primary-700: #1d4ed8;
-      --bn-color-primary-800: #1e40af;
-      --bn-color-surface: var(--bn-color-white);
-      --bn-color-surface-subtle: var(--bn-color-gray-50);
-      --bn-color-surface-muted: var(--bn-color-gray-100);
-      --bn-color-text: var(--bn-color-gray-900);
-      --bn-color-text-muted: var(--bn-color-gray-500);
-      --bn-color-border: var(--bn-color-gray-200);
-      --bn-color-border-focus: var(--bn-color-primary-500);
-      --bn-color-error-500: #ef4444; --bn-color-error-600: #dc2626;
-      --bn-color-success-500: #22c55e; --bn-color-success-600: #16a34a;
-      --bn-font-family: system-ui, -apple-system, sans-serif;
-      --bn-font-size-sm: 0.875rem; --bn-font-size-base: 1rem;
-      --bn-font-size-xs: 0.75rem; --bn-font-size-lg: 1.125rem;
-      --bn-font-weight-medium: 500; --bn-font-weight-semibold: 600; --bn-font-weight-bold: 700;
-      --bn-space-1: 0.25rem; --bn-space-2: 0.5rem; --bn-space-3: 0.75rem;
-      --bn-space-4: 1rem; --bn-space-6: 1.5rem; --bn-space-8: 2rem;
-      --bn-radius-md: 0.375rem; --bn-radius-lg: 0.5rem; --bn-radius-full: 9999px;
-      --bn-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-      --bn-transition-fast: 150ms ease;
-      --bn-focus-ring: 0 0 0 2px var(--bn-color-surface), 0 0 0 4px var(--bn-color-border-focus);
-      --bn-space-component-x: var(--bn-space-3); --bn-space-component-y: var(--bn-space-2);
-      --bn-font-size-component: var(--bn-font-size-base);
-      --bn-line-height-tight: 1.25;
-    }
-    body { font-family: var(--bn-font-family); color: var(--bn-color-text); background: var(--bn-color-surface-subtle); display: flex; min-height: 100vh; }
-    nav[data-sidebar] { width: 240px; background: var(--bn-color-surface); border-right: 1px solid var(--bn-color-border); padding: var(--bn-space-4); }
-    nav[data-sidebar] h2 { font-size: var(--bn-font-size-lg); margin-bottom: var(--bn-space-6); }
-    nav[data-sidebar] a { display: block; padding: var(--bn-space-2) var(--bn-space-3); border-radius: var(--bn-radius-md); color: var(--bn-color-text); text-decoration: none; font-size: var(--bn-font-size-sm); margin-bottom: var(--bn-space-1); }
-    nav[data-sidebar] a:hover { background: var(--bn-color-surface-muted); }
-    nav[data-sidebar] a[aria-current] { background: var(--bn-color-primary-50); color: var(--bn-color-primary-700); font-weight: var(--bn-font-weight-medium); }
-    main { flex: 1; padding: var(--bn-space-8); max-width: 960px; }
-    main h1 { font-size: 1.5rem; margin-bottom: var(--bn-space-6); }
-    [data-bn="button"] { display: inline-flex; align-items: center; gap: var(--bn-space-2); padding: var(--bn-space-component-y) var(--bn-space-component-x); font-family: var(--bn-font-family); font-size: var(--bn-font-size-component); font-weight: var(--bn-font-weight-medium); line-height: var(--bn-line-height-tight); border: 1px solid transparent; border-radius: var(--bn-radius-md); cursor: pointer; }
-    [data-bn="button"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
-    [data-bn="button"][data-variant="primary"] { background: var(--bn-color-primary-600); color: white; }
-    [data-bn="button"][data-variant="primary"]:hover { background: var(--bn-color-primary-700); }
-    [data-bn="button"][data-variant="secondary"] { background: var(--bn-color-surface); color: var(--bn-color-text); border-color: var(--bn-color-border); }
-    [data-bn="button"][data-variant="destructive"] { background: var(--bn-color-error-600); color: white; }
-    [data-bn="field"] { display: flex; flex-direction: column; gap: var(--bn-space-1); }
-    [data-bn="field"] label { font-size: var(--bn-font-size-sm); font-weight: var(--bn-font-weight-medium); }
-    [data-bn="input"], [data-bn="select"] { padding: var(--bn-space-2) var(--bn-space-3); border: 1px solid var(--bn-color-border); border-radius: var(--bn-radius-md); font-size: var(--bn-font-size-base); }
-    [data-bn="input"]:focus, [data-bn="select"]:focus { border-color: var(--bn-color-border-focus); box-shadow: var(--bn-focus-ring); outline: none; }
-    [data-bn="table-container"] { overflow-x: auto; }
-    [data-bn="table"] { width: 100%; border-collapse: collapse; font-size: var(--bn-font-size-sm); }
-    [data-bn="table"] th { text-align: left; padding: var(--bn-space-3) var(--bn-space-4); font-weight: var(--bn-font-weight-medium); color: var(--bn-color-text-muted); border-bottom: 1px solid var(--bn-color-border); }
-    [data-bn="table"] td { padding: var(--bn-space-3) var(--bn-space-4); border-bottom: 1px solid var(--bn-color-border); }
-    [data-bn="table"] tbody tr:hover { background: var(--bn-color-surface-subtle); }
-    [data-bn="badge"] { display: inline-flex; padding: var(--bn-space-1) var(--bn-space-2); font-size: var(--bn-font-size-xs); font-weight: var(--bn-font-weight-medium); border-radius: var(--bn-radius-full); }
-    [data-bn="badge"][data-variant="success"] { background: #dcfce7; color: #166534; }
-    [data-bn="badge"][data-variant="default"] { background: var(--bn-color-gray-100); color: var(--bn-color-gray-700); }
-    [data-bn="card"] { background: var(--bn-color-surface); border: 1px solid var(--bn-color-border); border-radius: var(--bn-radius-lg); overflow: hidden; }
-    [data-bn="card-header"] { padding: var(--bn-space-4) var(--bn-space-6); border-bottom: 1px solid var(--bn-color-border); font-weight: var(--bn-font-weight-semibold); }
-    [data-bn="card-body"] { padding: var(--bn-space-4) var(--bn-space-6); }
-    [data-bn="card-footer"] { padding: var(--bn-space-4) var(--bn-space-6); border-top: 1px solid var(--bn-color-border); }
-    [data-bn="alert"] { display: flex; align-items: flex-start; gap: var(--bn-space-2); padding: var(--bn-space-3) var(--bn-space-4); border-radius: var(--bn-radius-md); font-size: var(--bn-font-size-sm); border: 1px solid; }
-    [data-bn="alert"][data-variant="success"] { background: #f0fdf4; border-color: #bbf7d0; color: #166534; }
-    [data-bn="pagination"] ul { display: flex; list-style: none; padding: 0; gap: var(--bn-space-1); }
-    [data-bn="pagination"] a { display: inline-flex; align-items: center; justify-content: center; min-width: 2rem; height: 2rem; padding: 0 var(--bn-space-2); font-size: var(--bn-font-size-sm); border-radius: var(--bn-radius-md); text-decoration: none; color: var(--bn-color-text); }
-    [data-bn="pagination"] a:hover { background: var(--bn-color-surface-muted); }
-    [data-bn="pagination"] a[aria-current] { background: var(--bn-color-primary-600); color: white; }
-    .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: var(--bn-space-4); margin-bottom: var(--bn-space-6); }
-    .form-grid { display: grid; gap: var(--bn-space-4); max-width: 480px; }
-    .form-actions { display: flex; gap: var(--bn-space-2); margin-top: var(--bn-space-4); }
-    .detail-header { display: flex; align-items: center; gap: var(--bn-space-4); margin-bottom: var(--bn-space-6); }
-    .detail-actions { display: flex; gap: var(--bn-space-2); }
-  </style>
+  <link rel="stylesheet" href="/bn-css/index.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
-<body>
-  <nav data-sidebar>
+<body data-bn="page" style="flex-direction: row">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <nav data-bn="sidebar" aria-label="Main navigation">
     <h2>BaseNative</h2>
     <a href="/">Dashboard</a>
     <a href="/users">Users</a>
     <a href="/users/new">Add User</a>
   </nav>
-  <main>
+  <main data-bn="content" id="main-content">
+    <div role="status" aria-live="polite" class="visually-hidden"></div>
     <!--CONTENT-->
   </main>
 </body>

--- a/examples/enterprise/views/user-form.html
+++ b/examples/enterprise/views/user-form.html
@@ -1,9 +1,9 @@
 <h1>New User</h1>
-<form class="form-grid" method="POST" action="/api/users">
+<form data-bn="form-grid" method="POST" action="/api/users">
   {{ nameInput }}
   {{ emailInput }}
   {{ roleSelect }}
-  <div class="form-actions">
+  <div data-bn="form-actions">
     {{ submitButton }}
     <a href="/users">{{ cancelButton }}</a>
   </div>

--- a/examples/express/public/styles.css
+++ b/examples/express/public/styles.css
@@ -360,7 +360,7 @@
 
   ul[role="list"][data-stat-grid] {
     display: grid;
-    grid-template-columns: repeat(var(--stat-grid-columns), 1fr);
+    grid-template-columns: repeat(4, 1fr);
     gap: var(--space-md);
     list-style: none;
     flex-direction: unset;
@@ -475,6 +475,7 @@
     padding: var(--space-xs) var(--space-sm);
     border-radius: var(--radius-pill);
     font-weight: var(--font-weight-semibold);
+    white-space: nowrap;
   }
   [data-status="active"], [data-status="done"] { background: var(--status-active-bg); color: var(--success); }
   [data-status="idle"], [data-status="dom"], [data-status="binding"] { background: var(--status-idle-bg); color: var(--accent); }
@@ -483,7 +484,7 @@
   mark[data-status="active"], mark[data-status="core"], mark[data-status="directive"] { background: var(--status-active-bg); color: var(--success); }
 
   /* -- Buttons -- */
-  button, a[role="button"] {
+  button:not([data-bn]), a[role="button"] {
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
     font-size: var(--font-size-sm);
@@ -500,24 +501,24 @@
     text-decoration: none;
     transition: background var(--duration-fast), border-color var(--duration-fast), color var(--duration-fast), box-shadow var(--duration-med);
   }
-  button:hover, a[role="button"]:hover { background: var(--accent-dim); border-color: var(--accent); color: var(--surface-0); box-shadow: var(--shadow-btn); }
-  button:focus-visible, a[role="button"]:focus-visible { outline: var(--border-inline-width) solid var(--accent); outline-offset: var(--border-inline-width); }
-  button[data-variant="danger"] { border-color: var(--danger); color: var(--danger); }
-  button[data-variant="danger"]:hover { background: var(--danger); color: var(--surface-0); }
+  button:not([data-bn]):hover, a[role="button"]:hover { background: var(--accent-dim); border-color: var(--accent); color: var(--surface-0); box-shadow: var(--shadow-btn); }
+  button:not([data-bn]):focus-visible, a[role="button"]:focus-visible { outline: var(--border-inline-width) solid var(--accent); outline-offset: var(--border-inline-width); }
+  button:not([data-bn])[data-variant="danger"] { border-color: var(--danger); color: var(--danger); }
+  button:not([data-bn])[data-variant="danger"]:hover { background: var(--danger); color: var(--surface-0); }
   [data-variant="outline"] { background: transparent; border-color: var(--border-accent); color: var(--text-1); }
   [data-variant="outline"]:hover { background: var(--surface-2); border-color: var(--accent); color: var(--accent); box-shadow: none; }
 
   /* -- Icons in buttons -- */
-  button > img[src*="/icons/"] {
+  button:not([data-bn]) > img[src*="/icons/"] {
     inline-size: 1em;
     block-size: 1em;
     vertical-align: middle;
     filter: brightness(0) invert(0.9);
   }
-  button:hover > img[src*="/icons/"] { filter: brightness(0) invert(0.03); }
+  button:not([data-bn]):hover > img[src*="/icons/"] { filter: brightness(0) invert(0.03); }
 
   /* -- Inputs -- */
-  input[type="text"] {
+  input[type="text"]:not([data-bn]) {
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
     font-size: var(--font-size-base);
@@ -529,11 +530,11 @@
     outline: none;
     transition: border-color var(--duration-med), box-shadow var(--duration-med);
   }
-  input[type="text"]:focus { border-color: var(--accent); box-shadow: var(--shadow-input), var(--shadow-btn); }
-  input[type="text"]::placeholder { color: var(--text-2); }
+  input[type="text"]:not([data-bn]):focus { border-color: var(--accent); box-shadow: var(--shadow-input), var(--shadow-btn); }
+  input[type="text"]:not([data-bn])::placeholder { color: var(--text-2); }
 
   /* -- Textarea -- */
-  textarea {
+  textarea:not([data-bn]) {
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
     font-size: var(--font-size-base);
@@ -549,11 +550,11 @@
     min-block-size: 4lh;
     transition: border-color var(--duration-med), box-shadow var(--duration-med);
   }
-  textarea:focus { border-color: var(--accent); box-shadow: var(--shadow-input), var(--shadow-btn); }
-  textarea::placeholder { color: var(--text-2); }
+  textarea:not([data-bn]):focus { border-color: var(--accent); box-shadow: var(--shadow-input), var(--shadow-btn); }
+  textarea:not([data-bn])::placeholder { color: var(--text-2); }
 
   /* -- Checkbox -- */
-  input[type="checkbox"] {
+  input[type="checkbox"]:not([data-bn]) {
     appearance: none;
     inline-size: var(--control-size);
     block-size: var(--control-size);
@@ -567,11 +568,11 @@
     flex-shrink: 0;
     transition: background var(--duration-fast), border-color var(--duration-fast), box-shadow var(--duration-fast);
   }
-  input[type="checkbox"]:checked {
+  input[type="checkbox"]:not([data-bn]):checked {
     background: var(--control-checked-bg);
     border-color: var(--control-checked-border);
   }
-  input[type="checkbox"]:checked::after {
+  input[type="checkbox"]:not([data-bn]):checked::after {
     content: '';
     position: absolute;
     inset-block-start: 0.125rem;
@@ -582,10 +583,10 @@
     border-width: 0 2px 2px 0;
     transform: rotate(45deg);
   }
-  input[type="checkbox"]:focus-visible { outline: var(--border-inline-width) solid var(--accent); outline-offset: var(--border-inline-width); }
+  input[type="checkbox"]:not([data-bn]):focus-visible { outline: var(--border-inline-width) solid var(--accent); outline-offset: var(--border-inline-width); }
 
   /* -- Radio -- */
-  input[type="radio"] {
+  input[type="radio"]:not([data-bn]) {
     appearance: none;
     inline-size: var(--control-size);
     block-size: var(--control-size);
@@ -599,10 +600,10 @@
     flex-shrink: 0;
     transition: background var(--duration-fast), border-color var(--duration-fast);
   }
-  input[type="radio"]:checked {
+  input[type="radio"]:not([data-bn]):checked {
     border-color: var(--control-checked-border);
   }
-  input[type="radio"]:checked::after {
+  input[type="radio"]:not([data-bn]):checked::after {
     content: '';
     position: absolute;
     inset-block-start: 50%;
@@ -613,7 +614,7 @@
     border-radius: 50%;
     transform: translate(-50%, -50%);
   }
-  input[type="radio"]:focus-visible { outline: var(--border-inline-width) solid var(--accent); outline-offset: var(--border-inline-width); }
+  input[type="radio"]:not([data-bn]):focus-visible { outline: var(--border-inline-width) solid var(--accent); outline-offset: var(--border-inline-width); }
 
   /* -- Range -- */
   input[type="range"] {
@@ -656,7 +657,7 @@
   input[type="date"]::-webkit-calendar-picker-indicator { filter: invert(0.7); cursor: pointer; }
 
   /* -- Select (base-select) -- */
-  select {
+  select:not([data-bn]) {
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
     font-size: var(--font-size-base);
@@ -675,15 +676,15 @@
     background-size: 0.625rem;
     transition: border-color var(--duration-med), box-shadow var(--duration-med);
   }
-  select:focus { border-color: var(--accent); box-shadow: var(--shadow-input), var(--shadow-btn); }
+  select:not([data-bn]):focus { border-color: var(--accent); box-shadow: var(--shadow-input), var(--shadow-btn); }
 
   @supports (appearance: base-select) {
-    select,
-    select::picker(select) {
+    select:not([data-bn]),
+    select:not([data-bn])::picker(select) {
       appearance: base-select;
     }
 
-    select {
+    select:not([data-bn]) {
       padding-inline-end: var(--space-md);
       background-image: none;
       display: flex;
@@ -691,16 +692,16 @@
       justify-content: space-between;
     }
 
-    select::picker-icon {
+    select:not([data-bn])::picker-icon {
       content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8' width='10' height='7'%3E%3Cpath d='M1.5 1.5l4.5 4.5 4.5-4.5' stroke='%23e8a44a' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
       margin-inline-start: auto;
       transition: rotate var(--duration-fast);
     }
-    select:open::picker-icon {
+    select:not([data-bn]):open::picker-icon {
       rotate: 180deg;
     }
 
-    select::picker(select) {
+    select:not([data-bn])::picker(select) {
       background: var(--popover-bg);
       border: var(--border-width) solid var(--popover-border);
       border-radius: var(--popover-radius);
@@ -713,13 +714,13 @@
     }
 
     @starting-style {
-      select::picker(select) {
+      select:not([data-bn])::picker(select) {
         opacity: 0;
         scale: 0.96;
       }
     }
 
-    select option {
+    select:not([data-bn]) option {
       font-family: var(--font-family);
       font-stretch: var(--font-mono);
       font-size: var(--font-size-base);
@@ -728,15 +729,15 @@
       color: var(--text-0);
       transition: background var(--duration-fast);
     }
-    select option:hover { background: var(--select-option-hover); }
-    select option:checked { color: var(--accent); font-weight: var(--font-weight-semibold); }
+    select:not([data-bn]) option:hover { background: var(--select-option-hover); }
+    select:not([data-bn]) option:checked { color: var(--accent); font-weight: var(--font-weight-semibold); }
 
-    select option::checkmark {
+    select:not([data-bn]) option::checkmark {
       color: var(--accent);
       margin-inline-end: var(--space-sm);
     }
 
-    select optgroup {
+    select:not([data-bn]) optgroup {
       font-family: var(--font-family);
       font-stretch: var(--font-mono);
       font-size: var(--font-size-xs);
@@ -748,7 +749,7 @@
   }
 
   /* -- Progress -- */
-  progress {
+  progress:not([data-bn]) {
     appearance: none;
     inline-size: 100%;
     block-size: var(--track-height);
@@ -757,9 +758,9 @@
     overflow: hidden;
     background: var(--track-bg);
   }
-  progress::-webkit-progress-bar { background: var(--track-bg); border-radius: var(--radius-pill); }
-  progress::-webkit-progress-value { background: var(--track-fill); border-radius: var(--radius-pill); transition: inline-size var(--duration-med); }
-  progress::-moz-progress-bar { background: var(--track-fill); border-radius: var(--radius-pill); }
+  progress:not([data-bn])::-webkit-progress-bar { background: var(--track-bg); border-radius: var(--radius-pill); }
+  progress:not([data-bn])::-webkit-progress-value { background: var(--track-fill); border-radius: var(--radius-pill); transition: inline-size var(--duration-med); }
+  progress:not([data-bn])::-moz-progress-bar { background: var(--track-fill); border-radius: var(--radius-pill); }
 
   /* -- Meter -- */
   meter {
@@ -822,7 +823,7 @@
   .attr { color: var(--syntax-attr); }
 
   /* -- Labels -- */
-  label {
+  label:not([data-bn]) {
     display: flex;
     flex-direction: column;
     gap: var(--space-xs);
@@ -911,8 +912,8 @@
   fieldset > label + label { margin-block-start: var(--space-md); }
 
   /* -- Inline label (for checkbox/radio rows) -- */
-  label:has(input[type="checkbox"]),
-  label:has(input[type="radio"]) {
+  label:not([data-bn]):has(input[type="checkbox"]),
+  label:not([data-bn]):has(input[type="radio"]) {
     flex-direction: row;
     align-items: center;
     gap: var(--space-sm);
@@ -921,20 +922,20 @@
     color: var(--text-1);
   }
 
-  /* -- Table -- */
-  table {
+  /* -- Table (express pages only, not data-bn components) -- */
+  table:not([data-bn]) {
     inline-size: 100%;
     border-collapse: collapse;
     font-size: var(--font-size-base);
   }
 
-  thead {
+  table:not([data-bn]) thead {
     position: sticky;
     inset-block-start: 0;
     z-index: 1;
   }
 
-  th {
+  table:not([data-bn]) th {
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
     font-size: var(--font-size-xs);
@@ -948,15 +949,15 @@
     border-block-end: var(--border-width) solid var(--border-accent);
   }
 
-  td {
+  table:not([data-bn]) td {
     padding: var(--space-sm) var(--space-md);
     border-block-end: var(--border-width) solid var(--border);
     color: var(--text-1);
   }
 
-  tbody tr:nth-child(even) { background: var(--table-stripe); }
-  tbody tr { transition: background var(--duration-fast); }
-  tbody tr:hover { background: var(--surface-2); }
+  table:not([data-bn]) tbody tr:nth-child(even) { background: var(--table-stripe); }
+  table:not([data-bn]) tbody tr { transition: background var(--duration-fast); }
+  table:not([data-bn]) tbody tr:hover { background: var(--surface-2); }
 
   /* -- Blockquote -- */
   blockquote {
@@ -1012,14 +1013,14 @@
   }
 
   /* -- Details / Summary -- */
-  details {
+  details:not([data-bn]) {
     border: var(--border-width) solid var(--border);
     border-radius: var(--radius-md);
     margin-block-end: var(--space-sm);
     interpolate-size: allow-keywords;
   }
 
-  summary {
+  details:not([data-bn]) > summary {
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
     font-size: var(--font-size-sm);
@@ -1034,26 +1035,26 @@
     transition: background var(--duration-fast), color var(--duration-fast);
     border-radius: var(--radius-md);
   }
-  summary:hover { background: var(--surface-2); color: var(--accent); }
-  summary::-webkit-details-marker { display: none; }
+  details:not([data-bn]) > summary:hover { background: var(--surface-2); color: var(--accent); }
+  details:not([data-bn]) > summary::-webkit-details-marker { display: none; }
 
-  summary::before {
+  details:not([data-bn]) > summary::before {
     content: '▸';
     color: var(--details-marker);
     font-size: 0.85em;
     transition: rotate var(--duration-fast);
   }
-  details[open] > summary::before { rotate: 90deg; }
-  details[open] > summary { margin-block-end: 0; }
+  details:not([data-bn])[open] > summary::before { rotate: 90deg; }
+  details:not([data-bn])[open] > summary { margin-block-end: 0; }
 
-  details > :not(summary) {
+  details:not([data-bn]) > :not(summary) {
     padding: var(--space-sm) var(--space-md) var(--space-md);
     color: var(--text-1);
     font-size: var(--font-size-base);
   }
 
   /* -- Dialog -- */
-  dialog {
+  dialog:not([data-bn]) {
     margin: auto;
     background: var(--dialog-bg);
     color: var(--text-0);
@@ -1066,33 +1067,33 @@
     transition-behavior: allow-discrete;
   }
 
-  dialog::backdrop {
+  dialog:not([data-bn])::backdrop {
     background: var(--dialog-backdrop);
     transition: opacity var(--duration-med), overlay var(--duration-med), display var(--duration-med);
     transition-behavior: allow-discrete;
   }
 
-  dialog[open] { opacity: 1; scale: 1; }
+  dialog:not([data-bn])[open] { opacity: 1; scale: 1; }
 
   @starting-style {
-    dialog[open] { opacity: 0; scale: 0.95; }
-    dialog[open]::backdrop { opacity: 0; }
+    dialog:not([data-bn])[open] { opacity: 0; scale: 0.95; }
+    dialog:not([data-bn])[open]::backdrop { opacity: 0; }
   }
 
-  dialog > header {
+  dialog:not([data-bn]) > header {
     margin-block-end: var(--space-md);
     padding-block-end: var(--space-md);
     border-block-end: var(--border-width) solid var(--border);
   }
 
-  dialog > header h3 {
+  dialog:not([data-bn]) > header h3 {
     font-family: var(--font-family);
     font-stretch: var(--font-serif);
     font-size: var(--font-size-xl);
     font-weight: var(--font-weight-normal);
   }
 
-  dialog > footer {
+  dialog:not([data-bn]) > footer {
     margin-block-start: var(--space-lg);
     display: flex;
     justify-content: flex-end;
@@ -1103,7 +1104,7 @@
   }
 
   /* -- Popover -- */
-  [popover] {
+  [popover]:not([data-bn]) {
     margin: 0;
     padding: var(--space-md);
     background: var(--popover-bg);
@@ -1118,10 +1119,10 @@
     scale: 1;
   }
 
-  [popover]::backdrop { background: transparent; }
+  [popover]:not([data-bn])::backdrop { background: transparent; }
 
   @starting-style {
-    [popover]:popover-open { opacity: 0; scale: 0.96; }
+    [popover]:not([data-bn]):popover-open { opacity: 0; scale: 0.96; }
   }
 
   /* Tooltip variant */
@@ -1571,4 +1572,18 @@
       transition-duration: 0.01ms !important;
     }
   }
+
+  /* -- Showcase layout helpers -- */
+  [data-showcase-row] { display: flex; gap: var(--space-md); flex-wrap: wrap; align-items: center; }
+  [data-showcase-form] { display: grid; gap: var(--space-lg); max-inline-size: 32rem; }
+  [data-showcase-stack] { display: grid; gap: var(--space-sm); }
+  [data-showcase-card] { max-inline-size: 24rem; }
+
+  /* -- Component overrides for express theme -- */
+  [data-bn="button"] { min-block-size: 2.75rem; }
+  [data-bn="spinner"] > span { border-width: 3px; }
+  [data-bn="progress"] { block-size: var(--track-height, 0.375rem); }
+  [data-bn="progress"]::-webkit-progress-bar { background: var(--track-bg, var(--surface-2)); }
+  [data-bn="progress"]::-webkit-progress-value { background: var(--accent); }
+  [data-bn="progress"]::-moz-progress-bar { background: var(--accent); }
 }

--- a/examples/express/public/theme.css
+++ b/examples/express/public/theme.css
@@ -1,0 +1,126 @@
+/*
+ * Express Example Theme — Dark / Golden Amber
+ *
+ * Overrides core --bn-* semantic tokens to produce the distinctive
+ * dark background + golden accent look. The express-specific tokens
+ * (--surface-*, --text-*, --accent, etc.) are also defined here so
+ * existing styles.css rules continue to work as the migration to
+ * fully --bn-* based styles progresses.
+ */
+
+:root {
+  /* === Core token overrides === */
+
+  /* Surfaces — dark */
+  --bn-color-surface: #0a0a0c;
+  --bn-color-surface-subtle: #131318;
+  --bn-color-surface-muted: #1a1a22;
+  --bn-color-surface-raised: #131318;
+  --bn-color-surface-inset: #08080a;
+  --bn-color-surface-inverse: #e8e6f0;
+
+  /* Text — light on dark */
+  --bn-color-text: #e8e6f0;
+  --bn-color-text-muted: #b0adc0;
+  --bn-color-text-subtle: #7a7890;
+  --bn-color-text-inverse: #0a0a0c;
+  --bn-color-text-link: #e8a44a;
+
+  /* Borders — dark */
+  --bn-color-border: #2a2a38;
+  --bn-color-border-strong: #3d3d52;
+  --bn-color-border-focus: #e8a44a;
+
+  /* Font — BaseNative with font-stretch */
+  --bn-font-family: 'BaseNative', system-ui, sans-serif;
+
+  /* Primary — remap to golden for buttons/links */
+  --bn-color-primary-50: #fdf4e7;
+  --bn-color-primary-100: #fbe5c4;
+  --bn-color-primary-200: #f5cc8a;
+  --bn-color-primary-300: #efb35e;
+  --bn-color-primary-400: #e8a44a;
+  --bn-color-primary-500: #d4913a;
+  --bn-color-primary-600: #b07a30;
+  --bn-color-primary-700: #8c6126;
+  --bn-color-primary-800: #68491c;
+  --bn-color-primary-900: #4a3414;
+
+  /* Radius — tighter for BaseNative aesthetic */
+  --bn-radius-sm: 0.15rem;
+  --bn-radius-md: 0.25rem;
+  --bn-radius-lg: 0.5rem;
+  --bn-radius-xl: 0.75rem;
+
+  /* Accent — golden amber (overrides primary-as-accent) */
+  --bn-color-accent-50: #fdf4e7;
+  --bn-color-accent-100: #fbe5c4;
+  --bn-color-accent-200: #f5cc8a;
+  --bn-color-accent-300: #efb35e;
+  --bn-color-accent-400: #e8a44a;
+  --bn-color-accent-500: #d4913a;
+  --bn-color-accent-600: #b07a30;
+  --bn-color-accent-700: #8c6126;
+  --bn-color-accent-800: #68491c;
+  --bn-color-accent-900: #4a3414;
+
+  /* Alert/badge semantic — dark theme */
+  --bn-color-info-bg: rgb(130 170 255 / 0.1);
+  --bn-color-info-border: rgb(130 170 255 / 0.2);
+  --bn-color-info-text: #82aaff;
+  --bn-color-success-bg: rgb(195 232 141 / 0.1);
+  --bn-color-success-border: rgb(195 232 141 / 0.2);
+  --bn-color-success-text: #c3e88d;
+  --bn-color-warning-bg: rgb(232 164 74 / 0.1);
+  --bn-color-warning-border: rgb(232 164 74 / 0.2);
+  --bn-color-warning-text: #e8a44a;
+  --bn-color-error-bg: rgb(240 113 120 / 0.1);
+  --bn-color-error-border: rgb(240 113 120 / 0.2);
+  --bn-color-error-text: #f07178;
+
+  --bn-color-success-badge-bg: rgb(195 232 141 / 0.12);
+  --bn-color-success-badge-text: #c3e88d;
+  --bn-color-warning-badge-bg: rgb(232 164 74 / 0.12);
+  --bn-color-warning-badge-text: #e8a44a;
+  --bn-color-error-badge-bg: rgb(240 113 120 / 0.12);
+  --bn-color-error-badge-text: #f07178;
+
+  /* Focus ring — golden */
+  --bn-focus-ring: 0 0 0 2px #0a0a0c, 0 0 0 4px #e8a44a;
+
+  /* Shadows — dark-optimized */
+  --bn-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
+  --bn-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.4), 0 2px 4px -2px rgb(0 0 0 / 0.3);
+  --bn-shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.4);
+
+  /* === Express-specific tokens (for existing styles.css compatibility) === */
+
+  /* Surfaces */
+  --surface-0: #0a0a0c;
+  --surface-1: #131318;
+  --surface-2: #1a1a22;
+  --surface-3: #24242f;
+  --surface-inset: #08080a;
+
+  /* Borders */
+  --border: #2a2a38;
+  --border-accent: #3d3d52;
+
+  /* Text */
+  --text-0: #e8e6f0;
+  --text-1: #b0adc0;
+  --text-2: #7a7890;
+
+  /* Accent */
+  --accent: #e8a44a;
+  --accent-dim: #b07a30;
+  --accent-glow: #e8a44a33;
+  --accent-glow-strong: #e8a44a55;
+
+  /* Status */
+  --danger: #f07178;
+  --danger-glow: #f0717833;
+  --success: #c3e88d;
+  --success-glow: #c3e88d33;
+  --info: #82aaff;
+}

--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -1,8 +1,19 @@
 import express from 'express';
-import { readFileSync } from 'node:fs';
+import { readFileSync, watch } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { render } from '@basenative/server';
+import {
+  renderButton, renderBadge, renderAvatar,
+  renderInput, renderTextarea, renderSelect, renderCheckbox, renderRadioGroup, renderToggle,
+  renderCombobox, renderMultiselect,
+  renderAlert, renderProgress, renderSpinner, renderSkeleton,
+  renderCard, renderAccordion, renderTabs,
+  renderBreadcrumb, renderPagination,
+  renderTable, renderDataGrid,
+  renderDialog, renderDrawer, renderDropdownMenu, renderTooltip, renderCommandPalette,
+  renderTree, renderVirtualList, renderToastContainer,
+} from '../../packages/components/src/index.js';
 import {
   getComponentsPageContext,
   getHomePageContext,
@@ -17,6 +28,7 @@ const read = (file) => readFileSync(join(__dirname, file), 'utf-8');
 const app = express();
 app.use(express.json());
 app.use(express.static(join(__dirname, 'public')));
+app.use('/bn-css', express.static(join(pkgRoot, 'packages', 'components', 'src')));
 app.use('/fonts', express.static(join(pkgRoot, 'packages', 'fonts')));
 app.use('/icons', express.static(join(pkgRoot, 'packages', 'icons', 'src')));
 
@@ -88,6 +100,178 @@ app.get('/test-signals', (req, res) => {
   res.send(html);
 });
 
+app.get('/showcase', (req, res) => {
+  const ctx = {
+    // Buttons
+    buttons: [
+      renderButton('Primary', { variant: 'primary' }),
+      renderButton('Secondary', { variant: 'secondary' }),
+      renderButton('Destructive', { variant: 'destructive' }),
+      renderButton('Ghost', { variant: 'ghost' }),
+      renderButton('Disabled', { variant: 'primary', disabled: true }),
+    ].join('\n'),
+
+    // Badges
+    badges: [
+      renderBadge('Default', { variant: 'default' }),
+      renderBadge('Primary', { variant: 'primary' }),
+      renderBadge('Success', { variant: 'success' }),
+      renderBadge('Warning', { variant: 'warning' }),
+      renderBadge('Error', { variant: 'error' }),
+    ].join('\n'),
+
+    // Avatars
+    avatars: [
+      renderAvatar({ name: 'Alice Johnson', size: 'sm' }),
+      renderAvatar({ name: 'Bob Smith' }),
+      renderAvatar({ name: 'Carol Davis', size: 'lg' }),
+      renderAvatar({ name: 'Dan Lee', size: 'xl' }),
+    ].join('\n'),
+
+    // Form controls
+    inputDefault: renderInput({ name: 'email', label: 'Email', type: 'email', placeholder: 'you@example.com', helpText: 'We will not share your email.' }),
+    inputError: renderInput({ name: 'username', label: 'Username', value: 'ab', error: 'Must be at least 3 characters' }),
+    textarea: renderTextarea({ name: 'bio', label: 'Bio', placeholder: 'Tell us about yourself...', rows: 3 }),
+    select: renderSelect({ name: 'role', label: 'Role', items: ['Admin', 'Editor', 'Viewer'], placeholder: 'Choose a role' }),
+    combobox: renderCombobox({ name: 'framework', label: 'Framework', items: ['Angular', 'React', 'Vue', 'Svelte', 'Solid'], placeholder: 'Search frameworks...' }),
+    multiselect: renderMultiselect({ name: 'tags', label: 'Tags', items: ['JavaScript', 'TypeScript', 'CSS', 'HTML', 'Node.js'], selected: ['JavaScript', 'CSS'] }),
+    checkbox: renderCheckbox({ name: 'terms', label: 'I agree to the terms and conditions' }),
+    radioGroup: renderRadioGroup({ name: 'plan', label: 'Plan', items: ['Free', 'Pro', 'Enterprise'], selected: 'Pro' }),
+    toggle: renderToggle({ name: 'notifications', label: 'Email notifications', checked: true }),
+
+    // Feedback
+    alertInfo: renderAlert('This is an informational message.', { variant: 'info' }),
+    alertSuccess: renderAlert('Operation completed successfully.', { variant: 'success' }),
+    alertWarning: renderAlert('Proceed with caution.', { variant: 'warning' }),
+    alertError: renderAlert('Something went wrong.', { variant: 'error', dismissible: true }),
+    progress: renderProgress({ value: 65, max: 100, label: 'Upload progress' }),
+    spinner: renderSpinner({ label: 'Loading' }),
+    spinnerLg: renderSpinner({ size: 'lg', label: 'Loading' }),
+    skeleton: renderSkeleton({ width: '100%', height: '1rem', count: 3 }),
+
+    // Cards & layout
+    card: renderCard({ header: 'Card Title', body: '<p>Card body content with descriptive text about the feature or item being presented.</p>', footer: 'Updated 2 hours ago' }),
+    accordion: renderAccordion({ items: [
+      { title: 'What is BaseNative?', content: 'A lightweight signals-based runtime for native template elements with ~120 lines of client code.' },
+      { title: 'How does SSR work?', content: 'The server renderer evaluates @if, @for, @switch directives at request time and returns clean HTML.' },
+      { title: 'What about hydration?', content: 'The client hydrate() function walks the DOM tree, binds reactive expressions, and attaches event handlers.' },
+    ] }),
+    tabs: renderTabs({ tabs: [
+      { id: 'overview', label: 'Overview', content: '<p>BaseNative brings Angular-inspired control flow to native template elements.</p>' },
+      { id: 'features', label: 'Features', content: '<p>Signals, computed values, effects, SSR, hydration, and template directives.</p>' },
+      { id: 'api', label: 'API', content: '<p>signal(), computed(), effect(), hydrate(), render().</p>' },
+    ] }),
+
+    // Navigation
+    breadcrumb: renderBreadcrumb({ items: [
+      { label: 'Home', href: '/' },
+      { label: 'Components', href: '/components' },
+      { label: 'Showcase' },
+    ] }),
+    pagination: renderPagination({ currentPage: 3, totalPages: 10, baseUrl: '/showcase' }),
+
+    // Data
+    table: renderTable({
+      columns: [
+        { key: 'name', label: 'Name' },
+        { key: 'role', label: 'Role' },
+        { key: 'status', label: 'Status' },
+      ],
+      rows: [
+        { name: 'Alice Johnson', role: 'Admin', status: 'Active' },
+        { name: 'Bob Smith', role: 'Editor', status: 'Active' },
+        { name: 'Carol Davis', role: 'Viewer', status: 'Inactive' },
+      ],
+      caption: 'Team members',
+    }),
+    datagrid: renderDataGrid({
+      columns: [
+        { key: 'task', label: 'Task', sortable: true },
+        { key: 'assignee', label: 'Assignee', sortable: true },
+        { key: 'priority', label: 'Priority' },
+        { key: 'status', label: 'Status' },
+      ],
+      rows: [
+        { id: 1, task: 'Design token system', assignee: 'Alice', priority: 'High', status: 'Done' },
+        { id: 2, task: 'Signal reactivity', assignee: 'Bob', priority: 'High', status: 'Done' },
+        { id: 3, task: 'Server rendering', assignee: 'Carol', priority: 'Medium', status: 'Active' },
+        { id: 4, task: 'Client hydration', assignee: 'Dan', priority: 'Medium', status: 'Pending' },
+        { id: 5, task: 'Component library', assignee: 'Alice', priority: 'Low', status: 'Active' },
+      ],
+      sortBy: 'task',
+      sortDir: 'asc',
+      selectable: true,
+      caption: 'Project tasks',
+    }),
+    tree: renderTree({
+      items: [
+        { id: '1', label: 'src', icon: '\u{1F4C1}', children: [
+          { id: '1-1', label: 'runtime', icon: '\u{1F4C1}', children: [
+            { id: '1-1-1', label: 'signals.js', icon: '\u{1F4C4}' },
+            { id: '1-1-2', label: 'hydrate.js', icon: '\u{1F4C4}' },
+            { id: '1-1-3', label: 'bind.js', icon: '\u{1F4C4}' },
+          ]},
+          { id: '1-2', label: 'server', icon: '\u{1F4C1}', children: [
+            { id: '1-2-1', label: 'render.js', icon: '\u{1F4C4}' },
+          ]},
+        ]},
+        { id: '2', label: 'examples', icon: '\u{1F4C1}', children: [
+          { id: '2-1', label: 'express', icon: '\u{1F4C1}' },
+          { id: '2-2', label: 'enterprise', icon: '\u{1F4C1}' },
+        ]},
+      ],
+      expanded: new Set(['1', '1-1']),
+      selected: '1-1-1',
+    }),
+    virtualList: renderVirtualList({
+      items: Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`),
+      itemHeight: 40,
+      containerHeight: 200,
+    }),
+
+    // Overlays
+    dialog: renderDialog({
+      title: 'Confirm Action',
+      content: '<p>Are you sure you want to proceed? This action cannot be undone.</p>',
+      footer: renderButton('Cancel', { variant: 'secondary' }) + renderButton('Confirm', { variant: 'primary' }),
+      id: 'demo-dialog',
+    }),
+    drawer: renderDrawer({
+      title: 'Settings',
+      content: '<p>Drawer body content goes here. This slides in from the edge of the viewport.</p>',
+      position: 'right',
+      id: 'demo-drawer',
+    }),
+    dropdown: renderDropdownMenu({
+      trigger: 'Actions',
+      items: [
+        { label: 'Edit', action: 'edit', icon: '\u{270F}\u{FE0F}' },
+        { label: 'Duplicate', action: 'duplicate', icon: '\u{1F4CB}' },
+        { separator: true },
+        { label: 'Delete', action: 'delete', icon: '\u{1F5D1}\u{FE0F}' },
+      ],
+    }),
+    tooltip: renderTooltip({
+      trigger: 'Hover me',
+      content: 'This is a tooltip with helpful context',
+      position: 'top',
+    }),
+    commandPalette: renderCommandPalette({
+      commands: [
+        { label: 'Go to Home', action: 'home', group: 'Navigation', icon: '\u{1F3E0}' },
+        { label: 'Go to Tasks', action: 'tasks', group: 'Navigation', icon: '\u{2705}' },
+        { label: 'New Task', action: 'new-task', group: 'Actions', icon: '\u{2795}', shortcut: 'Ctrl+N' },
+        { label: 'Search', action: 'search', group: 'Actions', icon: '\u{1F50D}', shortcut: 'Ctrl+K' },
+      ],
+      id: 'demo-cmd',
+    }),
+
+    toastContainer: renderToastContainer('top-right'),
+  };
+  const html = renderPage('showcase.html', ctx, { title: 'Showcase', activePage: 'showcase' });
+  res.send(html);
+});
+
 // -- API --
 
 app.post('/api/tasks', (req, res) => {
@@ -107,6 +291,39 @@ app.delete('/api/tasks/:id', (req, res) => {
   tasks.splice(idx, 1);
   res.status(204).end();
 });
+
+// -- Live reload (dev only) --
+const liveClients = new Set();
+
+app.get('/__live', (req, res) => {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  res.write('data: connected\n\n');
+  liveClients.add(res);
+  req.on('close', () => liveClients.delete(res));
+});
+
+let reloadTimer;
+function notifyReload() {
+  clearTimeout(reloadTimer);
+  reloadTimer = setTimeout(() => {
+    for (const client of liveClients) client.write('data: reload\n\n');
+  }, 200);
+}
+
+const watchDirs = [
+  join(__dirname, 'views'),
+  join(__dirname, 'public'),
+  join(pkgRoot, 'packages', 'components', 'src'),
+];
+for (const dir of watchDirs) {
+  try {
+    watch(dir, { recursive: true }, () => notifyReload());
+  } catch { /* dir may not exist in CI */ }
+}
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/examples/express/site-data.js
+++ b/examples/express/site-data.js
@@ -1,4 +1,4 @@
-export const navPages = ['home', 'tasks', 'playground', 'docs', 'components'];
+export const navPages = ['home', 'tasks', 'playground', 'docs', 'components', 'showcase'];
 
 export const staticTasks = [
   { id: 1, title: 'Design token system', status: 'done' },
@@ -46,10 +46,10 @@ export function getTasksPageContext(tasks) {
 export function getComponentsPageContext() {
   return {
     readinessStats: [
-      { label: 'Current Milestone', value: 'v0.4+ Workflow Breadth' },
-      { label: 'Evergreen Support', value: 'Chrome, Edge, Firefox, Safari' },
-      { label: 'Public Packages', value: 'Runtime, Server, Components, Router, Forms' },
-      { label: 'Advanced Widgets', value: 'Implemented' },
+      { label: 'Current Milestone', value: 'v0.4+' },
+      { label: 'Browser Support', value: '4 engines' },
+      { label: 'Public Packages', value: '5' },
+      { label: 'Advanced Widgets', value: 'Shipped' },
     ],
     releaseStages: [
       {

--- a/examples/express/views/components.html
+++ b/examples/express/views/components.html
@@ -186,14 +186,22 @@
 
   <article>
     <header><h3>Explicitly deferred</h3></header>
-    <ul role="list">
-      <template @for="item of deferredWork; track item.item">
-        <li>
-          <span>{{ item.item }}</span>
-          <span>{{ item.reason }}</span>
-        </li>
-      </template>
-    </ul>
+    <table>
+      <thead>
+        <tr>
+          <th>Scope</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <template @for="item of deferredWork; track item.item">
+          <tr>
+            <td>{{ item.item }}</td>
+            <td>{{ item.reason }}</td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
   </article>
 </section>
 

--- a/examples/express/views/docs.html
+++ b/examples/express/views/docs.html
@@ -103,7 +103,7 @@ name.<span class="fn">set</span>(<span class="str">'BaseNative'</span>);
     </header>
     <p>Iterate over arrays. Supports <code>track</code> for identity. Loop variables: <code>$index</code>, <code>$first</code>, <code>$last</code>, <code>$even</code>, <code>$odd</code>.</p>
     <pre><code><span class="tag">&lt;template</span> <span class="attr">@for</span>=<span class="str">"item of items(); track item.id"</span><span class="tag">&gt;</span>
-  <span class="tag">&lt;li&gt;</span>{{ item.name }}<span class="tag">&lt;/li&gt;</span>
+  <span class="tag">&lt;li&gt;</span>&#123;&#123; item.name &#125;&#125;<span class="tag">&lt;/li&gt;</span>
 <span class="tag">&lt;/template&gt;</span>
 <span class="tag">&lt;template</span> <span class="attr">@empty</span><span class="tag">&gt;</span>
   <span class="tag">&lt;li&gt;</span>No items found<span class="tag">&lt;/li&gt;</span>
@@ -137,11 +137,11 @@ name.<span class="fn">set</span>(<span class="str">'BaseNative'</span>);
 
 <span class="cmt">&lt;!-- Event handler --&gt;</span>
 <span class="tag">&lt;button</span> <span class="attr">@click</span>=<span class="str">"incrementCount()"</span><span class="tag">&gt;</span>
-  Clicked {{ count() }} times
+  Clicked &#123;&#123; count() &#125;&#125; times
 <span class="tag">&lt;/button&gt;</span>
 
 <span class="cmt">&lt;!-- Text interpolation --&gt;</span>
-<span class="tag">&lt;p&gt;</span>Hello, {{ name() }}<span class="tag">&lt;/p&gt;</span></code></pre>
+<span class="tag">&lt;p&gt;</span>Hello, &#123;&#123; name() &#125;&#125;<span class="tag">&lt;/p&gt;</span></code></pre>
   </article>
 </section>
 
@@ -159,7 +159,7 @@ name.<span class="fn">set</span>(<span class="str">'BaseNative'</span>);
 
 <span class="kw">const</span> html = <span class="fn">render</span>(<span class="str">`
   &lt;template @for="item of items; track item.id"&gt;
-    &lt;li&gt;{{ item.name }}&lt;/li&gt;
+    &lt;li&gt;&#123;&#123; item.name &#125;&#125;&lt;/li&gt;
   &lt;/template&gt;
 `</span>, {
   items: [

--- a/examples/express/views/layout.html
+++ b/examples/express/views/layout.html
@@ -1,16 +1,18 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title><!--TITLE--> — BaseNative</title>
+<link rel="stylesheet" href="/bn-css/index.css">
 <link rel="stylesheet" href="/fonts/fonts.css">
+<link rel="stylesheet" href="/theme.css">
 <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header>
-    <nav>
+    <nav aria-label="Main navigation">
       <h1>Base<em>Native</em></h1>
       <ul>
         <li><a href="/" <!--HOME_ARIA-->>Home</a></li>
@@ -18,6 +20,7 @@
         <li><a href="/playground" <!--PLAYGROUND_ARIA-->>Playground</a></li>
         <li><a href="/docs" <!--DOCS_ARIA-->>Docs</a></li>
         <li><a href="/components" <!--COMPONENTS_ARIA-->>Components</a></li>
+        <li><a href="/showcase" <!--SHOWCASE_ARIA-->>Showcase</a></li>
       </ul>
     </nav>
   </header>
@@ -29,5 +32,6 @@
     <p>BaseNative — Semantic HTML + Signals · pilot-stage runtime and server foundation</p>
   </footer>
   <!--SCRIPTS-->
+  <script>if(!location.search.includes('nolr'))new EventSource('/__live').onmessage=e=>{if(e.data==='reload')location.reload()}</script>
 </body>
 </html>

--- a/examples/express/views/showcase.html
+++ b/examples/express/views/showcase.html
@@ -1,0 +1,235 @@
+<section>
+  <h2>Component <em>Showcase</em></h2>
+  <p>Every component in the BaseNative design system, server-rendered and styled from the core CSS. Each section below is a live render call — no mockups.</p>
+</section>
+
+<section>
+  <h2>Buttons</h2>
+  <article>
+    <header><h3>Variants</h3></header>
+    <nav data-showcase-row>
+      {{ buttons }}
+    </nav>
+  </article>
+</section>
+
+<section>
+  <h2>Badges</h2>
+  <article>
+    <header><h3>Variants</h3></header>
+    <nav data-showcase-row>
+      {{ badges }}
+    </nav>
+  </article>
+</section>
+
+<section>
+  <h2>Avatars</h2>
+  <article>
+    <header><h3>Sizes and fallbacks</h3></header>
+    <nav data-showcase-row>
+      {{ avatars }}
+    </nav>
+  </article>
+</section>
+
+<section>
+  <h2>Form <em>Controls</em></h2>
+  <article>
+    <header><h3>Inputs</h3></header>
+    <div data-showcase-form>
+      {{ inputDefault }}
+      {{ inputError }}
+    </div>
+  </article>
+  <article>
+    <header><h3>Textarea</h3></header>
+    <div data-showcase-form>
+      {{ textarea }}
+    </div>
+  </article>
+  <article>
+    <header><h3>Select</h3></header>
+    <div data-showcase-form>
+      {{ select }}
+    </div>
+  </article>
+  <article>
+    <header><h3>Combobox</h3></header>
+    <div data-showcase-form>
+      {{ combobox }}
+    </div>
+  </article>
+  <article>
+    <header><h3>Multiselect</h3></header>
+    <div data-showcase-form>
+      {{ multiselect }}
+    </div>
+  </article>
+  <article>
+    <header><h3>Checkbox, radio, toggle</h3></header>
+    <div data-showcase-form>
+      {{ checkbox }}
+      {{ radioGroup }}
+      {{ toggle }}
+    </div>
+  </article>
+</section>
+
+<section>
+  <h2>Feedback</h2>
+  <article>
+    <header><h3>Alerts</h3></header>
+    <div data-showcase-stack>
+      {{ alertInfo }}
+      {{ alertSuccess }}
+      {{ alertWarning }}
+      {{ alertError }}
+    </div>
+  </article>
+  <article>
+    <header><h3>Progress</h3></header>
+    {{ progress }}
+  </article>
+  <article>
+    <header><h3>Spinner</h3></header>
+    <nav data-showcase-row>
+      {{ spinner }}
+      {{ spinnerLg }}
+    </nav>
+  </article>
+  <article>
+    <header><h3>Skeleton</h3></header>
+    {{ skeleton }}
+  </article>
+</section>
+
+<section>
+  <h2>Cards <em>&amp; Layout</em></h2>
+  <article>
+    <header><h3>Card</h3></header>
+    <div data-showcase-card>
+      {{ card }}
+    </div>
+  </article>
+  <article>
+    <header><h3>Accordion</h3></header>
+    <div data-showcase-form>
+      {{ accordion }}
+    </div>
+  </article>
+  <article>
+    <header><h3>Tabs</h3></header>
+    {{ tabs }}
+  </article>
+</section>
+
+<section>
+  <h2>Navigation</h2>
+  <article>
+    <header><h3>Breadcrumb</h3></header>
+    {{ breadcrumb }}
+  </article>
+  <article>
+    <header><h3>Pagination</h3></header>
+    {{ pagination }}
+  </article>
+</section>
+
+<section>
+  <h2>Data</h2>
+  <article>
+    <header><h3>Table</h3></header>
+    {{ table }}
+  </article>
+  <article>
+    <header><h3>Data grid</h3></header>
+    {{ datagrid }}
+  </article>
+  <article>
+    <header><h3>Tree</h3></header>
+    <div data-showcase-card>
+      {{ tree }}
+    </div>
+  </article>
+  <article>
+    <header><h3>Virtual list</h3></header>
+    <div data-showcase-form>
+      {{ virtualList }}
+    </div>
+  </article>
+</section>
+
+<section>
+  <h2>Overlays</h2>
+  <article>
+    <header><h3>Dialog</h3></header>
+    <button data-bn="button" data-variant="secondary" onclick="document.getElementById('demo-dialog').showModal()">Open dialog</button>
+    {{ dialog }}
+  </article>
+  <article>
+    <header><h3>Drawer</h3></header>
+    <button data-bn="button" data-variant="secondary" onclick="openDrawer()">Open drawer</button>
+    {{ drawer }}
+  </article>
+  <article>
+    <header><h3>Dropdown menu</h3></header>
+    {{ dropdown }}
+  </article>
+  <article>
+    <header><h3>Tooltip</h3></header>
+    {{ tooltip }}
+  </article>
+  <article>
+    <header><h3>Command palette</h3></header>
+    <button data-bn="button" data-variant="secondary" onclick="document.getElementById('demo-cmd').showModal()">Open command palette</button>
+    {{ commandPalette }}
+  </article>
+</section>
+
+{{ toastContainer }}
+
+<script type="module">
+// -- Tabs --
+document.querySelectorAll('[data-bn="tab"]').forEach(tab => {
+  tab.addEventListener('click', () => {
+    const tabs = tab.closest('[data-bn="tabs"]');
+    tabs.querySelectorAll('[data-bn="tab"]').forEach(t => t.setAttribute('aria-selected', 'false'));
+    tabs.querySelectorAll('[data-bn="tab-panel"]').forEach(p => p.hidden = true);
+    tab.setAttribute('aria-selected', 'true');
+    const panel = tabs.querySelector('#' + tab.getAttribute('aria-controls'));
+    if (panel) panel.hidden = false;
+  });
+});
+
+// -- Accordion (native details/summary) --
+// Already interactive via native <details> — no JS needed
+
+// -- Dialog --
+document.querySelectorAll('[data-bn="dialog-close"]').forEach(btn => {
+  btn.addEventListener('click', () => btn.closest('[data-bn="dialog"]')?.close());
+});
+
+// -- Drawer --
+const drawer = document.getElementById('demo-drawer');
+const drawerOverlay = document.querySelector('[data-bn="drawer-overlay"]');
+function openDrawer() {
+  drawer?.setAttribute('data-open', '');
+  drawerOverlay?.removeAttribute('hidden');
+}
+function closeDrawer() {
+  drawer?.removeAttribute('data-open');
+  drawerOverlay?.setAttribute('hidden', '');
+}
+document.querySelector('[data-bn="drawer-close"]')?.addEventListener('click', closeDrawer);
+drawerOverlay?.addEventListener('click', closeDrawer);
+
+// -- Alert dismiss --
+document.querySelectorAll('[data-bn="alert-dismiss"]').forEach(btn => {
+  btn.addEventListener('click', () => btn.closest('[data-bn="alert"]')?.remove());
+});
+
+// -- Toast demo --
+import { signal, effect } from '/basenative.js';
+const toastCount = signal(0);
+</script>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -4,8 +4,13 @@
   "type": "module",
   "exports": {
     ".": "./src/index.js",
+    "./css": "./src/index.css",
     "./tokens.css": "./src/tokens.css",
-    "./theme.css": "./src/theme.css"
+    "./theme.css": "./src/theme.css",
+    "./components.css": "./src/components.css",
+    "./layout.css": "./src/layout.css",
+    "./reset.css": "./src/reset.css",
+    "./states.css": "./src/states.css"
   },
   "types": "./types/index.d.ts",
   "dependencies": {

--- a/packages/components/src/components.css
+++ b/packages/components/src/components.css
@@ -1,3 +1,4 @@
+@layer components {
 /* BaseNative Component Styles */
 
 /* === Button === */
@@ -93,6 +94,49 @@
   font-size: var(--bn-font-size-component);
   cursor: pointer;
 }
+[data-bn="checkbox"], [data-bn="radio"] {
+  appearance: none;
+  width: 1.125rem;
+  height: 1.125rem;
+  background: var(--bn-color-surface);
+  border: var(--bn-border-width) solid var(--bn-color-border-strong);
+  cursor: pointer;
+  flex-shrink: 0;
+  position: relative;
+  transition: background-color var(--bn-transition-fast), border-color var(--bn-transition-fast);
+}
+[data-bn="checkbox"] { border-radius: var(--bn-radius-sm); }
+[data-bn="radio"] { border-radius: var(--bn-radius-full); }
+[data-bn="checkbox"]:checked, [data-bn="radio"]:checked {
+  background: var(--bn-color-accent-600);
+  border-color: var(--bn-color-accent-600);
+}
+[data-bn="checkbox"]:checked::after {
+  content: '';
+  position: absolute;
+  top: 1px;
+  left: 4px;
+  width: 5px;
+  height: 9px;
+  border: solid var(--bn-color-white);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+[data-bn="radio"]:checked::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 6px;
+  height: 6px;
+  background: var(--bn-color-white);
+  border-radius: var(--bn-radius-full);
+  transform: translate(-50%, -50%);
+}
+[data-bn="checkbox"]:focus-visible, [data-bn="radio"]:focus-visible {
+  box-shadow: var(--bn-focus-ring);
+  outline: none;
+}
 [data-bn="radio-group"] {
   border: none;
   padding: 0;
@@ -141,10 +185,10 @@
   font-size: var(--bn-font-size-sm);
   border: 1px solid;
 }
-[data-bn="alert"][data-variant="info"] { background: var(--bn-color-primary-50); border-color: var(--bn-color-primary-200); color: var(--bn-color-primary-800); }
-[data-bn="alert"][data-variant="success"] { background: #f0fdf4; border-color: #bbf7d0; color: #166534; }
-[data-bn="alert"][data-variant="warning"] { background: #fffbeb; border-color: #fde68a; color: #92400e; }
-[data-bn="alert"][data-variant="error"] { background: #fef2f2; border-color: #fecaca; color: #991b1b; }
+[data-bn="alert"][data-variant="info"] { background: var(--bn-color-info-bg); border-color: var(--bn-color-info-border); color: var(--bn-color-info-text); }
+[data-bn="alert"][data-variant="success"] { background: var(--bn-color-success-bg); border-color: var(--bn-color-success-border); color: var(--bn-color-success-text); }
+[data-bn="alert"][data-variant="warning"] { background: var(--bn-color-warning-bg); border-color: var(--bn-color-warning-border); color: var(--bn-color-warning-text); }
+[data-bn="alert"][data-variant="error"] { background: var(--bn-color-error-bg); border-color: var(--bn-color-error-border); color: var(--bn-color-error-text); }
 [data-bn="alert-dismiss"] {
   margin-left: auto;
   background: none;
@@ -155,6 +199,7 @@
   opacity: 0.6;
 }
 [data-bn="alert-dismiss"]:hover { opacity: 1; }
+[data-bn="alert-dismiss"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; border-radius: var(--bn-radius-sm); }
 
 /* === Toast === */
 [data-bn="toast-container"] {
@@ -224,6 +269,7 @@
   color: var(--bn-color-text);
 }
 [data-bn="pagination"] a:hover { background: var(--bn-color-surface-muted); }
+[data-bn="pagination"] a:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
 [data-bn="pagination"] a[aria-current="page"] {
   background: var(--bn-color-primary-600);
   color: var(--bn-color-white);
@@ -240,11 +286,11 @@
   border-radius: var(--bn-radius-full);
   line-height: 1;
 }
-[data-bn="badge"][data-variant="default"] { background: var(--bn-color-gray-100); color: var(--bn-color-gray-700); }
-[data-bn="badge"][data-variant="primary"] { background: var(--bn-color-primary-100); color: var(--bn-color-primary-700); }
-[data-bn="badge"][data-variant="success"] { background: #dcfce7; color: #166534; }
-[data-bn="badge"][data-variant="warning"] { background: #fef3c7; color: #92400e; }
-[data-bn="badge"][data-variant="error"] { background: #fee2e2; color: #991b1b; }
+[data-bn="badge"][data-variant="default"] { background: var(--bn-color-surface-muted); color: var(--bn-color-text-muted); }
+[data-bn="badge"][data-variant="primary"] { background: var(--bn-color-info-bg); color: var(--bn-color-info-text); }
+[data-bn="badge"][data-variant="success"] { background: var(--bn-color-success-badge-bg); color: var(--bn-color-success-badge-text); }
+[data-bn="badge"][data-variant="warning"] { background: var(--bn-color-warning-badge-bg); color: var(--bn-color-warning-badge-text); }
+[data-bn="badge"][data-variant="error"] { background: var(--bn-color-error-badge-bg); color: var(--bn-color-error-badge-text); }
 
 /* === Card === */
 [data-bn="card"] {
@@ -272,11 +318,11 @@
   border-radius: var(--bn-radius-full);
   appearance: none;
   border: none;
-  background: var(--bn-color-gray-200);
+  background: var(--bn-color-surface-muted);
 }
-[data-bn="progress"]::-webkit-progress-bar { background: var(--bn-color-gray-200); border-radius: var(--bn-radius-full); }
-[data-bn="progress"]::-webkit-progress-value { background: var(--bn-color-primary-600); border-radius: var(--bn-radius-full); }
-[data-bn="progress"]::-moz-progress-bar { background: var(--bn-color-primary-600); border-radius: var(--bn-radius-full); }
+[data-bn="progress"]::-webkit-progress-bar { background: var(--bn-color-surface-muted); border-radius: var(--bn-radius-full); }
+[data-bn="progress"]::-webkit-progress-value { background: var(--bn-color-accent-600); border-radius: var(--bn-radius-full); }
+[data-bn="progress"]::-moz-progress-bar { background: var(--bn-color-accent-600); border-radius: var(--bn-radius-full); }
 
 /* === Spinner === */
 [data-bn="spinner"] {
@@ -287,8 +333,8 @@
 [data-bn="spinner"] > span {
   width: 1.25rem;
   height: 1.25rem;
-  border: 2px solid var(--bn-color-gray-200);
-  border-top-color: var(--bn-color-primary-600);
+  border: 2px solid var(--bn-color-border);
+  border-top-color: var(--bn-color-accent-600);
   border-radius: var(--bn-radius-full);
   animation: bn-spin 0.6s linear infinite;
 }
@@ -298,10 +344,631 @@
 
 /* === Skeleton === */
 [data-bn="skeleton"] {
-  background: linear-gradient(90deg, var(--bn-color-gray-200) 25%, var(--bn-color-gray-100) 50%, var(--bn-color-gray-200) 75%);
+  background: linear-gradient(90deg, var(--bn-color-surface-muted) 25%, var(--bn-color-border) 50%, var(--bn-color-surface-muted) 75%);
   background-size: 200% 100%;
   animation: bn-shimmer 1.5s infinite;
   border-radius: var(--bn-radius-md);
 }
 [data-bn="skeleton"][data-variant="circle"] { border-radius: var(--bn-radius-full); }
 @keyframes bn-shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+
+/* === Accordion === */
+[data-bn="accordion"] {
+  display: flex;
+  flex-direction: column;
+}
+[data-bn="accordion-item"] {
+  border: var(--bn-border-width) solid var(--bn-color-border);
+  border-radius: var(--bn-radius-lg);
+  overflow: hidden;
+}
+[data-bn="accordion-item"] + [data-bn="accordion-item"] { margin-top: calc(-1 * var(--bn-border-width)); border-top-left-radius: 0; border-top-right-radius: 0; }
+[data-bn="accordion-item"]:first-child { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
+[data-bn="accordion-item"]:only-child { border-radius: var(--bn-radius-lg); }
+[data-bn="accordion-header"] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--bn-space-component-y) var(--bn-space-component-x);
+  font-size: var(--bn-font-size-component);
+  font-weight: var(--bn-font-weight-medium);
+  background: var(--bn-color-surface);
+  cursor: pointer;
+  border: none;
+  width: 100%;
+  text-align: left;
+  color: var(--bn-color-text);
+}
+[data-bn="accordion-header"]:hover { background: var(--bn-color-surface-subtle); }
+[data-bn="accordion-header"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; position: relative; z-index: 1; }
+[data-bn="accordion-content"] {
+  padding: var(--bn-space-3) var(--bn-space-4);
+  font-size: var(--bn-font-size-sm);
+  color: var(--bn-color-text);
+  border-top: var(--bn-border-width) solid var(--bn-color-border);
+}
+
+/* === Avatar === */
+[data-bn="avatar"] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: var(--bn-radius-full);
+  overflow: hidden;
+  background: var(--bn-color-surface-muted);
+  color: var(--bn-color-accent-600);
+  font-weight: var(--bn-font-weight-medium);
+  font-size: var(--bn-font-size-sm);
+  flex-shrink: 0;
+}
+[data-bn="avatar"][data-size="sm"] { width: 2rem; height: 2rem; font-size: var(--bn-font-size-xs); }
+[data-bn="avatar"][data-size="lg"] { width: 3rem; height: 3rem; font-size: var(--bn-font-size-base); }
+[data-bn="avatar"][data-size="xl"] { width: 4rem; height: 4rem; font-size: var(--bn-font-size-lg); }
+[data-bn="avatar"][data-shape="square"] { border-radius: var(--bn-radius-lg); }
+[data-bn="avatar-img"] { width: 100%; height: 100%; object-fit: cover; }
+[data-bn="avatar-initials"] { line-height: 1; user-select: none; }
+
+/* === Breadcrumb === */
+[data-bn="breadcrumb"] { font-size: var(--bn-font-size-sm); }
+[data-bn="breadcrumb-list"] {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--bn-space-1);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+[data-bn="breadcrumb-item"] { display: inline-flex; align-items: center; gap: var(--bn-space-1); }
+[data-bn="breadcrumb-item"] a {
+  color: var(--bn-color-text-muted);
+  text-decoration: none;
+}
+[data-bn="breadcrumb-item"] a:hover { color: var(--bn-color-text); text-decoration: underline; }
+[data-bn="breadcrumb-item"] a:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; border-radius: var(--bn-radius-sm); }
+[data-bn="breadcrumb-item"][aria-current] { color: var(--bn-color-text); font-weight: var(--bn-font-weight-medium); }
+[data-bn="breadcrumb-separator"] {
+  color: var(--bn-color-text-subtle);
+  font-size: var(--bn-font-size-xs);
+  user-select: none;
+}
+
+/* === Combobox === */
+[data-bn="combobox"] { position: relative; }
+[data-bn="combobox-input"] {
+  padding: var(--bn-space-component-y) var(--bn-space-component-x);
+  font-family: var(--bn-font-family);
+  font-size: var(--bn-font-size-component);
+  color: var(--bn-color-text);
+  background: var(--bn-color-surface);
+  border: var(--bn-border-width) solid var(--bn-color-border);
+  border-radius: var(--bn-radius-md);
+  width: 100%;
+  transition: border-color var(--bn-transition-fast);
+}
+[data-bn="combobox-input"]:focus {
+  border-color: var(--bn-color-border-focus);
+  box-shadow: var(--bn-focus-ring);
+  outline: none;
+}
+[data-bn="combobox-input"][aria-invalid="true"] { border-color: var(--bn-color-error-500); }
+[data-bn="combobox-input"]:disabled { opacity: 0.5; cursor: not-allowed; background: var(--bn-color-surface-muted); }
+
+/* === Command Palette === */
+[data-bn="command-palette"] {
+  border: none;
+  padding: 0;
+  border-radius: var(--bn-radius-xl);
+  background: var(--bn-color-surface);
+  box-shadow: var(--bn-shadow-lg);
+  max-width: 32rem;
+  width: 90vi;
+  max-height: min(24rem, 80vh);
+  overflow: hidden;
+}
+[data-bn="command-palette"][open] {
+  display: flex;
+  flex-direction: column;
+}
+[data-bn="command-palette"]::backdrop {
+  background: rgb(0 0 0 / 0.4);
+  backdrop-filter: blur(4px);
+}
+[data-bn="command-header"] {
+  padding: var(--bn-space-3) var(--bn-space-4);
+  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+}
+[data-bn="command-input"] {
+  width: 100%;
+  padding: var(--bn-space-2) 0;
+  border: none;
+  background: transparent;
+  font-size: var(--bn-font-size-base);
+  color: var(--bn-color-text);
+  outline: none;
+}
+[data-bn="command-input"]::placeholder { color: var(--bn-color-text-subtle); }
+[data-bn="command-list"] {
+  overflow-y: auto;
+  flex: 1;
+  padding: var(--bn-space-2);
+}
+[data-bn="command-group"] { margin-bottom: var(--bn-space-2); }
+[data-bn="command-group-label"] {
+  padding: var(--bn-space-1) var(--bn-space-2);
+  font-size: var(--bn-font-size-xs);
+  font-weight: var(--bn-font-weight-medium);
+  color: var(--bn-color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: var(--bn-letter-spacing-wide);
+}
+[data-bn="command-item"] {
+  display: flex;
+  align-items: center;
+  gap: var(--bn-space-3);
+  padding: var(--bn-space-2) var(--bn-space-3);
+  border-radius: var(--bn-radius-md);
+  cursor: pointer;
+  color: var(--bn-color-text);
+  font-size: var(--bn-font-size-sm);
+}
+[data-bn="command-item"]:hover, [data-bn="command-item"][aria-selected="true"] { background: var(--bn-color-surface-muted); }
+[data-bn="command-item"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
+[data-bn="command-icon"] { flex-shrink: 0; width: 1rem; height: 1rem; color: var(--bn-color-text-muted); }
+[data-bn="command-label"] { flex: 1; }
+[data-bn="command-shortcut"] {
+  font-family: var(--bn-font-mono);
+  font-size: var(--bn-font-size-xs);
+  color: var(--bn-color-text-subtle);
+}
+[data-bn="command-footer"] {
+  padding: var(--bn-space-2) var(--bn-space-4);
+  border-top: var(--bn-border-width) solid var(--bn-color-border);
+  font-size: var(--bn-font-size-xs);
+  color: var(--bn-color-text-muted);
+}
+
+/* === Data Grid === */
+[data-bn="datagrid"] {
+  border: var(--bn-border-width) solid var(--bn-color-border);
+  border-radius: var(--bn-radius-lg);
+  overflow: hidden;
+}
+[data-bn="datagrid-scroll"] { overflow-x: auto; }
+[data-bn="datagrid-table"] {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--bn-font-size-sm);
+}
+[data-bn="datagrid-th"] {
+  text-align: left;
+  padding: var(--bn-space-3) var(--bn-space-4);
+  font-weight: var(--bn-font-weight-medium);
+  color: var(--bn-color-text-muted);
+  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+  background: var(--bn-color-surface-subtle);
+  position: sticky;
+  top: 0;
+  white-space: nowrap;
+  user-select: none;
+}
+[data-bn="datagrid-th"][data-sortable] { cursor: pointer; }
+[data-bn="datagrid-th"][data-sortable]:hover { color: var(--bn-color-text); }
+[data-bn="datagrid-th"][data-sortable]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
+[data-bn="datagrid-th"][data-sorted]::after {
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-left: var(--bn-space-1);
+  vertical-align: middle;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+}
+[data-bn="datagrid-th"][data-sorted="asc"]::after { border-bottom: 4px solid currentColor; }
+[data-bn="datagrid-th"][data-sorted="desc"]::after { border-top: 4px solid currentColor; }
+[data-bn="datagrid-th-select"], [data-bn="datagrid-td-select"] {
+  width: 2.5rem;
+  text-align: center;
+}
+[data-bn="datagrid-row"]:hover { background: var(--bn-color-surface-subtle); }
+[data-bn="datagrid-td"] {
+  padding: var(--bn-space-3) var(--bn-space-4);
+  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+  color: var(--bn-color-text);
+}
+[data-bn="datagrid-empty"] {
+  text-align: center;
+  color: var(--bn-color-text-muted);
+  padding: var(--bn-space-8);
+}
+[data-bn="datagrid-footer"] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--bn-space-3) var(--bn-space-4);
+  border-top: var(--bn-border-width) solid var(--bn-color-border);
+  background: var(--bn-color-surface-subtle);
+}
+[data-bn="datagrid-info"] {
+  font-size: var(--bn-font-size-xs);
+  color: var(--bn-color-text-muted);
+}
+
+/* === Dialog === */
+[data-bn="dialog"] {
+  border: none;
+  padding: 0;
+  border-radius: var(--bn-radius-xl);
+  background: var(--bn-color-surface);
+  box-shadow: var(--bn-shadow-lg);
+  max-width: 28rem;
+  width: 90vi;
+  color: var(--bn-color-text);
+}
+[data-bn="dialog"]::backdrop {
+  background: rgb(0 0 0 / 0.4);
+  backdrop-filter: blur(4px);
+}
+[data-bn="dialog"][data-size="sm"] { max-width: 20rem; }
+[data-bn="dialog"][data-size="lg"] { max-width: 40rem; }
+[data-bn="dialog-header"] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--bn-space-4) var(--bn-space-6);
+  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+}
+[data-bn="dialog-title"] {
+  font-size: var(--bn-font-size-lg);
+  font-weight: var(--bn-font-weight-semibold);
+}
+[data-bn="dialog-close"] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  background: transparent;
+  border-radius: var(--bn-radius-md);
+  cursor: pointer;
+  color: var(--bn-color-text-muted);
+  font-size: var(--bn-font-size-lg);
+}
+[data-bn="dialog-close"]:hover { background: var(--bn-color-surface-muted); color: var(--bn-color-text); }
+[data-bn="dialog-close"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
+[data-bn="dialog-body"] { padding: var(--bn-space-4) var(--bn-space-6); }
+[data-bn="dialog-footer"] {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--bn-space-2);
+  padding: var(--bn-space-4) var(--bn-space-6);
+  border-top: var(--bn-border-width) solid var(--bn-color-border);
+}
+
+/* === Drawer === */
+[data-bn="drawer"] {
+  display: none;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  z-index: var(--bn-z-modal);
+  background: var(--bn-color-surface);
+  box-shadow: var(--bn-shadow-lg);
+  flex-direction: column;
+  width: 20rem;
+}
+[data-bn="drawer"][data-position="left"] { right: auto; left: 0; }
+[data-bn="drawer"][data-open] { display: flex; }
+[data-bn="drawer"][data-size="sm"] { width: 16rem; }
+[data-bn="drawer"][data-size="lg"] { width: 28rem; }
+[data-bn="drawer-overlay"] {
+  position: fixed;
+  inset: 0;
+  z-index: calc(var(--bn-z-modal) - 1);
+  background: rgb(0 0 0 / 0.4);
+  backdrop-filter: blur(2px);
+}
+[data-bn="drawer-overlay"][hidden] { display: none; }
+[data-bn="drawer-header"] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--bn-space-4) var(--bn-space-6);
+  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+}
+[data-bn="drawer-title"] {
+  font-size: var(--bn-font-size-lg);
+  font-weight: var(--bn-font-weight-semibold);
+}
+[data-bn="drawer-close"] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  background: transparent;
+  border-radius: var(--bn-radius-md);
+  cursor: pointer;
+  color: var(--bn-color-text-muted);
+}
+[data-bn="drawer-close"]:hover { background: var(--bn-color-surface-muted); color: var(--bn-color-text); }
+[data-bn="drawer-close"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
+[data-bn="drawer-body"] { padding: var(--bn-space-4) var(--bn-space-6); flex: 1; overflow-y: auto; }
+
+/* === Dropdown Menu === */
+[data-bn="dropdown"] { position: relative; display: inline-flex; }
+[data-bn="dropdown-trigger"] {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--bn-space-2);
+  padding: var(--bn-space-component-y) var(--bn-space-component-x);
+  font-family: var(--bn-font-family);
+  font-size: var(--bn-font-size-component);
+  font-weight: var(--bn-font-weight-medium);
+  background: var(--bn-color-surface);
+  color: var(--bn-color-text);
+  border: var(--bn-border-width) solid var(--bn-color-border);
+  border-radius: var(--bn-radius-md);
+  cursor: pointer;
+}
+[data-bn="dropdown-trigger"]:hover { background: var(--bn-color-surface-muted); }
+[data-bn="dropdown-trigger"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
+[data-bn="dropdown-menu"] {
+  position: absolute;
+  z-index: var(--bn-z-dropdown);
+  min-width: 10rem;
+  padding: var(--bn-space-1);
+  background: var(--bn-color-surface);
+  border: var(--bn-border-width) solid var(--bn-color-border);
+  border-radius: var(--bn-radius-lg);
+  box-shadow: var(--bn-shadow-md);
+}
+[data-bn="dropdown-menu"]:popover-open {
+  display: flex;
+  flex-direction: column;
+}
+[data-bn="dropdown-item"] {
+  display: flex;
+  align-items: center;
+  gap: var(--bn-space-2);
+  padding: var(--bn-space-2) var(--bn-space-3);
+  font-size: var(--bn-font-size-sm);
+  color: var(--bn-color-text);
+  border: none;
+  background: transparent;
+  border-radius: var(--bn-radius-md);
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+}
+[data-bn="dropdown-item"]:hover { background: var(--bn-color-surface-muted); }
+[data-bn="dropdown-item"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
+[data-bn="dropdown-item"][aria-disabled="true"] { opacity: 0.5; cursor: not-allowed; }
+[data-bn="dropdown-icon"] { flex-shrink: 0; width: 1rem; height: 1rem; color: var(--bn-color-text-muted); }
+[data-bn="dropdown-shortcut"] {
+  margin-left: auto;
+  font-family: var(--bn-font-mono);
+  font-size: var(--bn-font-size-xs);
+  color: var(--bn-color-text-subtle);
+}
+[data-bn="dropdown-separator"] {
+  height: var(--bn-border-width);
+  background: var(--bn-color-border);
+  margin: var(--bn-space-1) 0;
+}
+
+/* === Multiselect === */
+[data-bn="multiselect"] { position: relative; }
+[data-bn="multiselect"] select[hidden] { display: none; }
+[data-bn="multiselect"][data-disabled] { opacity: 0.5; pointer-events: none; }
+[data-bn="multiselect-container"] {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--bn-space-1);
+  padding: var(--bn-space-1) var(--bn-space-2);
+  min-height: 2.5rem;
+  background: var(--bn-color-surface);
+  border: var(--bn-border-width) solid var(--bn-color-border);
+  border-radius: var(--bn-radius-md);
+  cursor: text;
+  transition: border-color var(--bn-transition-fast);
+}
+[data-bn="multiselect-container"]:focus-within {
+  border-color: var(--bn-color-border-focus);
+  box-shadow: var(--bn-focus-ring);
+}
+[data-bn="multiselect-tags"] {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--bn-space-1);
+}
+[data-bn="tag"] {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--bn-space-1);
+  padding: var(--bn-space-1) var(--bn-space-2);
+  font-size: var(--bn-font-size-xs);
+  font-weight: var(--bn-font-weight-medium);
+  background: var(--bn-color-surface-muted);
+  border-radius: var(--bn-radius-full);
+  color: var(--bn-color-text);
+  line-height: 1;
+}
+[data-bn="tag-remove"] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  border: none;
+  background: transparent;
+  border-radius: var(--bn-radius-full);
+  cursor: pointer;
+  color: var(--bn-color-text-muted);
+  font-size: var(--bn-font-size-xs);
+  line-height: 1;
+}
+[data-bn="tag-remove"]:hover { background: var(--bn-color-border); color: var(--bn-color-text); }
+[data-bn="tag-remove"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
+[data-bn="multiselect-search"] {
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: var(--bn-font-size-component);
+  color: var(--bn-color-text);
+  flex: 1;
+  min-width: 4rem;
+  padding: var(--bn-space-1) 0;
+}
+
+/* === Tabs === */
+[data-bn="tabs"] { display: flex; flex-direction: column; }
+[data-bn="tab-list"] {
+  display: flex;
+  gap: 0;
+  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+}
+[data-bn="tab"] {
+  padding: var(--bn-space-2) var(--bn-space-4);
+  font-size: var(--bn-font-size-sm);
+  font-weight: var(--bn-font-weight-medium);
+  color: var(--bn-color-text-muted);
+  background: transparent;
+  border: none;
+  border-bottom: var(--bn-border-width-thick) solid transparent;
+  cursor: pointer;
+  margin-bottom: calc(-1 * var(--bn-border-width));
+  transition: color var(--bn-transition-fast), border-color var(--bn-transition-fast);
+}
+[data-bn="tab"]:hover { color: var(--bn-color-text); }
+[data-bn="tab"][aria-selected="true"] {
+  color: var(--bn-color-text);
+  border-bottom-color: var(--bn-color-accent-600);
+}
+[data-bn="tab"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; position: relative; z-index: 1; }
+[data-bn="tab"]:disabled { opacity: 0.5; cursor: not-allowed; }
+[data-bn="tab-panel"] { padding: var(--bn-space-4) 0; }
+[data-bn="tab-panel"][hidden] { display: none; }
+/* Tabs: pills variant */
+[data-bn="tabs"][data-variant="pills"] [data-bn="tab-list"] { border-bottom: none; gap: var(--bn-space-1); }
+[data-bn="tabs"][data-variant="pills"] [data-bn="tab"] {
+  border-bottom: none;
+  border-radius: var(--bn-radius-md);
+  margin-bottom: 0;
+}
+[data-bn="tabs"][data-variant="pills"] [data-bn="tab"][aria-selected="true"] {
+  background: var(--bn-color-surface-muted);
+  color: var(--bn-color-text);
+}
+
+/* === Toast (individual item) === */
+[data-bn="toast"] {
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--bn-space-2);
+  padding: var(--bn-space-3) var(--bn-space-4);
+  background: var(--bn-color-surface);
+  border: var(--bn-border-width) solid var(--bn-color-border);
+  border-radius: var(--bn-radius-lg);
+  box-shadow: var(--bn-shadow-md);
+  font-size: var(--bn-font-size-sm);
+  color: var(--bn-color-text);
+  max-width: 24rem;
+}
+[data-bn="toast"][data-variant="success"] { border-color: var(--bn-color-success-border); }
+[data-bn="toast"][data-variant="error"] { border-color: var(--bn-color-error-border); }
+[data-bn="toast"][data-variant="warning"] { border-color: var(--bn-color-warning-border); }
+[data-bn="toast"][data-variant="info"] { border-color: var(--bn-color-info-border); }
+
+/* === Tooltip === */
+[data-bn="tooltip"] {
+  position: absolute;
+  z-index: var(--bn-z-dropdown);
+  max-width: 20rem;
+  padding: var(--bn-space-2) var(--bn-space-3);
+  background: var(--bn-color-surface-inverse);
+  color: var(--bn-color-text-inverse);
+  font-size: var(--bn-font-size-xs);
+  border-radius: var(--bn-radius-md);
+  pointer-events: none;
+  white-space: normal;
+  line-height: var(--bn-line-height-normal);
+}
+[data-bn="tooltip-trigger"] { cursor: default; }
+
+/* === Tree === */
+[data-bn="tree"] {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: var(--bn-font-size-sm);
+}
+[data-bn="tree-item"] { display: flex; flex-direction: column; }
+[data-bn="tree-item-content"] {
+  display: flex;
+  align-items: center;
+  gap: var(--bn-space-1);
+  padding: var(--bn-space-1) var(--bn-space-2);
+  border-radius: var(--bn-radius-md);
+  cursor: pointer;
+  color: var(--bn-color-text);
+}
+[data-bn="tree-item-content"]:hover { background: var(--bn-color-surface-subtle); }
+[data-bn="tree-item-content"][data-selected] { background: var(--bn-color-primary-50); color: var(--bn-color-primary-700); }
+[data-bn="tree-item-content"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; position: relative; z-index: 1; }
+[data-bn="tree-indent"] { flex-shrink: 0; }
+[data-bn="tree-toggle"] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--bn-color-text-muted);
+  border-radius: var(--bn-radius-sm);
+  flex-shrink: 0;
+}
+[data-bn="tree-toggle"]:hover { background: var(--bn-color-surface-muted); }
+[data-bn="tree-toggle"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
+[data-bn="tree-icon"] { flex-shrink: 0; width: 1rem; height: 1rem; color: var(--bn-color-text-muted); }
+[data-bn="tree-label"] { flex: 1; }
+[data-bn="tree-children"] {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+/* Tree item indentation via data-level */
+[data-bn="tree-item"][data-level="1"] [data-bn="tree-item-content"] { padding-left: var(--bn-space-6); }
+[data-bn="tree-item"][data-level="2"] [data-bn="tree-item-content"] { padding-left: var(--bn-space-10); }
+[data-bn="tree-item"][data-level="3"] [data-bn="tree-item-content"] { padding-left: var(--bn-space-16); }
+/* Tree Grid */
+[data-bn="treegrid"] { width: 100%; border-collapse: collapse; font-size: var(--bn-font-size-sm); }
+[data-bn="treegrid-row"] { cursor: pointer; }
+[data-bn="treegrid-row"]:hover { background: var(--bn-color-surface-subtle); }
+[data-bn="treegrid-row"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
+
+/* === Virtualizer === */
+[data-bn="virtualizer"] {
+  overflow: auto;
+  border: var(--bn-border-width) solid var(--bn-color-border);
+  border-radius: var(--bn-radius-lg);
+}
+[data-bn="virtual-window"] { position: relative; }
+[data-bn="virtual-item"] {
+  padding: var(--bn-space-3) var(--bn-space-4);
+  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+  font-size: var(--bn-font-size-sm);
+}
+[data-bn="virtual-item"]:last-child { border-bottom: none; }
+
+} /* end @layer components */

--- a/packages/components/src/components.css
+++ b/packages/components/src/components.css
@@ -241,6 +241,7 @@
   border-bottom: 1px solid var(--bn-color-border);
   color: var(--bn-color-text);
 }
+[data-bn="table"] tbody tr:nth-child(even) { background: rgb(255 255 255 / 0.02); }
 [data-bn="table"] tbody tr:hover { background: var(--bn-color-surface-subtle); }
 [data-bn="table-empty"] {
   text-align: center;
@@ -286,7 +287,7 @@
   border-radius: var(--bn-radius-full);
   line-height: 1;
 }
-[data-bn="badge"][data-variant="default"] { background: var(--bn-color-surface-muted); color: var(--bn-color-text-muted); }
+[data-bn="badge"][data-variant="default"] { background: var(--bn-color-border); color: var(--bn-color-text); }
 [data-bn="badge"][data-variant="primary"] { background: var(--bn-color-info-bg); color: var(--bn-color-info-text); }
 [data-bn="badge"][data-variant="success"] { background: var(--bn-color-success-badge-bg); color: var(--bn-color-success-badge-text); }
 [data-bn="badge"][data-variant="warning"] { background: var(--bn-color-warning-badge-bg); color: var(--bn-color-warning-badge-text); }
@@ -368,7 +369,7 @@
 [data-bn="accordion-header"] {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: var(--bn-space-2);
   padding: var(--bn-space-component-y) var(--bn-space-component-x);
   font-size: var(--bn-font-size-component);
   font-weight: var(--bn-font-weight-medium);
@@ -378,7 +379,17 @@
   width: 100%;
   text-align: left;
   color: var(--bn-color-text);
+  list-style: none;
 }
+[data-bn="accordion-header"]::before {
+  content: '\25B8';
+  font-size: 0.75em;
+  color: var(--bn-color-accent-600);
+  transition: rotate var(--bn-transition-fast);
+  flex-shrink: 0;
+}
+[data-bn="accordion-header"]::-webkit-details-marker { display: none; }
+[data-bn="accordion-item"][open] > [data-bn="accordion-header"]::before { rotate: 90deg; }
 [data-bn="accordion-header"]:hover { background: var(--bn-color-surface-subtle); }
 [data-bn="accordion-header"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; position: relative; z-index: 1; }
 [data-bn="accordion-content"] {
@@ -397,9 +408,9 @@
   height: 2.5rem;
   border-radius: var(--bn-radius-full);
   overflow: hidden;
-  background: var(--bn-color-surface-muted);
-  color: var(--bn-color-accent-600);
-  font-weight: var(--bn-font-weight-medium);
+  background: var(--bn-color-border-strong);
+  color: var(--bn-color-text);
+  font-weight: var(--bn-font-weight-semibold);
   font-size: var(--bn-font-size-sm);
   flex-shrink: 0;
 }
@@ -423,12 +434,12 @@
 }
 [data-bn="breadcrumb-item"] { display: inline-flex; align-items: center; gap: var(--bn-space-1); }
 [data-bn="breadcrumb-item"] a {
-  color: var(--bn-color-text-muted);
+  color: var(--bn-color-text-link);
   text-decoration: none;
 }
 [data-bn="breadcrumb-item"] a:hover { color: var(--bn-color-text); text-decoration: underline; }
 [data-bn="breadcrumb-item"] a:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; border-radius: var(--bn-radius-sm); }
-[data-bn="breadcrumb-item"][aria-current] { color: var(--bn-color-text); font-weight: var(--bn-font-weight-medium); }
+[data-bn="breadcrumb-item"][aria-current] { color: var(--bn-color-text); font-weight: var(--bn-font-weight-semibold); }
 [data-bn="breadcrumb-separator"] {
   color: var(--bn-color-text-subtle);
   font-size: var(--bn-font-size-xs);
@@ -572,6 +583,35 @@
 [data-bn="datagrid-th-select"], [data-bn="datagrid-td-select"] {
   width: 2.5rem;
   text-align: center;
+}
+[data-bn="datagrid"] input[type="checkbox"] {
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  background: var(--bn-color-surface);
+  border: var(--bn-border-width) solid var(--bn-color-border-strong);
+  border-radius: var(--bn-radius-sm);
+  cursor: pointer;
+  position: relative;
+}
+[data-bn="datagrid"] input[type="checkbox"]:checked {
+  background: var(--bn-color-accent-600);
+  border-color: var(--bn-color-accent-600);
+}
+[data-bn="datagrid"] input[type="checkbox"]:checked::after {
+  content: '';
+  position: absolute;
+  top: 1px;
+  left: 3px;
+  width: 4px;
+  height: 7px;
+  border: solid var(--bn-color-white);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+[data-bn="datagrid"] input[type="checkbox"]:focus-visible {
+  box-shadow: var(--bn-focus-ring);
+  outline: none;
 }
 [data-bn="datagrid-row"]:hover { background: var(--bn-color-surface-subtle); }
 [data-bn="datagrid-td"] {
@@ -842,7 +882,7 @@
   color: var(--bn-color-text-muted);
   background: transparent;
   border: none;
-  border-bottom: var(--bn-border-width-thick) solid transparent;
+  border-bottom: 3px solid transparent;
   cursor: pointer;
   margin-bottom: calc(-1 * var(--bn-border-width));
   transition: color var(--bn-transition-fast), border-color var(--bn-transition-fast);

--- a/packages/components/src/index.css
+++ b/packages/components/src/index.css
@@ -1,0 +1,7 @@
+@import './layers.css';
+@import './reset.css';
+@import './tokens.css';
+@import './theme.css';
+@import './layout.css';
+@import './components.css';
+@import './states.css';

--- a/packages/components/src/layers.css
+++ b/packages/components/src/layers.css
@@ -1,0 +1,1 @@
+@layer reset, tokens, layout, components, states;

--- a/packages/components/src/layout.css
+++ b/packages/components/src/layout.css
@@ -1,0 +1,127 @@
+@layer layout {
+  /* Page Shell */
+  [data-bn="page"] {
+    display: flex;
+    flex-direction: column;
+    min-height: 100dvh;
+  }
+
+  /* Top Bar */
+  [data-bn="topbar"] {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--bn-space-3) var(--bn-space-8);
+    background: var(--bn-color-surface);
+    border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+  }
+  [data-bn="topbar"] a[data-bn="brand"] {
+    font-size: var(--bn-font-size-lg);
+    font-weight: var(--bn-font-weight-semibold);
+    color: var(--bn-color-text);
+    text-decoration: none;
+  }
+  [data-bn="topbar"] nav {
+    display: flex;
+    gap: var(--bn-space-4);
+  }
+  [data-bn="topbar"] nav a {
+    font-size: var(--bn-font-size-sm);
+    color: var(--bn-color-text-muted);
+    text-decoration: none;
+    padding: var(--bn-space-1) var(--bn-space-2);
+    border-radius: var(--bn-radius-md);
+  }
+  [data-bn="topbar"] nav a:hover {
+    color: var(--bn-color-text);
+    background: var(--bn-color-surface-muted);
+  }
+  [data-bn="topbar"] nav a[aria-current="page"] {
+    color: var(--bn-color-text);
+    background: var(--bn-color-surface-muted);
+    font-weight: var(--bn-font-weight-medium);
+  }
+
+  /* Sidebar */
+  [data-bn="sidebar"] {
+    width: 240px;
+    background: var(--bn-color-surface);
+    border-right: var(--bn-border-width) solid var(--bn-color-border);
+    padding: var(--bn-space-4);
+    flex-shrink: 0;
+  }
+  [data-bn="sidebar"] h2 {
+    font-size: var(--bn-font-size-lg);
+    margin-bottom: var(--bn-space-6);
+  }
+  [data-bn="sidebar"] a {
+    display: block;
+    padding: var(--bn-space-2) var(--bn-space-3);
+    border-radius: var(--bn-radius-md);
+    color: var(--bn-color-text);
+    text-decoration: none;
+    font-size: var(--bn-font-size-sm);
+    margin-bottom: var(--bn-space-1);
+  }
+  [data-bn="sidebar"] a:hover { background: var(--bn-color-surface-muted); }
+  [data-bn="sidebar"] a[aria-current="page"] {
+    background: var(--bn-color-primary-50);
+    color: var(--bn-color-primary-700);
+    font-weight: var(--bn-font-weight-medium);
+  }
+
+  /* Content Area */
+  [data-bn="content"] {
+    flex: 1;
+    padding: var(--bn-space-8);
+    max-inline-size: var(--bn-size-content-max);
+    width: 100%;
+    margin-inline: auto;
+    container-type: inline-size;
+    container-name: page;
+  }
+  [data-bn="content"] h1 {
+    font-size: var(--bn-font-size-2xl);
+    margin-bottom: var(--bn-space-6);
+  }
+
+  /* Footer */
+  [data-bn="footer"] {
+    padding: var(--bn-space-4) var(--bn-space-8);
+    text-align: center;
+    font-size: var(--bn-font-size-xs);
+    color: var(--bn-color-text-muted);
+    border-top: var(--bn-border-width) solid var(--bn-color-border);
+    background: var(--bn-color-surface);
+  }
+
+  /* Stats Grid */
+  [data-bn="stats-grid"] {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--bn-space-4);
+    margin-bottom: var(--bn-space-6);
+    container-type: inline-size;
+    container-name: stats;
+  }
+
+  /* Form Grid */
+  [data-bn="form-grid"] {
+    display: grid;
+    gap: var(--bn-space-4);
+    max-width: 480px;
+  }
+
+  /* Form Actions */
+  [data-bn="form-actions"] {
+    display: flex;
+    gap: var(--bn-space-2);
+    margin-top: var(--bn-space-4);
+  }
+
+  /* Center Card (login/register) */
+  [data-bn="center-card"] {
+    max-width: 420px;
+    margin: var(--bn-space-8) auto;
+  }
+}

--- a/packages/components/src/reset.css
+++ b/packages/components/src/reset.css
@@ -1,0 +1,40 @@
+@layer reset {
+  *, *::before, *::after { box-sizing: border-box; margin: 0; }
+  html { hanging-punctuation: first last; -webkit-text-size-adjust: 100%; }
+  body { min-height: 100dvh; line-height: var(--bn-line-height-normal); font-family: var(--bn-font-family); color: var(--bn-color-text); background: var(--bn-color-surface); -webkit-font-smoothing: antialiased; }
+  img, picture, video, canvas, svg { display: block; max-width: 100%; }
+  input, button, textarea, select { font: inherit; }
+  p, h1, h2, h3, h4, h5, h6 { overflow-wrap: break-word; }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .skip-link {
+    position: absolute;
+    top: -100%;
+    left: var(--bn-space-4);
+    z-index: 9999;
+    padding: var(--bn-space-2) var(--bn-space-4);
+    background: var(--bn-color-surface);
+    color: var(--bn-color-text);
+    border: var(--bn-border-width) solid var(--bn-color-border);
+    border-radius: var(--bn-radius-md);
+    font-size: var(--bn-font-size-sm);
+    font-weight: var(--bn-font-weight-medium);
+    text-decoration: none;
+  }
+  .skip-link:focus {
+    top: var(--bn-space-4);
+    outline: none;
+    box-shadow: var(--bn-focus-ring);
+  }
+}

--- a/packages/components/src/states.css
+++ b/packages/components/src/states.css
@@ -1,0 +1,45 @@
+@layer states {
+  /* Container Queries — Stats Grid */
+  @container stats (max-width: 36rem) {
+    [data-bn="stats-grid"] {
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    }
+  }
+  @container stats (max-width: 20rem) {
+    [data-bn="stats-grid"] {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* Container Queries — Page Content */
+  @container page (max-width: 40rem) {
+    [data-bn="form-grid"] { max-width: 100%; }
+  }
+
+  /* Reduced Motion */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
+
+  /* Print */
+  @media print {
+    [data-bn="topbar"],
+    [data-bn="sidebar"],
+    [data-bn="footer"],
+    .skip-link { display: none; }
+
+    [data-bn="content"] {
+      max-inline-size: 100%;
+      padding: 0;
+    }
+
+    [data-bn="page"] {
+      min-height: auto;
+    }
+  }
+}

--- a/packages/components/src/theme.css
+++ b/packages/components/src/theme.css
@@ -1,9 +1,53 @@
-/* BaseNative Theme — Dark Mode */
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
+@layer tokens {
+  /* Dark Mode — automatic via prefers-color-scheme */
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bn-color-surface: var(--bn-color-gray-950);
+      --bn-color-surface-subtle: var(--bn-color-gray-900);
+      --bn-color-surface-muted: var(--bn-color-gray-800);
+      --bn-color-surface-raised: var(--bn-color-gray-900);
+      --bn-color-surface-inset: var(--bn-color-gray-950);
+      --bn-color-surface-inverse: var(--bn-color-gray-50);
+
+      --bn-color-text: var(--bn-color-gray-50);
+      --bn-color-text-muted: var(--bn-color-gray-400);
+      --bn-color-text-subtle: var(--bn-color-gray-500);
+      --bn-color-text-inverse: var(--bn-color-gray-900);
+      --bn-color-text-link: var(--bn-color-primary-400);
+
+      --bn-color-border: var(--bn-color-gray-800);
+      --bn-color-border-strong: var(--bn-color-gray-700);
+
+      /* Alert/Badge semantic backgrounds — dark */
+      --bn-color-info-bg: rgb(37 99 235 / 0.12);
+      --bn-color-info-border: rgb(37 99 235 / 0.25);
+      --bn-color-info-text: var(--bn-color-primary-300);
+      --bn-color-success-bg: rgb(22 163 74 / 0.12);
+      --bn-color-success-border: rgb(22 163 74 / 0.25);
+      --bn-color-success-text: #86efac;
+      --bn-color-warning-bg: rgb(217 119 6 / 0.12);
+      --bn-color-warning-border: rgb(217 119 6 / 0.25);
+      --bn-color-warning-text: #fcd34d;
+      --bn-color-error-bg: rgb(220 38 38 / 0.12);
+      --bn-color-error-border: rgb(220 38 38 / 0.25);
+      --bn-color-error-text: #fca5a5;
+
+      --bn-color-success-badge-bg: rgb(22 163 74 / 0.15);
+      --bn-color-success-badge-text: #86efac;
+      --bn-color-warning-badge-bg: rgb(217 119 6 / 0.15);
+      --bn-color-warning-badge-text: #fcd34d;
+      --bn-color-error-badge-bg: rgb(220 38 38 / 0.15);
+      --bn-color-error-badge-text: #fca5a5;
+    }
+  }
+
+  /* Explicit dark theme override */
+  [data-theme="dark"] {
     --bn-color-surface: var(--bn-color-gray-950);
     --bn-color-surface-subtle: var(--bn-color-gray-900);
     --bn-color-surface-muted: var(--bn-color-gray-800);
+    --bn-color-surface-raised: var(--bn-color-gray-900);
+    --bn-color-surface-inset: var(--bn-color-gray-950);
     --bn-color-surface-inverse: var(--bn-color-gray-50);
 
     --bn-color-text: var(--bn-color-gray-50);
@@ -14,22 +58,26 @@
 
     --bn-color-border: var(--bn-color-gray-800);
     --bn-color-border-strong: var(--bn-color-gray-700);
+
+    /* Alert/Badge semantic backgrounds — dark */
+    --bn-color-info-bg: rgb(37 99 235 / 0.12);
+    --bn-color-info-border: rgb(37 99 235 / 0.25);
+    --bn-color-info-text: var(--bn-color-primary-300);
+    --bn-color-success-bg: rgb(22 163 74 / 0.12);
+    --bn-color-success-border: rgb(22 163 74 / 0.25);
+    --bn-color-success-text: #86efac;
+    --bn-color-warning-bg: rgb(217 119 6 / 0.12);
+    --bn-color-warning-border: rgb(217 119 6 / 0.25);
+    --bn-color-warning-text: #fcd34d;
+    --bn-color-error-bg: rgb(220 38 38 / 0.12);
+    --bn-color-error-border: rgb(220 38 38 / 0.25);
+    --bn-color-error-text: #fca5a5;
+
+    --bn-color-success-badge-bg: rgb(22 163 74 / 0.15);
+    --bn-color-success-badge-text: #86efac;
+    --bn-color-warning-badge-bg: rgb(217 119 6 / 0.15);
+    --bn-color-warning-badge-text: #fcd34d;
+    --bn-color-error-badge-bg: rgb(220 38 38 / 0.15);
+    --bn-color-error-badge-text: #fca5a5;
   }
-}
-
-/* Explicit dark theme override */
-[data-theme="dark"] {
-  --bn-color-surface: var(--bn-color-gray-950);
-  --bn-color-surface-subtle: var(--bn-color-gray-900);
-  --bn-color-surface-muted: var(--bn-color-gray-800);
-  --bn-color-surface-inverse: var(--bn-color-gray-50);
-
-  --bn-color-text: var(--bn-color-gray-50);
-  --bn-color-text-muted: var(--bn-color-gray-400);
-  --bn-color-text-subtle: var(--bn-color-gray-500);
-  --bn-color-text-inverse: var(--bn-color-gray-900);
-  --bn-color-text-link: var(--bn-color-primary-400);
-
-  --bn-color-border: var(--bn-color-gray-800);
-  --bn-color-border-strong: var(--bn-color-gray-700);
 }

--- a/packages/components/src/tokens.css
+++ b/packages/components/src/tokens.css
@@ -1,134 +1,186 @@
-/* BaseNative Design Tokens */
-:root {
-  /* Colors — Neutral */
-  --bn-color-white: #ffffff;
-  --bn-color-black: #09090b;
-  --bn-color-gray-50: #fafafa;
-  --bn-color-gray-100: #f4f4f5;
-  --bn-color-gray-200: #e4e4e7;
-  --bn-color-gray-300: #d4d4d8;
-  --bn-color-gray-400: #a1a1aa;
-  --bn-color-gray-500: #71717a;
-  --bn-color-gray-600: #52525b;
-  --bn-color-gray-700: #3f3f46;
-  --bn-color-gray-800: #27272a;
-  --bn-color-gray-900: #18181b;
-  --bn-color-gray-950: #09090b;
+@layer tokens {
+  :root {
+    /* Colors — Neutral */
+    --bn-color-white: #ffffff;
+    --bn-color-black: #09090b;
+    --bn-color-gray-50: #fafafa;
+    --bn-color-gray-100: #f4f4f5;
+    --bn-color-gray-200: #e4e4e7;
+    --bn-color-gray-300: #d4d4d8;
+    --bn-color-gray-400: #a1a1aa;
+    --bn-color-gray-500: #71717a;
+    --bn-color-gray-600: #52525b;
+    --bn-color-gray-700: #3f3f46;
+    --bn-color-gray-800: #27272a;
+    --bn-color-gray-900: #18181b;
+    --bn-color-gray-950: #09090b;
 
-  /* Colors — Primary */
-  --bn-color-primary-50: #eff6ff;
-  --bn-color-primary-100: #dbeafe;
-  --bn-color-primary-200: #bfdbfe;
-  --bn-color-primary-300: #93c5fd;
-  --bn-color-primary-400: #60a5fa;
-  --bn-color-primary-500: #3b82f6;
-  --bn-color-primary-600: #2563eb;
-  --bn-color-primary-700: #1d4ed8;
-  --bn-color-primary-800: #1e40af;
-  --bn-color-primary-900: #1e3a8a;
+    /* Colors — Primary */
+    --bn-color-primary-50: #eff6ff;
+    --bn-color-primary-100: #dbeafe;
+    --bn-color-primary-200: #bfdbfe;
+    --bn-color-primary-300: #93c5fd;
+    --bn-color-primary-400: #60a5fa;
+    --bn-color-primary-500: #3b82f6;
+    --bn-color-primary-600: #2563eb;
+    --bn-color-primary-700: #1d4ed8;
+    --bn-color-primary-800: #1e40af;
+    --bn-color-primary-900: #1e3a8a;
 
-  /* Colors — Semantic */
-  --bn-color-success-500: #22c55e;
-  --bn-color-success-600: #16a34a;
-  --bn-color-warning-500: #f59e0b;
-  --bn-color-warning-600: #d97706;
-  --bn-color-error-500: #ef4444;
-  --bn-color-error-600: #dc2626;
-  --bn-color-info-500: #3b82f6;
-  --bn-color-info-600: #2563eb;
+    /* Colors — Accent (themeable identity color) */
+    --bn-color-accent-50: var(--bn-color-primary-50);
+    --bn-color-accent-100: var(--bn-color-primary-100);
+    --bn-color-accent-200: var(--bn-color-primary-200);
+    --bn-color-accent-300: var(--bn-color-primary-300);
+    --bn-color-accent-400: var(--bn-color-primary-400);
+    --bn-color-accent-500: var(--bn-color-primary-500);
+    --bn-color-accent-600: var(--bn-color-primary-600);
+    --bn-color-accent-700: var(--bn-color-primary-700);
+    --bn-color-accent-800: var(--bn-color-primary-800);
+    --bn-color-accent-900: var(--bn-color-primary-900);
 
-  /* Semantic Surface */
-  --bn-color-surface: var(--bn-color-white);
-  --bn-color-surface-subtle: var(--bn-color-gray-50);
-  --bn-color-surface-muted: var(--bn-color-gray-100);
-  --bn-color-surface-inverse: var(--bn-color-gray-900);
+    /* Colors — Semantic Status */
+    --bn-color-success-500: #22c55e;
+    --bn-color-success-600: #16a34a;
+    --bn-color-warning-500: #f59e0b;
+    --bn-color-warning-600: #d97706;
+    --bn-color-error-500: #ef4444;
+    --bn-color-error-600: #dc2626;
+    --bn-color-info-500: #3b82f6;
+    --bn-color-info-600: #2563eb;
 
-  /* Semantic Text */
-  --bn-color-text: var(--bn-color-gray-900);
-  --bn-color-text-muted: var(--bn-color-gray-500);
-  --bn-color-text-subtle: var(--bn-color-gray-400);
-  --bn-color-text-inverse: var(--bn-color-white);
-  --bn-color-text-link: var(--bn-color-primary-600);
+    /* Colors — Semantic Alert/Badge Backgrounds */
+    --bn-color-info-bg: var(--bn-color-primary-50);
+    --bn-color-info-border: var(--bn-color-primary-200);
+    --bn-color-info-text: var(--bn-color-primary-800);
+    --bn-color-success-bg: #f0fdf4;
+    --bn-color-success-border: #bbf7d0;
+    --bn-color-success-text: #166534;
+    --bn-color-warning-bg: #fffbeb;
+    --bn-color-warning-border: #fde68a;
+    --bn-color-warning-text: #92400e;
+    --bn-color-error-bg: #fef2f2;
+    --bn-color-error-border: #fecaca;
+    --bn-color-error-text: #991b1b;
 
-  /* Semantic Border */
-  --bn-color-border: var(--bn-color-gray-200);
-  --bn-color-border-strong: var(--bn-color-gray-300);
-  --bn-color-border-focus: var(--bn-color-primary-500);
+    /* Colors — Semantic Badge Backgrounds (lighter variant) */
+    --bn-color-success-badge-bg: #dcfce7;
+    --bn-color-success-badge-text: #166534;
+    --bn-color-warning-badge-bg: #fef3c7;
+    --bn-color-warning-badge-text: #92400e;
+    --bn-color-error-badge-bg: #fee2e2;
+    --bn-color-error-badge-text: #991b1b;
 
-  /* Typography */
-  --bn-font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
-  --bn-font-mono: ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
-  --bn-font-size-xs: 0.75rem;
-  --bn-font-size-sm: 0.875rem;
-  --bn-font-size-base: 1rem;
-  --bn-font-size-lg: 1.125rem;
-  --bn-font-size-xl: 1.25rem;
-  --bn-font-size-2xl: 1.5rem;
-  --bn-font-size-3xl: 1.875rem;
-  --bn-font-weight-normal: 400;
-  --bn-font-weight-medium: 500;
-  --bn-font-weight-semibold: 600;
-  --bn-font-weight-bold: 700;
-  --bn-line-height-tight: 1.25;
-  --bn-line-height-normal: 1.5;
-  --bn-line-height-relaxed: 1.75;
+    /* Semantic Surface */
+    --bn-color-surface: var(--bn-color-white);
+    --bn-color-surface-subtle: var(--bn-color-gray-50);
+    --bn-color-surface-muted: var(--bn-color-gray-100);
+    --bn-color-surface-raised: var(--bn-color-white);
+    --bn-color-surface-inset: var(--bn-color-gray-50);
+    --bn-color-surface-inverse: var(--bn-color-gray-900);
 
-  /* Spacing */
-  --bn-space-0: 0;
-  --bn-space-1: 0.25rem;
-  --bn-space-2: 0.5rem;
-  --bn-space-3: 0.75rem;
-  --bn-space-4: 1rem;
-  --bn-space-5: 1.25rem;
-  --bn-space-6: 1.5rem;
-  --bn-space-8: 2rem;
-  --bn-space-10: 2.5rem;
-  --bn-space-12: 3rem;
-  --bn-space-16: 4rem;
+    /* Semantic Text */
+    --bn-color-text: var(--bn-color-gray-900);
+    --bn-color-text-muted: var(--bn-color-gray-500);
+    --bn-color-text-subtle: var(--bn-color-gray-400);
+    --bn-color-text-inverse: var(--bn-color-white);
+    --bn-color-text-link: var(--bn-color-primary-600);
 
-  /* Border Radius */
-  --bn-radius-sm: 0.25rem;
-  --bn-radius-md: 0.375rem;
-  --bn-radius-lg: 0.5rem;
-  --bn-radius-xl: 0.75rem;
-  --bn-radius-full: 9999px;
+    /* Semantic Border */
+    --bn-color-border: var(--bn-color-gray-200);
+    --bn-color-border-strong: var(--bn-color-gray-300);
+    --bn-color-border-focus: var(--bn-color-primary-500);
 
-  /* Shadows */
-  --bn-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --bn-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --bn-shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+    /* Typography */
+    --bn-font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+    --bn-font-mono: ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+    --bn-font-size-xs: 0.75rem;
+    --bn-font-size-sm: 0.875rem;
+    --bn-font-size-base: 1rem;
+    --bn-font-size-lg: 1.125rem;
+    --bn-font-size-xl: 1.25rem;
+    --bn-font-size-2xl: 1.5rem;
+    --bn-font-size-3xl: 1.875rem;
+    --bn-font-size-4xl: 2.25rem;
+    --bn-font-weight-normal: 400;
+    --bn-font-weight-medium: 500;
+    --bn-font-weight-semibold: 600;
+    --bn-font-weight-bold: 700;
+    --bn-line-height-tight: 1.25;
+    --bn-line-height-normal: 1.5;
+    --bn-line-height-relaxed: 1.75;
+    --bn-letter-spacing-tight: -0.025em;
+    --bn-letter-spacing-normal: 0;
+    --bn-letter-spacing-wide: 0.025em;
 
-  /* Transitions */
-  --bn-transition-fast: 150ms ease;
-  --bn-transition-normal: 200ms ease;
-  --bn-transition-slow: 300ms ease;
+    /* Spacing */
+    --bn-space-0: 0;
+    --bn-space-1: 0.25rem;
+    --bn-space-2: 0.5rem;
+    --bn-space-3: 0.75rem;
+    --bn-space-4: 1rem;
+    --bn-space-5: 1.25rem;
+    --bn-space-6: 1.5rem;
+    --bn-space-8: 2rem;
+    --bn-space-10: 2.5rem;
+    --bn-space-12: 3rem;
+    --bn-space-16: 4rem;
 
-  /* Focus Ring */
-  --bn-focus-ring: 0 0 0 2px var(--bn-color-surface), 0 0 0 4px var(--bn-color-border-focus);
+    /* Sizing */
+    --bn-size-content-max: 64rem;
+    --bn-size-text-max: 65ch;
 
-  /* Z-index */
-  --bn-z-dropdown: 1000;
-  --bn-z-modal: 1100;
-  --bn-z-toast: 1200;
-}
+    /* Border */
+    --bn-border-width: 1px;
+    --bn-border-width-thick: 2px;
+    --bn-radius-sm: 0.25rem;
+    --bn-radius-md: 0.375rem;
+    --bn-radius-lg: 0.5rem;
+    --bn-radius-xl: 0.75rem;
+    --bn-radius-full: 9999px;
 
-/* Density: Compact */
-[data-density="compact"] {
-  --bn-space-component-x: var(--bn-space-2);
-  --bn-space-component-y: var(--bn-space-1);
-  --bn-font-size-component: var(--bn-font-size-sm);
-}
+    /* Shadows */
+    --bn-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    --bn-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+    --bn-shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
 
-/* Density: Default */
-:root, [data-density="default"] {
-  --bn-space-component-x: var(--bn-space-3);
-  --bn-space-component-y: var(--bn-space-2);
-  --bn-font-size-component: var(--bn-font-size-base);
-}
+    /* Transitions */
+    --bn-transition-fast: 150ms ease;
+    --bn-transition-normal: 200ms ease;
+    --bn-transition-slow: 300ms ease;
 
-/* Density: Spacious */
-[data-density="spacious"] {
-  --bn-space-component-x: var(--bn-space-4);
-  --bn-space-component-y: var(--bn-space-3);
-  --bn-font-size-component: var(--bn-font-size-base);
+    /* Easing */
+    --bn-ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+    --bn-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+    --bn-ease-out-back: cubic-bezier(0.34, 1.3, 0.64, 1);
+
+    /* Focus Ring */
+    --bn-focus-ring: 0 0 0 2px var(--bn-color-surface), 0 0 0 4px var(--bn-color-border-focus);
+
+    /* Z-index */
+    --bn-z-dropdown: 1000;
+    --bn-z-modal: 1100;
+    --bn-z-toast: 1200;
+  }
+
+  /* Density: Compact */
+  [data-density="compact"] {
+    --bn-space-component-x: var(--bn-space-2);
+    --bn-space-component-y: var(--bn-space-1);
+    --bn-font-size-component: var(--bn-font-size-sm);
+  }
+
+  /* Density: Default */
+  :root, [data-density="default"] {
+    --bn-space-component-x: var(--bn-space-3);
+    --bn-space-component-y: var(--bn-space-2);
+    --bn-font-size-component: var(--bn-font-size-base);
+  }
+
+  /* Density: Spacious */
+  [data-density="spacious"] {
+    --bn-space-component-x: var(--bn-space-4);
+    --bn-space-component-y: var(--bn-space-3);
+    --bn-font-size-component: var(--bn-font-size-base);
+  }
 }


### PR DESCRIPTION
## Summary
- Establishes a single-source core design system in `packages/components/` with CSS cascade layers, semantic tokens, accent scale, density system, and dark mode support
- Adds CSS for all 15 previously unstyled JS components (accordion, avatar, breadcrumb, combobox, command-palette, datagrid, dialog, drawer, dropdown-menu, multiselect, tabs, toast, tooltip, tree, virtualizer)
- Migrates enterprise and enterprise-v2 examples from inline CSS to core imports, converting class selectors to `data-bn` attributes with skip links, ARIA live regions, and nav labels
- Bridges express dark/golden theme via `theme.css` token overrides so core components render with the BaseNative aesthetic
- Adds `/showcase` route with live server-rendered demos of every component, interactive tabs/accordion/dialog/drawer, and client-side hydration
- Adds live reload dev server (SSE + file watcher with debounce)
- Fixes SSR interpolation eating `{{ }}` inside docs code blocks, stat grid data, and status badge text wrapping

## Test plan
- [ ] `pnpm exec nx run-many --target=test --all` — 441 tests pass, 0 failures
- [ ] Visit `/showcase` — all 27 component types render, dialog/drawer/accordion/tabs are interactive
- [ ] Visit `/`, `/tasks`, `/playground`, `/docs`, `/components` — no visual regressions
- [ ] Visit enterprise and enterprise-v2 examples — layouts render from core CSS with skip links and ARIA

🤖 Generated with [Claude Code](https://claude.com/claude-code)