### PR TITLE
fix(ci): add NX_CLOUD_ACCESS_TOKEN to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+env:
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add missing `NX_CLOUD_ACCESS_TOKEN` env var to the deploy workflow
- The `ci.yml` and `release.yml` workflows already had this, but `deploy.yml` was missing it
- Without the token, `nx bundle` fails during `pnpm build:pages` with "Workspace is unable to be authorized"

## Test plan
- [ ] Deploy workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)