### PR TITLE
fix(ci): downgrade checkout action from v5 to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
## Summary
- `actions/checkout@v5` doesn't exist, causing the Release workflow to fail on every push to main
- Downgraded to `@v4` to match all other workflows in the repo

## Test plan
- [ ] Verify Release workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)