### PR TITLE
feat: Phase 3 production readiness — plugins, wizard, visual builder, flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,3 +181,34 @@ chore(ci): add bundle size check to PR workflow
 - **PendingBusiness** — Business management app built on BaseNative
 - **Greenput** — Input/workflow platform built on BaseNative  
 - **Greenput OS** — Long-term: BaseNative as hardware runtime substrate
+
+---
+
+## Next Steps / AI Backlog
+
+**UPSTREAM DOGFOODING DIRECTIVE**: You are the foundational framework builder. If a downstream consumer app (Greenput, PendingBusiness, DuganLabs) requires a generically useful primitive (like a specialized UI component, an auth flow wrapper, or parsing string utility), YOU must build it here as an open-source package first. 
+
+You will pull from this task list when executing autonomously.
+
+### Epic 1: Dogfooding Primitives (`@basenative/markdown` & `@basenative/components`)
+- **Task A**: Build `@basenative/markdown`, a pure ES module zero-dependency markdown parser. This is a hard blocker for DuganLabs' Dynamic Blog Epic.
+- **Task B**: Expand `@basenative/components` with a Drag-and-Drop Calendar/Pipeline block component utilizing CSS grid and native drag-and-drop APIs. This is a hard blocker for Greenput's Schedule-Aware Lead Routing Epic.
+- **Task C**: Build `@basenative/integrations/plaid`, a headless wrapper module that wraps the Plaid Link client-side initialization script and the server-side OAuth exchange logic. This is a hard blocker for PendingBusiness's FedNow auto-pay engine.
+
+### Epic 2: Reactivity Optimization (`@basenative/runtime`)
+- **Task A**: Write benchmarking tests in `benchmarks/` to measure `effect()` re-render overhead with 10,000 DOM nodes.
+- **Task B**: Implement a `batch()` API to allow synchronous grouping of signal mutations without triggering immediate re-renders, solving the diamond problem.
+- **Task C**: Implement comprehensive unit testing (`node:test`) for diamond-dependency cases.
+
+### Epic 3: SSR Advanced Streaming (`@basenative/server`)
+- **Task A**: Introduce `@defer` directive parser logic, splitting the document stream parsing to allow "Suspense-like" partial HTML streaming.
+- **Task B**: Link `@defer` chunks to `hydrate()` so that delayed script injection re-evaluates the signal tree automatically.
+
+### Epic 4: No-Code Visual Builder Engine [Phase 3]
+- **Task A**: Initialize `@basenative/visual-builder` package. Build an AST-to-DOM parser that can translate JSON schema representations back into BaseNative primitives safely.
+- **Task B**: Expose a drag-and-drop layout grid component inside `@basenative/components` that hooks directly into the visual builder state machine.
+- **Task C**: Implement a specialized `<bn-canvas>` web component to orchestrate the drag-and-drop interface, strictly respecting `display: contents` constraints on hosts.
+
+### Epic 5: Plugin Infrastructure & Feature Flags [Phase 3]
+- **Task A**: Build `@basenative/flags`, enabling edge-cached feature flag evaluations utilizing Cloudflare KV.
+- **Task B**: Overhaul `@basenative/runtime` to expose an internal `registerPlugin()` API hooked into the reactivity lifecycle. Ensure external plugins can intercept signal writes without breaking the diamond-problem resolutions.

--- a/PRD.md
+++ b/PRD.md
@@ -65,6 +65,8 @@ Modern web development is buried under abstraction layers that obscure what the 
 - i18n, realtime, and notification packages
 - E2E test coverage with Playwright
 - npm publishing pipeline via Changesets
+- **Baseline Component Expansion**: Build robust native implementations for Data tables, accessible Modals with focus trapping, and layout primitives.
+- **SSR Streaming Enhancements**: Suspense-like boundaries for out-of-order template streaming and selective hydration.
 
 ### Phase 3 — Ecosystem (Next)
 - Visual builder for no-code template composition

--- a/benchmarks/effect-dom-nodes.bench.js
+++ b/benchmarks/effect-dom-nodes.bench.js
@@ -1,0 +1,145 @@
+import { signal, computed, effect, batch } from '@basenative/runtime';
+import { performance } from 'node:perf_hooks';
+
+const WARMUP = 100;
+const ITERATIONS = 2000;
+
+function bench(name, fn) {
+  for (let i = 0; i < WARMUP; i++) fn();
+
+  const start = performance.now();
+  for (let i = 0; i < ITERATIONS; i++) fn();
+  const elapsed = performance.now() - start;
+
+  const opsPerSec = Math.round((ITERATIONS / elapsed) * 1000);
+  const avgMs = (elapsed / ITERATIONS).toFixed(4);
+  console.log(`  ${name}: ${avgMs}ms avg, ${opsPerSec.toLocaleString()} ops/sec`);
+}
+
+console.log('Effect + DOM Node Re-render Benchmarks');
+console.log('='.repeat(55));
+
+// Simulate DOM text nodes as plain objects (no real DOM in Node.js)
+function createDOMNode(id) {
+  return { id, textContent: '' };
+}
+
+console.log('\n--- 10,000 DOM nodes, 1 signal each ---');
+
+bench('create 10k signal→effect pairs', () => {
+  const nodes = [];
+  const effects = [];
+  for (let i = 0; i < 10000; i++) {
+    const s = signal(i);
+    const node = createDOMNode(i);
+    effects.push(effect(() => { node.textContent = String(s()); }));
+  }
+  for (const e of effects) e.dispose();
+});
+
+bench('update 1 signal observed by 10k effects', () => {
+  const s = signal(0);
+  const nodes = [];
+  const effects = [];
+  for (let i = 0; i < 10000; i++) {
+    const node = createDOMNode(i);
+    nodes.push(node);
+    effects.push(effect(() => { node.textContent = `val:${s()}`; }));
+  }
+  s.set(1);
+  for (const e of effects) e.dispose();
+});
+
+bench('batch update 1 signal observed by 10k effects', () => {
+  const s = signal(0);
+  const nodes = [];
+  const effects = [];
+  for (let i = 0; i < 10000; i++) {
+    const node = createDOMNode(i);
+    nodes.push(node);
+    effects.push(effect(() => { node.textContent = `val:${s()}`; }));
+  }
+  batch(() => { s.set(1); });
+  for (const e of effects) e.dispose();
+});
+
+console.log('\n--- 10,000 nodes with computed derivation ---');
+
+bench('10k computed → effect chains, single source update', () => {
+  const source = signal(0);
+  const nodes = [];
+  const effects = [];
+  for (let i = 0; i < 10000; i++) {
+    const idx = i;
+    const derived = computed(() => source() + idx);
+    const node = createDOMNode(i);
+    nodes.push(node);
+    effects.push(effect(() => { node.textContent = String(derived()); }));
+  }
+  source.set(1);
+  for (const e of effects) e.dispose();
+});
+
+bench('10k computed → effect chains, batched source update', () => {
+  const source = signal(0);
+  const nodes = [];
+  const effects = [];
+  for (let i = 0; i < 10000; i++) {
+    const idx = i;
+    const derived = computed(() => source() + idx);
+    const node = createDOMNode(i);
+    nodes.push(node);
+    effects.push(effect(() => { node.textContent = String(derived()); }));
+  }
+  batch(() => { source.set(1); });
+  for (const e of effects) e.dispose();
+});
+
+console.log('\n--- Diamond dependency at scale ---');
+
+bench('1000 diamond graphs (A→B,A→C,effect(B+C))', () => {
+  const effects = [];
+  for (let i = 0; i < 1000; i++) {
+    const a = signal(i);
+    const b = computed(() => a() * 2);
+    const c = computed(() => a() * 3);
+    const node = createDOMNode(i);
+    effects.push(effect(() => { node.textContent = String(b() + c()); }));
+    a.set(i + 1);
+  }
+  for (const e of effects) e.dispose();
+});
+
+bench('1000 diamond graphs batched', () => {
+  const effects = [];
+  for (let i = 0; i < 1000; i++) {
+    const a = signal(i);
+    const b = computed(() => a() * 2);
+    const c = computed(() => a() * 3);
+    const node = createDOMNode(i);
+    effects.push(effect(() => { node.textContent = String(b() + c()); }));
+    batch(() => { a.set(i + 1); });
+  }
+  for (const e of effects) e.dispose();
+});
+
+console.log('\n--- Multi-signal batch updates ---');
+
+bench('batch 100 signal updates, 100 effects each', () => {
+  const signals = Array.from({ length: 100 }, (_, i) => signal(i));
+  const effects = [];
+  for (let i = 0; i < 100; i++) {
+    const s = signals[i];
+    for (let j = 0; j < 100; j++) {
+      const node = createDOMNode(i * 100 + j);
+      effects.push(effect(() => { node.textContent = String(s()); }));
+    }
+  }
+  batch(() => {
+    for (const s of signals) s.set(v => v + 1);
+  });
+  for (const e of effects) e.dispose();
+});
+
+console.log('\n' + '='.repeat(55));
+console.log('Done.');

--- a/examples/express/public/basenative.js
+++ b/examples/express/public/basenative.js
@@ -1,4 +1,4 @@
-// packages/runtime/src/signals.js
+// ../../packages/runtime/src/signals.js
 var currentEffect = null;
 function cleanupEffect(effectRef) {
   for (const subscribers of effectRef.subscriptions) {
@@ -66,7 +66,7 @@ function effect(fn) {
   return execute;
 }
 
-// src/shared/expression.js
+// ../../src/shared/expression.js
 var SCOPE_SLOT = Symbol.for("basenative.scopeSlot");
 var EXPRESSION_CACHE = /* @__PURE__ */ new Map();
 var UNSAFE_PROPERTIES = /* @__PURE__ */ new Set(["__proto__", "prototype", "constructor"]);
@@ -692,7 +692,7 @@ function evaluateExpression(source, ctx = {}, options = {}) {
   }
 }
 
-// packages/runtime/src/evaluate.js
+// ../../packages/runtime/src/evaluate.js
 function evaluate(expr, ctx, options) {
   return evaluateExpression(expr, ctx, options);
 }
@@ -703,7 +703,7 @@ function interpolate(text, ctx, options) {
   });
 }
 
-// packages/runtime/src/dom-lifecycle.js
+// ../../packages/runtime/src/dom-lifecycle.js
 var CLEANUPS = Symbol("basenative.cleanups");
 function registerCleanup(node, cleanup) {
   if (!node || typeof cleanup !== "function") return cleanup;
@@ -740,7 +740,7 @@ function removeNodeRange(start, end) {
   }
 }
 
-// packages/runtime/src/scope.js
+// ../../packages/runtime/src/scope.js
 function createScopeSlot(initial) {
   const state = signal(initial);
   return {
@@ -782,7 +782,7 @@ function updateLoopContext(slots, itemName, item, index, length) {
   slots.$odd.set(index % 2 !== 0);
 }
 
-// packages/runtime/src/bind.js
+// ../../packages/runtime/src/bind.js
 function bindNode(node, ctx, options) {
   let processed = 0;
   if (node.nodeType === Node.TEXT_NODE) {
@@ -837,7 +837,7 @@ function bindNode(node, ctx, options) {
   return processed;
 }
 
-// packages/runtime/src/diagnostics.js
+// ../../packages/runtime/src/diagnostics.js
 function logDiagnostic(diagnostic) {
   const method = diagnostic.level === "error" ? "error" : "warn";
   console[method]?.(`[BaseNative:${diagnostic.code}] ${diagnostic.message}`, diagnostic);
@@ -874,7 +874,7 @@ function reportHydrationMismatch(options, message, detail = {}) {
   }
 }
 
-// packages/runtime/src/hydrate.js
+// ../../packages/runtime/src/hydrate.js
 function insertAfterAnchor(anchor, nodes) {
   let ref = anchor;
   for (const node of nodes) {
@@ -1201,7 +1201,7 @@ function hydrate(root, ctx, options = {}) {
   return () => disposeNodeTree(root);
 }
 
-// packages/runtime/src/features.js
+// ../../packages/runtime/src/features.js
 function cssSupports(target, rule) {
   return Boolean(target?.CSS?.supports?.(rule));
 }
@@ -1220,7 +1220,7 @@ function supportsFeature(name, target = globalThis) {
 }
 var browserFeatures = detectBrowserFeatures();
 
-// packages/runtime/src/devtools.js
+// ../../packages/runtime/src/devtools.js
 var devtoolsState = {
   signals: /* @__PURE__ */ new Map(),
   effects: /* @__PURE__ */ new Map(),
@@ -1289,7 +1289,7 @@ function isDevtoolsEnabled() {
   return devtoolsState.enabled;
 }
 
-// packages/runtime/src/error-boundary.js
+// ../../packages/runtime/src/error-boundary.js
 function createErrorBoundary(options = {}) {
   let lastError = null;
   let hasError = false;
@@ -1359,7 +1359,7 @@ function escapeComment(str) {
   return String(str).replace(/--/g, "- -");
 }
 
-// packages/runtime/src/plugins.js
+// ../../packages/runtime/src/plugins.js
 var VALID_HOOKS = [
   "beforeRender",
   "afterRender",
@@ -1438,7 +1438,7 @@ function createPluginRegistry() {
   return { register, runHook, getDirective, getPlugins };
 }
 
-// packages/runtime/src/lazy.js
+// ../../packages/runtime/src/lazy.js
 function createLazyHydrator(options = {}) {
   const { rootMargin = "0px", threshold = 0 } = options;
   const pending = /* @__PURE__ */ new Map();
@@ -1550,7 +1550,7 @@ function hydrateOnMedia(hydrateFn, query) {
   return cleanup;
 }
 
-// packages/runtime/src/vitals.js
+// ../../packages/runtime/src/vitals.js
 function createObserver(type, callback) {
   if (typeof PerformanceObserver === "undefined") return null;
   try {
@@ -1655,6 +1655,115 @@ function createVitalsReporter(options = {}) {
     }
   };
 }
+
+// ../../packages/runtime/src/debug.js
+var _debugEnabled = false;
+var _label = "";
+var _logger = typeof console !== "undefined" ? console : null;
+var stats = {
+  signalsCreated: 0,
+  effectsCreated: 0,
+  signalWrites: 0,
+  signalReads: 0,
+  effectRuns: 0
+};
+function log(level, ...args) {
+  if (!_debugEnabled || !_logger) return;
+  const prefix = _label ? `[BN:debug:${_label}]` : "[BN:debug]";
+  _logger[level]?.(prefix, ...args);
+}
+function enableDebug(opts = {}) {
+  _debugEnabled = true;
+  _label = opts.label ?? "";
+  _logger = opts.logger ?? (typeof console !== "undefined" ? console : null);
+  _debugEnabled = true;
+  if (opts.trackReads !== void 0) {
+    _config.trackReads = Boolean(opts.trackReads);
+  }
+  log("info", "debug mode enabled", opts.label ? `(${opts.label})` : "");
+}
+function disableDebug() {
+  log("info", "debug mode disabled. stats:", getDebugStats());
+  _debugEnabled = false;
+  _label = "";
+  Object.assign(stats, {
+    signalsCreated: 0,
+    effectsCreated: 0,
+    signalWrites: 0,
+    signalReads: 0,
+    effectRuns: 0
+  });
+}
+function isDebugEnabled() {
+  return _debugEnabled;
+}
+function getDebugStats() {
+  return { ...stats };
+}
+var _config = {
+  trackReads: false
+};
+function debugSignal(s, name = "signal") {
+  stats.signalsCreated++;
+  log("debug", `signal:${name} created`, `(${s()})`);
+  const wrapped = () => {
+    if (_config.trackReads) {
+      stats.signalReads++;
+      log("debug", `signal:${name} read \u2192`, s());
+    }
+    return s();
+  };
+  wrapped.set = (next) => {
+    const before = s();
+    s.set(next);
+    const after = s();
+    if (_debugEnabled) {
+      stats.signalWrites++;
+      log("debug", `signal:${name} set`, before, "\u2192", after);
+    }
+  };
+  wrapped.peek = () => s.peek();
+  return wrapped;
+}
+function debugEffect(fn, name = "effect") {
+  stats.effectsCreated++;
+  let runCount = 0;
+  const handle = effect(() => {
+    runCount++;
+    stats.effectRuns++;
+    const start = typeof performance !== "undefined" ? performance.now() : Date.now();
+    log("debug", `effect:${name} run #${runCount} started`);
+    const result = fn();
+    const duration = (typeof performance !== "undefined" ? performance.now() : Date.now()) - start;
+    log("debug", `effect:${name} run #${runCount} done (${duration.toFixed(2)}ms)`);
+    return result;
+  });
+  return handle;
+}
+function debugTime(label, fn) {
+  if (!_debugEnabled) return fn();
+  const start = typeof performance !== "undefined" ? performance.now() : Date.now();
+  let result;
+  try {
+    result = fn();
+  } finally {
+    const ms = ((typeof performance !== "undefined" ? performance.now() : Date.now()) - start).toFixed(2);
+    log("info", `\u23F1 ${label}: ${ms}ms`);
+  }
+  return result;
+}
+function debugAssert(condition, message) {
+  if (!_debugEnabled) return;
+  if (!condition) {
+    log("error", `assertion failed: ${message}`);
+    throw new Error(`[BN:debug] Assertion failed: ${message}`);
+  }
+}
+function debugDeps(s, name = "signal") {
+  if (!_debugEnabled) return;
+  const value = typeof s === "function" ? s() : s;
+  log("info", `deps:${name} current value:`, value);
+}
 export {
   browserFeatures,
   computed,
@@ -1662,16 +1771,25 @@ export {
   createLazyHydrator,
   createPluginRegistry,
   createVitalsReporter,
+  debugAssert,
+  debugDeps,
+  debugEffect,
+  debugSignal,
+  debugTime,
   definePlugin,
   detectBrowserFeatures,
+  disableDebug,
   disableDevtools,
   effect,
   emitDiagnostic,
+  enableDebug,
   enableDevtools,
+  getDebugStats,
   hydrate,
   hydrateOnIdle,
   hydrateOnInteraction,
   hydrateOnMedia,
+  isDebugEnabled,
   isDevtoolsEnabled,
   lazyHydrate,
   observeCLS,

--- a/packages/components/src/calendar.js
+++ b/packages/components/src/calendar.js
@@ -1,0 +1,249 @@
+/**
+ * Calendar / Pipeline block — drag-and-drop scheduling component.
+ *
+ * Renders a CSS-grid-based weekly calendar with draggable event blocks.
+ * Uses native HTML5 Drag and Drop API. No external dependencies.
+ *
+ * Usage (SSR):
+ *   renderCalendar({
+ *     startDate: '2025-06-02',
+ *     events: [{ id: '1', title: 'Job', start: '2025-06-02T09:00', end: '2025-06-02T11:00', ... }],
+ *     hours: { start: 7, end: 19 },
+ *   })
+ *
+ * Client-side: initCalendarDragDrop(container, { onDrop })
+ */
+
+/**
+ * Format an ISO date string to a short day label.
+ */
+function formatDay(dateStr) {
+  const d = new Date(dateStr);
+  const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  return `${days[d.getDay()]} ${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+/**
+ * Get array of date strings (YYYY-MM-DD) for a week starting at startDate.
+ */
+function weekDates(startDate) {
+  const dates = [];
+  const d = new Date(startDate);
+  for (let i = 0; i < 7; i++) {
+    const iso = d.toISOString().split('T')[0];
+    dates.push(iso);
+    d.setDate(d.getDate() + 1);
+  }
+  return dates;
+}
+
+/**
+ * Server-side render a weekly calendar grid with event blocks.
+ *
+ * @param {object} options
+ * @param {string} options.startDate      ISO date for the week start (Monday)
+ * @param {Array}  options.events         Array of event objects
+ * @param {string} options.events[].id
+ * @param {string} options.events[].title
+ * @param {string} options.events[].start ISO datetime
+ * @param {string} options.events[].end   ISO datetime
+ * @param {string} [options.events[].status]   Optional status for styling
+ * @param {string} [options.events[].color]    Optional CSS color override
+ * @param {string} [options.events[].assignee] Optional assignee name
+ * @param {object} [options.hours]         Working hours range
+ * @param {number} [options.hours.start=7]
+ * @param {number} [options.hours.end=19]
+ * @param {string} [options.emptyMessage='No events']
+ * @param {string} [options.id]
+ * @param {string} [options.attrs]
+ * @returns {string} HTML
+ */
+export function renderCalendar(options = {}) {
+  const {
+    startDate,
+    events = [],
+    hours = {},
+    emptyMessage = 'No events',
+    id = `bn-calendar-${Math.random().toString(36).slice(2)}`,
+    attrs = '',
+  } = options;
+
+  const hourStart = hours.start ?? 7;
+  const hourEnd = hours.end ?? 19;
+  const totalHours = hourEnd - hourStart;
+  const dates = weekDates(startDate);
+
+  // Header row: time gutter + 7 day columns
+  const headerCells = dates.map(d =>
+    `<div data-bn="calendar-day-header" data-date="${d}">${formatDay(d)}</div>`
+  ).join('');
+
+  // Time gutter labels
+  const timeLabels = [];
+  for (let h = hourStart; h < hourEnd; h++) {
+    const label = h <= 12 ? `${h}am` : `${h - 12}pm`;
+    timeLabels.push(
+      `<div data-bn="calendar-time-label" data-hour="${h}" style="grid-row: ${h - hourStart + 2}">${h === 12 ? '12pm' : label}</div>`
+    );
+  }
+
+  // Day columns with drop zones
+  const dayColumns = dates.map((date, colIndex) => {
+    const dayEvents = events.filter(e => e.start && e.start.startsWith(date));
+
+    const eventBlocks = dayEvents.map(ev => {
+      const startHour = new Date(ev.start).getHours() + new Date(ev.start).getMinutes() / 60;
+      const endHour = new Date(ev.end).getHours() + new Date(ev.end).getMinutes() / 60;
+      const topRow = Math.max(startHour - hourStart + 2, 2);
+      const span = Math.max(endHour - startHour, 0.5);
+      const statusAttr = ev.status ? ` data-status="${ev.status}"` : '';
+      const colorStyle = ev.color ? ` --bn-calendar-event-color: ${ev.color};` : '';
+
+      return `<div data-bn="calendar-event" draggable="true" data-event-id="${ev.id}"${statusAttr} style="grid-row: ${topRow} / span ${Math.ceil(span)};${colorStyle}">
+  <span data-bn="calendar-event-title">${ev.title}</span>
+  ${ev.assignee ? `<span data-bn="calendar-event-assignee">${ev.assignee}</span>` : ''}
+  <span data-bn="calendar-event-time">${new Date(ev.start).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })} – ${new Date(ev.end).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}</span>
+</div>`;
+    }).join('');
+
+    // Drop zone cells for each hour
+    const hourSlots = [];
+    for (let h = hourStart; h < hourEnd; h++) {
+      hourSlots.push(
+        `<div data-bn="calendar-slot" data-date="${date}" data-hour="${h}" style="grid-row: ${h - hourStart + 2}"></div>`
+      );
+    }
+
+    return `<div data-bn="calendar-day-column" data-date="${date}" style="grid-column: ${colIndex + 2}">
+  ${hourSlots.join('')}
+  ${eventBlocks}
+</div>`;
+  }).join('');
+
+  return `<div data-bn="calendar" id="${id}" ${attrs}>
+  <div data-bn="calendar-grid" style="--bn-calendar-hours: ${totalHours}; --bn-calendar-cols: 7;">
+    <div data-bn="calendar-corner"></div>
+    ${headerCells}
+    <div data-bn="calendar-time-gutter">
+      ${timeLabels.join('')}
+    </div>
+    ${dayColumns}
+  </div>
+  ${events.length === 0 ? `<div data-bn="calendar-empty">${emptyMessage}</div>` : ''}
+</div>`;
+}
+
+/**
+ * Render a pipeline/kanban block for use outside the calendar
+ * (e.g., sidebar cards that can be dragged onto the calendar).
+ *
+ * @param {object} options
+ * @param {string} options.id
+ * @param {string} options.title
+ * @param {string} [options.subtitle]
+ * @param {string} [options.status]
+ * @param {string} [options.attrs]
+ * @returns {string} HTML
+ */
+export function renderPipelineBlock(options = {}) {
+  const { id, title, subtitle, status, attrs = '' } = options;
+  const statusAttr = status ? ` data-status="${status}"` : '';
+
+  return `<div data-bn="pipeline-block" draggable="true" data-block-id="${id}"${statusAttr} ${attrs}>
+  <span data-bn="pipeline-block-title">${title}</span>
+  ${subtitle ? `<span data-bn="pipeline-block-subtitle">${subtitle}</span>` : ''}
+</div>`;
+}
+
+/**
+ * Client-side: Initialize drag-and-drop on a calendar container.
+ *
+ * @param {HTMLElement} container  The [data-bn="calendar"] element
+ * @param {object} callbacks
+ * @param {function} callbacks.onDrop  Called with { eventId, date, hour, sourceType }
+ * @returns {{ destroy: () => void }}
+ */
+export function initCalendarDragDrop(container, callbacks = {}) {
+  const { onDrop } = callbacks;
+
+  function handleDragStart(e) {
+    const event = e.target.closest('[data-event-id]');
+    const block = e.target.closest('[data-block-id]');
+    if (event) {
+      e.dataTransfer.setData('text/plain', JSON.stringify({
+        type: 'event',
+        id: event.dataset.eventId,
+      }));
+      e.dataTransfer.effectAllowed = 'move';
+      event.setAttribute('data-dragging', '');
+    } else if (block) {
+      e.dataTransfer.setData('text/plain', JSON.stringify({
+        type: 'pipeline',
+        id: block.dataset.blockId,
+      }));
+      e.dataTransfer.effectAllowed = 'copy';
+      block.setAttribute('data-dragging', '');
+    }
+  }
+
+  function handleDragOver(e) {
+    const slot = e.target.closest('[data-bn="calendar-slot"]');
+    if (slot) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      slot.setAttribute('data-drop-target', '');
+    }
+  }
+
+  function handleDragLeave(e) {
+    const slot = e.target.closest('[data-bn="calendar-slot"]');
+    if (slot) {
+      slot.removeAttribute('data-drop-target');
+    }
+  }
+
+  function handleDrop(e) {
+    e.preventDefault();
+    const slot = e.target.closest('[data-bn="calendar-slot"]');
+    if (!slot) return;
+
+    slot.removeAttribute('data-drop-target');
+
+    try {
+      const data = JSON.parse(e.dataTransfer.getData('text/plain'));
+      if (onDrop) {
+        onDrop({
+          eventId: data.id,
+          date: slot.dataset.date,
+          hour: parseInt(slot.dataset.hour, 10),
+          sourceType: data.type,
+        });
+      }
+    } catch { /* ignore malformed drag data */ }
+  }
+
+  function handleDragEnd(e) {
+    container.querySelectorAll('[data-dragging]').forEach(el =>
+      el.removeAttribute('data-dragging')
+    );
+    container.querySelectorAll('[data-drop-target]').forEach(el =>
+      el.removeAttribute('data-drop-target')
+    );
+  }
+
+  container.addEventListener('dragstart', handleDragStart);
+  container.addEventListener('dragover', handleDragOver);
+  container.addEventListener('dragleave', handleDragLeave);
+  container.addEventListener('drop', handleDrop);
+  container.addEventListener('dragend', handleDragEnd);
+
+  return {
+    destroy() {
+      container.removeEventListener('dragstart', handleDragStart);
+      container.removeEventListener('dragover', handleDragOver);
+      container.removeEventListener('dragleave', handleDragLeave);
+      container.removeEventListener('drop', handleDrop);
+      container.removeEventListener('dragend', handleDragEnd);
+    },
+  };
+}

--- a/packages/components/src/components.css
+++ b/packages/components/src/components.css
@@ -1011,4 +1011,139 @@
 }
 [data-bn="virtual-item"]:last-child { border-bottom: none; }
 
+/* === Calendar === */
+[data-bn="calendar"] {
+  position: relative;
+  overflow: auto;
+  border: var(--bn-border-width) solid var(--bn-color-border);
+  border-radius: var(--bn-radius-md);
+  background: var(--bn-color-surface);
+}
+[data-bn="calendar-grid"] {
+  display: grid;
+  grid-template-columns: 4rem repeat(var(--bn-calendar-cols, 7), 1fr);
+  grid-template-rows: auto repeat(var(--bn-calendar-hours, 12), minmax(3.5rem, 1fr));
+  min-height: 0;
+}
+[data-bn="calendar-corner"] {
+  grid-column: 1;
+  grid-row: 1;
+  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+  border-right: var(--bn-border-width) solid var(--bn-color-border);
+  background: var(--bn-color-surface-muted);
+}
+[data-bn="calendar-day-header"] {
+  grid-row: 1;
+  padding: var(--bn-space-2) var(--bn-space-3);
+  font-size: var(--bn-font-size-sm);
+  font-weight: var(--bn-font-weight-semibold);
+  text-align: center;
+  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+  border-right: var(--bn-border-width) solid var(--bn-color-border);
+  background: var(--bn-color-surface-muted);
+}
+[data-bn="calendar-day-header"]:last-of-type { border-right: none; }
+[data-bn="calendar-time-gutter"] {
+  grid-column: 1;
+  grid-row: 2 / -1;
+  position: relative;
+  border-right: var(--bn-border-width) solid var(--bn-color-border);
+}
+[data-bn="calendar-time-label"] {
+  position: absolute;
+  right: var(--bn-space-2);
+  font-size: var(--bn-font-size-xs);
+  color: var(--bn-color-text-muted);
+  line-height: 1;
+  transform: translateY(-50%);
+}
+[data-bn="calendar-day-column"] {
+  position: relative;
+  display: grid;
+  grid-row: 2 / -1;
+  grid-template-rows: subgrid;
+  border-right: var(--bn-border-width) solid var(--bn-color-border);
+}
+[data-bn="calendar-day-column"]:last-of-type { border-right: none; }
+[data-bn="calendar-slot"] {
+  border-bottom: var(--bn-border-width) solid var(--bn-color-border-light, var(--bn-color-border));
+  transition: background-color var(--bn-transition-fast);
+}
+[data-bn="calendar-slot"][data-drop-target] {
+  background: var(--bn-color-primary-50, hsl(210 100% 95%));
+}
+[data-bn="calendar-event"] {
+  position: absolute;
+  inset-inline: var(--bn-space-1);
+  display: flex;
+  flex-direction: column;
+  gap: var(--bn-space-half, 0.125rem);
+  padding: var(--bn-space-1) var(--bn-space-2);
+  background: var(--bn-calendar-event-color, var(--bn-color-primary-100));
+  border-left: 3px solid var(--bn-calendar-event-color, var(--bn-color-primary-600));
+  border-radius: var(--bn-radius-sm);
+  font-size: var(--bn-font-size-xs);
+  cursor: grab;
+  overflow: hidden;
+  z-index: 1;
+}
+[data-bn="calendar-event"][data-dragging] { opacity: 0.5; cursor: grabbing; }
+[data-bn="calendar-event"][data-status="scheduled"] {
+  --bn-calendar-event-color: var(--bn-color-primary-600);
+  background: var(--bn-color-primary-50);
+}
+[data-bn="calendar-event"][data-status="in_progress"] {
+  --bn-calendar-event-color: var(--bn-color-warning-500, hsl(38 90% 50%));
+  background: var(--bn-color-warning-50, hsl(38 90% 95%));
+}
+[data-bn="calendar-event"][data-status="completed"] {
+  --bn-calendar-event-color: var(--bn-color-success-500, hsl(145 55% 40%));
+  background: var(--bn-color-success-50, hsl(145 55% 95%));
+}
+[data-bn="calendar-event-title"] {
+  font-weight: var(--bn-font-weight-semibold);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+[data-bn="calendar-event-assignee"] {
+  color: var(--bn-color-text-muted);
+}
+[data-bn="calendar-event-time"] {
+  color: var(--bn-color-text-muted);
+}
+
+/* Pipeline block (draggable card for sidebar dispatch) */
+[data-bn="pipeline-block"] {
+  display: flex;
+  flex-direction: column;
+  gap: var(--bn-space-1);
+  padding: var(--bn-space-2) var(--bn-space-3);
+  background: var(--bn-color-surface);
+  border: var(--bn-border-width) solid var(--bn-color-border);
+  border-radius: var(--bn-radius-md);
+  cursor: grab;
+  transition: box-shadow var(--bn-transition-fast), border-color var(--bn-transition-fast);
+}
+[data-bn="pipeline-block"]:hover {
+  border-color: var(--bn-color-primary-300);
+  box-shadow: var(--bn-shadow-sm);
+}
+[data-bn="pipeline-block"][data-dragging] { opacity: 0.5; cursor: grabbing; }
+[data-bn="pipeline-block-title"] {
+  font-weight: var(--bn-font-weight-medium);
+  font-size: var(--bn-font-size-sm);
+}
+[data-bn="pipeline-block-subtitle"] {
+  font-size: var(--bn-font-size-xs);
+  color: var(--bn-color-text-muted);
+}
+
+[data-bn="calendar-empty"] {
+  padding: var(--bn-space-8);
+  text-align: center;
+  color: var(--bn-color-text-muted);
+  font-size: var(--bn-font-size-sm);
+}
+
 } /* end @layer components */

--- a/packages/components/src/components.test.js
+++ b/packages/components/src/components.test.js
@@ -30,6 +30,7 @@ import { renderDataGrid } from './datagrid.js';
 import { renderTree, renderTreeGrid } from './tree.js';
 import { renderVirtualList } from './virtualizer.js';
 import { renderAvatar } from './avatar.js';
+import { renderCalendar, renderPipelineBlock } from './calendar.js';
 
 describe('Button', () => {
   it('renders a primary button', () => {
@@ -653,5 +654,73 @@ describe('Textarea — additional', () => {
   it('renders placeholder', () => {
     const html = renderTextarea({ name: 'note', placeholder: 'Enter note...' });
     assert.ok(html.includes('placeholder="Enter note..."'));
+  });
+});
+
+describe('Calendar', () => {
+  it('renders a weekly grid', () => {
+    const html = renderCalendar({ startDate: '2025-06-02' });
+    assert.ok(html.includes('data-bn="calendar"'));
+    assert.ok(html.includes('data-bn="calendar-grid"'));
+  });
+
+  it('renders day headers for 7 days', () => {
+    const html = renderCalendar({ startDate: '2025-06-02' });
+    assert.ok(html.includes('data-bn="calendar-day-header"'));
+    assert.ok(html.includes('data-date="2025-06-02"'));
+    assert.ok(html.includes('data-date="2025-06-08"'));
+  });
+
+  it('renders events in the correct column', () => {
+    const html = renderCalendar({
+      startDate: '2025-06-02',
+      events: [
+        { id: 'j1', title: 'Fix wiring', start: '2025-06-03T09:00', end: '2025-06-03T11:00' },
+      ],
+    });
+    assert.ok(html.includes('data-event-id="j1"'));
+    assert.ok(html.includes('Fix wiring'));
+    assert.ok(html.includes('draggable="true"'));
+  });
+
+  it('renders event status attributes', () => {
+    const html = renderCalendar({
+      startDate: '2025-06-02',
+      events: [
+        { id: 'j2', title: 'HVAC', start: '2025-06-02T14:00', end: '2025-06-02T16:00', status: 'in_progress' },
+      ],
+    });
+    assert.ok(html.includes('data-status="in_progress"'));
+  });
+
+  it('renders empty message when no events', () => {
+    const html = renderCalendar({ startDate: '2025-06-02', emptyMessage: 'Nothing scheduled' });
+    assert.ok(html.includes('Nothing scheduled'));
+  });
+
+  it('renders time gutter labels', () => {
+    const html = renderCalendar({ startDate: '2025-06-02', hours: { start: 8, end: 17 } });
+    assert.ok(html.includes('data-bn="calendar-time-label"'));
+  });
+
+  it('renders drop zone slots', () => {
+    const html = renderCalendar({ startDate: '2025-06-02' });
+    assert.ok(html.includes('data-bn="calendar-slot"'));
+  });
+});
+
+describe('PipelineBlock', () => {
+  it('renders a draggable block', () => {
+    const html = renderPipelineBlock({ id: 'opp-1', title: 'New Lead' });
+    assert.ok(html.includes('data-bn="pipeline-block"'));
+    assert.ok(html.includes('draggable="true"'));
+    assert.ok(html.includes('data-block-id="opp-1"'));
+    assert.ok(html.includes('New Lead'));
+  });
+
+  it('renders subtitle and status', () => {
+    const html = renderPipelineBlock({ id: 'opp-2', title: 'Job', subtitle: '$1,500', status: 'qualified' });
+    assert.ok(html.includes('$1,500'));
+    assert.ok(html.includes('data-status="qualified"'));
   });
 });

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -84,3 +84,6 @@ export { renderDropdownMenu } from './dropdown-menu.js';
 
 // Command Palette
 export { renderCommandPalette } from './command-palette.js';
+
+// Calendar & Pipeline
+export { renderCalendar, renderPipelineBlock, initCalendarDragDrop } from './calendar.js';

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -87,3 +87,6 @@ export { renderCommandPalette } from './command-palette.js';
 
 // Calendar & Pipeline
 export { renderCalendar, renderPipelineBlock, initCalendarDragDrop } from './calendar.js';
+
+// Layout Grid (Visual Builder)
+export { renderLayoutGrid, layoutGridStyles } from './layout-grid.js';

--- a/packages/components/src/layout-grid.js
+++ b/packages/components/src/layout-grid.js
@@ -1,0 +1,80 @@
+/**
+ * renderLayoutGrid - A drag-and-drop CSS grid layout component.
+ * Designed to hook into @basenative/visual-builder's canvas state.
+ *
+ * @param {object} options
+ * @param {number} [options.columns=12] - Grid columns
+ * @param {number} [options.gap='1rem'] - Gap between cells
+ * @param {string} [options.minCellHeight='4rem'] - Minimum cell height
+ * @param {Array<{id: string, label?: string, content?: string, colSpan?: number, rowSpan?: number}>} [options.cells] - Grid cells
+ * @param {string} [options.id] - Unique ID for the grid
+ * @param {boolean} [options.editable=false] - Whether cells are draggable/resizable
+ * @returns {string} HTML string
+ */
+export function renderLayoutGrid(options = {}) {
+  const {
+    columns = 12,
+    gap = '1rem',
+    minCellHeight = '4rem',
+    cells = [],
+    id = 'layout-grid',
+    editable = false,
+  } = options;
+
+  const cellsHtml = cells.map((cell, i) => {
+    const span = cell.colSpan || 1;
+    const rowSpan = cell.rowSpan || 1;
+    const style = `grid-column: span ${span}; grid-row: span ${rowSpan}; min-height: ${minCellHeight}`;
+    const draggable = editable ? ' draggable="true"' : '';
+    const content = cell.content || cell.label || `Cell ${i + 1}`;
+    return `<div data-bn="layout-cell" data-cell-id="${esc(cell.id || `cell-${i}`)}" style="${style}"${draggable}>${content}</div>`;
+  }).join('\n');
+
+  return `<div data-bn="layout-grid" id="${esc(id)}" style="display:grid;grid-template-columns:repeat(${columns},1fr);gap:${gap}">
+${cellsHtml}
+</div>`;
+}
+
+/**
+ * CSS for layout grid components.
+ * @returns {string}
+ */
+export function layoutGridStyles() {
+  return `
+[data-bn="layout-grid"] {
+  min-height: 8rem;
+  border: 1px dashed var(--border, hsl(220 15% 22%));
+  border-radius: var(--radius-lg, 0.75rem);
+  padding: 0.5rem;
+}
+[data-bn="layout-cell"] {
+  background: var(--surface-2, hsl(220 15% 14%));
+  border: 1px solid var(--border, hsl(220 15% 22%));
+  border-radius: var(--radius-md, 0.5rem);
+  padding: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.875rem;
+  color: var(--text-secondary, hsl(220 10% 55%));
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+[data-bn="layout-cell"]:hover {
+  border-color: var(--accent, hsl(210 100% 60%));
+}
+[data-bn="layout-cell"][draggable="true"] {
+  cursor: grab;
+}
+[data-bn="layout-cell"][draggable="true"]:active {
+  cursor: grabbing;
+  opacity: 0.7;
+}
+[data-bn="layout-cell"].drop-target {
+  border-color: var(--accent, hsl(210 100% 60%));
+  box-shadow: inset 0 0 0 2px var(--accent, hsl(210 100% 60%));
+}`;
+}
+
+function esc(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}

--- a/packages/components/types/index.d.ts
+++ b/packages/components/types/index.d.ts
@@ -136,3 +136,43 @@ export function renderSkeleton(options?: {
   variant?: 'text' | 'circle';
   count?: number;
 }): string;
+
+// Calendar
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  start: string;
+  end: string;
+  status?: string;
+  color?: string;
+  assignee?: string;
+}
+
+export function renderCalendar(options?: {
+  startDate: string;
+  events?: CalendarEvent[];
+  hours?: { start?: number; end?: number };
+  emptyMessage?: string;
+  id?: string;
+  attrs?: string;
+}): string;
+
+export function renderPipelineBlock(options?: {
+  id: string;
+  title: string;
+  subtitle?: string;
+  status?: string;
+  attrs?: string;
+}): string;
+
+export interface CalendarDropEvent {
+  eventId: string;
+  date: string;
+  hour: number;
+  sourceType: 'event' | 'pipeline';
+}
+
+export function initCalendarDragDrop(
+  container: HTMLElement,
+  callbacks?: { onDrop?: (event: CalendarDropEvent) => void }
+): { destroy: () => void };

--- a/packages/flags/src/index.js
+++ b/packages/flags/src/index.js
@@ -1,3 +1,4 @@
 export { createFlagManager, flagMiddleware } from './flags.js';
 export { createMemoryProvider } from './providers/memory.js';
 export { createRemoteProvider } from './providers/remote.js';
+export { createKVProvider } from './providers/kv.js';

--- a/packages/flags/src/providers/kv.js
+++ b/packages/flags/src/providers/kv.js
@@ -1,0 +1,41 @@
+/**
+ * Cloudflare KV-backed feature flag provider with edge caching.
+ *
+ * @param {object} options
+ * @param {object} options.kv - Cloudflare KV namespace binding (env.FLAGS or similar)
+ * @param {string} [options.prefix='flags:'] - Key prefix in KV
+ * @param {number} [options.cacheTtl=60] - Edge cache TTL in seconds
+ * @returns {import('../../types/index.d.ts').FlagProvider}
+ */
+export function createKVProvider(options) {
+  const { kv, prefix = 'flags:', cacheTtl = 60 } = options;
+
+  if (!kv) throw new Error('@basenative/flags: KV binding is required for createKVProvider');
+
+  async function getFlag(name) {
+    const value = await kv.get(`${prefix}${name}`, { type: 'json', cacheTtl });
+    return value || null;
+  }
+
+  async function getAllFlags() {
+    const list = await kv.list({ prefix });
+    const flags = {};
+    const promises = list.keys.map(async (key) => {
+      const name = key.name.replace(prefix, '');
+      const value = await kv.get(key.name, { type: 'json', cacheTtl });
+      if (value) flags[name] = value;
+    });
+    await Promise.all(promises);
+    return flags;
+  }
+
+  async function setFlag(name, flag) {
+    await kv.put(`${prefix}${name}`, JSON.stringify(flag));
+  }
+
+  async function deleteFlag(name) {
+    await kv.delete(`${prefix}${name}`);
+  }
+
+  return { getFlag, getAllFlags, setFlag, deleteFlag };
+}

--- a/packages/forms/src/index.js
+++ b/packages/forms/src/index.js
@@ -1,3 +1,4 @@
 export { createField } from './field.js';
 export { createForm, zodAdapter } from './form.js';
+export { createWizard } from './wizard.js';
 export { required, minLength, maxLength, pattern, email, min, max, custom } from './validators.js';

--- a/packages/forms/src/wizard.js
+++ b/packages/forms/src/wizard.js
@@ -1,0 +1,76 @@
+import { signal, computed } from '@basenative/runtime';
+import { createForm } from './form.js';
+
+/**
+ * Creates a multi-step form wizard that wraps createForm for each step.
+ *
+ * @param {Array<{ fields: Record<string, Field>, label?: string }>} steps
+ * @param {object} [options]
+ * @param {Function} [options.onComplete] - Called with aggregated values when all steps are valid
+ * @returns {Wizard}
+ */
+export function createWizard(steps, options = {}) {
+  const stepCount = steps.length;
+  const forms = steps.map((step) => createForm(step.fields));
+  const currentStep = signal(0);
+  const visited = signal(new Set([0]));
+
+  const currentForm = computed(() => forms[currentStep()]);
+  const isFirst = computed(() => currentStep() === 0);
+  const isLast = computed(() => currentStep() === stepCount - 1);
+  const progress = computed(() => (currentStep() + 1) / stepCount);
+  const canNext = computed(() => currentForm().valid());
+  const allValid = computed(() => forms.every((form) => form.valid()));
+
+  function getValues() {
+    const result = {};
+    for (const form of forms) {
+      Object.assign(result, form.getValues());
+    }
+    return result;
+  }
+
+  function next() {
+    currentForm().touchAll();
+    if (!currentForm().valid() || isLast()) return;
+    const nextIndex = currentStep() + 1;
+    currentStep.set(nextIndex);
+    const v = new Set(visited());
+    v.add(nextIndex);
+    visited.set(v);
+  }
+
+  function prev() {
+    if (isFirst()) return;
+    currentStep.set(currentStep() - 1);
+  }
+
+  function goTo(index) {
+    if (index < 0 || index >= stepCount) return;
+    const v = visited();
+    const maxVisited = Math.max(...v);
+    if (index <= maxVisited + 1) {
+      currentStep.set(index);
+      const next = new Set(v);
+      next.add(index);
+      visited.set(next);
+    }
+  }
+
+  function reset() {
+    for (const form of forms) form.reset();
+    currentStep.set(0);
+    visited.set(new Set([0]));
+  }
+
+  function complete() {
+    if (!allValid()) return;
+    if (options.onComplete) return options.onComplete(getValues());
+  }
+
+  return {
+    currentStep, stepCount, steps: forms, currentForm,
+    isFirst, isLast, progress, canNext, visited, allValid,
+    next, prev, goTo, getValues, reset, complete,
+  };
+}

--- a/packages/forms/src/wizard.js
+++ b/packages/forms/src/wizard.js
@@ -1,75 +1,101 @@
 import { signal, computed } from '@basenative/runtime';
-import { createForm } from './form.js';
 
 /**
- * Creates a multi-step form wizard that wraps createForm for each step.
+ * Creates a multi-step form wizard that coordinates pre-built form instances.
  *
- * @param {Array<{ fields: Record<string, Field>, label?: string }>} steps
+ * @param {Array<{ name: string, form: Form, title?: string }>} steps
  * @param {object} [options]
  * @param {Function} [options.onComplete] - Called with aggregated values when all steps are valid
+ * @param {boolean} [options.validateBeforeNext] - Whether to validate before advancing (default: true)
  * @returns {Wizard}
  */
 export function createWizard(steps, options = {}) {
   const stepCount = steps.length;
-  const forms = steps.map((step) => createForm(step.fields));
-  const currentStep = signal(0);
+  const validateBeforeNext = options.validateBeforeNext !== false;
+  const currentIndex = signal(0);
   const visited = signal(new Set([0]));
 
-  const currentForm = computed(() => forms[currentStep()]);
-  const isFirst = computed(() => currentStep() === 0);
-  const isLast = computed(() => currentStep() === stepCount - 1);
-  const progress = computed(() => (currentStep() + 1) / stepCount);
+  const currentStep = computed(() => steps[currentIndex()]);
+  const currentForm = computed(() => currentStep().form);
+  const isFirst = computed(() => currentIndex() === 0);
+  const isLast = computed(() => currentIndex() === stepCount - 1);
+  const progress = computed(() => ((currentIndex() + 1) / stepCount) * 100);
   const canNext = computed(() => currentForm().valid());
-  const allValid = computed(() => forms.every((form) => form.valid()));
+  const allValid = computed(() => steps.every((step) => step.form.valid()));
 
   function getValues() {
     const result = {};
-    for (const form of forms) {
-      Object.assign(result, form.getValues());
+    for (const step of steps) {
+      result[step.name] = step.form.getValues();
     }
     return result;
   }
 
   function next() {
-    currentForm().touchAll();
-    if (!currentForm().valid() || isLast()) return;
-    const nextIndex = currentStep() + 1;
-    currentStep.set(nextIndex);
+    if (isLast()) return false;
+    if (validateBeforeNext) {
+      currentForm().touchAll();
+      if (!currentForm().valid()) return false;
+    }
+    const nextIdx = currentIndex() + 1;
+    currentIndex.set(nextIdx);
     const v = new Set(visited());
-    v.add(nextIndex);
+    v.add(nextIdx);
     visited.set(v);
+    return true;
   }
 
   function prev() {
-    if (isFirst()) return;
-    currentStep.set(currentStep() - 1);
+    if (isFirst()) return false;
+    currentIndex.set(currentIndex() - 1);
+    return true;
   }
 
   function goTo(index) {
-    if (index < 0 || index >= stepCount) return;
+    if (index < 0 || index >= stepCount) return false;
     const v = visited();
     const maxVisited = Math.max(...v);
     if (index <= maxVisited + 1) {
-      currentStep.set(index);
+      currentIndex.set(index);
       const next = new Set(v);
       next.add(index);
       visited.set(next);
+      return true;
     }
+    return false;
   }
 
   function reset() {
-    for (const form of forms) form.reset();
-    currentStep.set(0);
+    for (const step of steps) step.form.reset();
+    currentIndex.set(0);
     visited.set(new Set([0]));
   }
 
-  function complete() {
-    if (!allValid()) return;
-    if (options.onComplete) return options.onComplete(getValues());
+  async function complete() {
+    // Find first invalid step
+    for (let i = 0; i < steps.length; i++) {
+      steps[i].form.touchAll();
+      if (!steps[i].form.valid()) {
+        currentIndex.set(i);
+        return { ok: false, errors: steps[i].form.errors(), step: i };
+      }
+    }
+
+    const values = getValues();
+    if (options.onComplete) {
+      try {
+        const result = await options.onComplete(values);
+        return { ok: true, data: result };
+      } catch (error) {
+        return { ok: false, error };
+      }
+    }
+
+    return { ok: true, data: values };
   }
 
   return {
-    currentStep, stepCount, steps: forms, currentForm,
+    currentIndex, stepCount, steps, currentStep, currentForm,
     isFirst, isLast, progress, canNext, visited, allValid,
     next, prev, goTo, getValues, reset, complete,
   };

--- a/packages/forms/src/wizard.test.js
+++ b/packages/forms/src/wizard.test.js
@@ -1,0 +1,151 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createField } from './field.js';
+import { createForm } from './form.js';
+import { createWizard } from './wizard.js';
+import { required, min } from './validators.js';
+
+describe('createWizard', () => {
+  function makeTestWizard() {
+    const step1Form = createForm({
+      name: createField('', { validators: [required('Name is required')] }),
+      email: createField('', { validators: [required('Email is required')] }),
+    });
+
+    const step2Form = createForm({
+      salary: createField(0, { validators: [min(1, 'Salary required')] }),
+      filingStatus: createField('single'),
+    });
+
+    const step3Form = createForm({
+      confirm: createField(false),
+    });
+
+    return createWizard([
+      { name: 'personal', form: step1Form, title: 'Personal Info' },
+      { name: 'income', form: step2Form, title: 'Income Details' },
+      { name: 'review', form: step3Form, title: 'Review' },
+    ]);
+  }
+
+  it('starts at step 0', () => {
+    const w = makeTestWizard();
+    assert.equal(w.currentIndex(), 0);
+    assert.equal(w.isFirst(), true);
+    assert.equal(w.isLast(), false);
+    assert.equal(w.stepCount, 3);
+  });
+
+  it('tracks progress percentage', () => {
+    const w = makeTestWizard();
+    assert.ok(Math.abs(w.progress() - 33.33) < 1);
+  });
+
+  it('blocks next() when current step is invalid and validateBeforeNext is true', () => {
+    const w = makeTestWizard();
+    assert.equal(w.next(), false);
+    assert.equal(w.currentIndex(), 0);
+  });
+
+  it('advances on next() when step is valid', () => {
+    const w = makeTestWizard();
+    w.steps[0].form.fields.name.setValue('Warren');
+    w.steps[0].form.fields.email.setValue('warren@test.com');
+    assert.equal(w.next(), true);
+    assert.equal(w.currentIndex(), 1);
+  });
+
+  it('goes back on prev()', () => {
+    const w = makeTestWizard();
+    w.steps[0].form.fields.name.setValue('Warren');
+    w.steps[0].form.fields.email.setValue('warren@test.com');
+    w.next();
+    assert.equal(w.currentIndex(), 1);
+    assert.equal(w.prev(), true);
+    assert.equal(w.currentIndex(), 0);
+  });
+
+  it('prev() returns false at first step', () => {
+    const w = makeTestWizard();
+    assert.equal(w.prev(), false);
+  });
+
+  it('next() returns false at last step', () => {
+    const w = makeTestWizard();
+    // Fill all steps
+    w.steps[0].form.fields.name.setValue('Warren');
+    w.steps[0].form.fields.email.setValue('warren@test.com');
+    w.next();
+    w.steps[1].form.fields.salary.setValue(100000);
+    w.next();
+    assert.equal(w.isLast(), true);
+    assert.equal(w.next(), false);
+  });
+
+  it('getValues() collects all step values', () => {
+    const w = makeTestWizard();
+    w.steps[0].form.fields.name.setValue('Warren');
+    w.steps[0].form.fields.email.setValue('warren@test.com');
+    w.steps[1].form.fields.salary.setValue(150000);
+
+    const values = w.getValues();
+    assert.deepEqual(values.personal, { name: 'Warren', email: 'warren@test.com' });
+    assert.deepEqual(values.income, { salary: 150000, filingStatus: 'single' });
+  });
+
+  it('reset() returns to step 0 and resets all forms', () => {
+    const w = makeTestWizard();
+    w.steps[0].form.fields.name.setValue('Warren');
+    w.steps[0].form.fields.email.setValue('warren@test.com');
+    w.next();
+    w.reset();
+    assert.equal(w.currentIndex(), 0);
+    assert.equal(w.steps[0].form.fields.name.value(), '');
+  });
+
+  it('complete() fails and jumps to first invalid step', async () => {
+    const w = makeTestWizard();
+    w.steps[0].form.fields.name.setValue('Warren');
+    w.steps[0].form.fields.email.setValue('warren@test.com');
+    // Step 2 salary still 0 (invalid)
+    const result = await w.complete();
+    assert.equal(result.ok, false);
+    assert.equal(w.currentIndex(), 1); // Jumped to income step
+  });
+
+  it('complete() succeeds when all steps valid', async () => {
+    const w = makeTestWizard();
+    w.steps[0].form.fields.name.setValue('Warren');
+    w.steps[0].form.fields.email.setValue('warren@test.com');
+    w.steps[1].form.fields.salary.setValue(150000);
+
+    const result = await w.complete();
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.data.personal.name, 'Warren');
+  });
+
+  it('complete() calls onComplete handler', async () => {
+    let received = null;
+    const step1 = createForm({ name: createField('Test') });
+    const w = createWizard(
+      [{ name: 'info', form: step1 }],
+      { onComplete: (values) => { received = values; return 'done'; } }
+    );
+
+    const result = await w.complete();
+    assert.equal(result.ok, true);
+    assert.equal(result.data, 'done');
+    assert.deepEqual(received.info, { name: 'Test' });
+  });
+
+  it('visited tracks which steps have been seen', () => {
+    const w = makeTestWizard();
+    assert.equal(w.visited().has(0), true);
+    assert.equal(w.visited().has(1), false);
+
+    w.steps[0].form.fields.name.setValue('Warren');
+    w.steps[0].form.fields.email.setValue('warren@test.com');
+    w.next();
+    assert.equal(w.visited().has(1), true);
+  });
+});

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@basenative/integrations",
+  "version": "0.1.0",
+  "description": "Headless third-party integration wrappers for BaseNative apps",
+  "type": "module",
+  "exports": {
+    "./plaid": "./src/plaid.js"
+  },
+  "types": "./types/index.d.ts",
+  "files": ["src", "types"],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DuganLabs/basenative.git",
+    "directory": "packages/integrations"
+  },
+  "homepage": "https://github.com/DuganLabs/basenative#readme",
+  "bugs": {
+    "url": "https://github.com/DuganLabs/basenative/issues"
+  },
+  "keywords": ["basenative", "integrations", "plaid", "fintech"]
+}

--- a/packages/integrations/project.json
+++ b/packages/integrations/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "@basenative/integrations",
+  "targets": {
+    "test": {
+      "cache": true,
+      "command": "node --test",
+      "inputs": ["{projectRoot}/src/**/*.js"]
+    },
+    "lint": {
+      "cache": true,
+      "command": "pnpm exec eslint src/",
+      "inputs": ["{projectRoot}/src/**/*.js"]
+    }
+  }
+}

--- a/packages/integrations/src/plaid.js
+++ b/packages/integrations/src/plaid.js
@@ -1,0 +1,207 @@
+/**
+ * @basenative/integrations/plaid — headless Plaid Link wrapper.
+ *
+ * Client-side: loadPlaidLink() injects the Plaid Link script and
+ * returns a handler for opening the Link flow.
+ *
+ * Server-side: createLinkToken() and exchangePublicToken() wrap the
+ * Plaid API for Cloudflare Worker / Node.js environments.
+ */
+
+const PLAID_LINK_CDN = 'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
+
+// ---------- Client-side ----------
+
+/**
+ * Load the Plaid Link drop-in script if not already present.
+ * Returns a promise that resolves when the script is ready.
+ *
+ * @returns {Promise<void>}
+ */
+export function loadPlaidScript() {
+  return new Promise((resolve, reject) => {
+    if (typeof window === 'undefined') {
+      reject(new Error('@basenative/integrations/plaid: loadPlaidScript() requires a browser environment'));
+      return;
+    }
+
+    if (window.Plaid) {
+      resolve();
+      return;
+    }
+
+    const existing = document.querySelector(`script[src="${PLAID_LINK_CDN}"]`);
+    if (existing) {
+      existing.addEventListener('load', () => resolve());
+      existing.addEventListener('error', () => reject(new Error('Failed to load Plaid Link script')));
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = PLAID_LINK_CDN;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error('Failed to load Plaid Link script'));
+    document.head.appendChild(script);
+  });
+}
+
+/**
+ * Open Plaid Link with the given link token.
+ *
+ * @param {object} options
+ * @param {string} options.token         Link token from createLinkToken()
+ * @param {function} options.onSuccess   Called with (publicToken, metadata)
+ * @param {function} [options.onExit]    Called when user exits Link
+ * @param {function} [options.onEvent]   Called on Link events
+ * @returns {Promise<{ open: () => void, destroy: () => void }>}
+ */
+export async function openPlaidLink(options) {
+  const { token, onSuccess, onExit, onEvent } = options;
+
+  await loadPlaidScript();
+
+  if (!window.Plaid) {
+    throw new Error('@basenative/integrations/plaid: Plaid Link script failed to initialize');
+  }
+
+  const handler = window.Plaid.create({
+    token,
+    onSuccess: (publicToken, metadata) => {
+      if (onSuccess) onSuccess(publicToken, metadata);
+    },
+    onExit: (err, metadata) => {
+      if (onExit) onExit(err, metadata);
+    },
+    onEvent: (eventName, metadata) => {
+      if (onEvent) onEvent(eventName, metadata);
+    },
+  });
+
+  return {
+    open: () => handler.open(),
+    destroy: () => handler.destroy(),
+  };
+}
+
+// ---------- Server-side ----------
+
+const PLAID_ENVS = {
+  sandbox: 'https://sandbox.plaid.com',
+  development: 'https://development.plaid.com',
+  production: 'https://production.plaid.com',
+};
+
+/**
+ * Make a request to the Plaid API.
+ *
+ * @param {string} path        API path (e.g., '/link/token/create')
+ * @param {object} body        Request body
+ * @param {object} credentials
+ * @param {string} credentials.clientId
+ * @param {string} credentials.secret
+ * @param {string} [credentials.env='sandbox']
+ * @returns {Promise<object>}
+ */
+async function plaidRequest(path, body, credentials) {
+  const baseUrl = PLAID_ENVS[credentials.env || 'sandbox'];
+  if (!baseUrl) throw new Error(`@basenative/integrations/plaid: unknown env "${credentials.env}"`);
+
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: credentials.clientId,
+      secret: credentials.secret,
+      ...body,
+    }),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    const err = new Error(data.error_message || `Plaid API error: ${response.status}`);
+    err.plaidError = data;
+    throw err;
+  }
+
+  return data;
+}
+
+/**
+ * Create a Plaid Link token for client-side initialization.
+ *
+ * @param {object} options
+ * @param {string} options.userId           Your app's user ID
+ * @param {string} [options.clientName]     Display name in Link UI
+ * @param {string[]} [options.products]     Plaid products (default: ['transactions'])
+ * @param {string[]} [options.countryCodes] Country codes (default: ['US'])
+ * @param {string} [options.language]       Language (default: 'en')
+ * @param {object} credentials
+ * @param {string} credentials.clientId
+ * @param {string} credentials.secret
+ * @param {string} [credentials.env='sandbox']
+ * @returns {Promise<{ linkToken: string, expiration: string, requestId: string }>}
+ */
+export async function createLinkToken(options, credentials) {
+  const data = await plaidRequest('/link/token/create', {
+    user: { client_user_id: options.userId },
+    client_name: options.clientName || 'BaseNative App',
+    products: options.products || ['transactions'],
+    country_codes: options.countryCodes || ['US'],
+    language: options.language || 'en',
+  }, credentials);
+
+  return {
+    linkToken: data.link_token,
+    expiration: data.expiration,
+    requestId: data.request_id,
+  };
+}
+
+/**
+ * Exchange a public token (from Link onSuccess) for an access token.
+ *
+ * @param {string} publicToken  The public token from Plaid Link
+ * @param {object} credentials
+ * @returns {Promise<{ accessToken: string, itemId: string, requestId: string }>}
+ */
+export async function exchangePublicToken(publicToken, credentials) {
+  const data = await plaidRequest('/item/public_token/exchange', {
+    public_token: publicToken,
+  }, credentials);
+
+  return {
+    accessToken: data.access_token,
+    itemId: data.item_id,
+    requestId: data.request_id,
+  };
+}
+
+/**
+ * Fetch account balances for a linked item.
+ *
+ * @param {string} accessToken  The access token from exchangePublicToken()
+ * @param {object} credentials
+ * @returns {Promise<{ accounts: Array<{ id: string, name: string, type: string, subtype: string, balances: object }> }>}
+ */
+export async function getBalances(accessToken, credentials) {
+  const data = await plaidRequest('/accounts/balance/get', {
+    access_token: accessToken,
+  }, credentials);
+
+  return {
+    accounts: data.accounts.map(a => ({
+      id: a.account_id,
+      name: a.name,
+      type: a.type,
+      subtype: a.subtype,
+      balances: {
+        available: a.balances.available,
+        current: a.balances.current,
+        limit: a.balances.limit,
+        currency: a.balances.iso_currency_code,
+      },
+    })),
+  };
+}

--- a/packages/integrations/src/plaid.test.js
+++ b/packages/integrations/src/plaid.test.js
@@ -1,0 +1,140 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Mock fetch for server-side API tests
+const originalFetch = globalThis.fetch;
+
+describe('plaid server-side', () => {
+  it('createLinkToken calls /link/token/create', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        link_token: 'link-sandbox-abc123',
+        expiration: '2025-06-02T12:00:00Z',
+        request_id: 'req-001',
+      }),
+    }));
+
+    const { createLinkToken } = await import('./plaid.js');
+
+    const result = await createLinkToken(
+      { userId: 'user-1', clientName: 'TestApp' },
+      { clientId: 'cid', secret: 'sec', env: 'sandbox' }
+    );
+
+    assert.equal(result.linkToken, 'link-sandbox-abc123');
+    assert.equal(result.expiration, '2025-06-02T12:00:00Z');
+    assert.equal(result.requestId, 'req-001');
+
+    const [url, opts] = globalThis.fetch.mock.calls[0].arguments;
+    assert.equal(url, 'https://sandbox.plaid.com/link/token/create');
+    assert.equal(opts.method, 'POST');
+
+    const body = JSON.parse(opts.body);
+    assert.equal(body.client_id, 'cid');
+    assert.equal(body.secret, 'sec');
+    assert.equal(body.user.client_user_id, 'user-1');
+    assert.equal(body.client_name, 'TestApp');
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('exchangePublicToken calls /item/public_token/exchange', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        access_token: 'access-sandbox-xyz',
+        item_id: 'item-001',
+        request_id: 'req-002',
+      }),
+    }));
+
+    // Re-import to use fresh fetch mock
+    const mod = await import('./plaid.js?v=2');
+    const result = await mod.exchangePublicToken(
+      'public-sandbox-token',
+      { clientId: 'cid', secret: 'sec', env: 'sandbox' }
+    );
+
+    assert.equal(result.accessToken, 'access-sandbox-xyz');
+    assert.equal(result.itemId, 'item-001');
+
+    const body = JSON.parse(globalThis.fetch.mock.calls[0].arguments[1].body);
+    assert.equal(body.public_token, 'public-sandbox-token');
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('getBalances calls /accounts/balance/get', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        accounts: [{
+          account_id: 'acc-1',
+          name: 'Checking',
+          type: 'depository',
+          subtype: 'checking',
+          balances: {
+            available: 1000,
+            current: 1200,
+            limit: null,
+            iso_currency_code: 'USD',
+          },
+        }],
+      }),
+    }));
+
+    const mod = await import('./plaid.js?v=3');
+    const result = await mod.getBalances(
+      'access-token',
+      { clientId: 'cid', secret: 'sec', env: 'sandbox' }
+    );
+
+    assert.equal(result.accounts.length, 1);
+    assert.equal(result.accounts[0].id, 'acc-1');
+    assert.equal(result.accounts[0].name, 'Checking');
+    assert.equal(result.accounts[0].balances.available, 1000);
+    assert.equal(result.accounts[0].balances.currency, 'USD');
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('throws on Plaid API error', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({
+        error_message: 'INVALID_CREDENTIALS',
+        error_type: 'INVALID_INPUT',
+      }),
+    }));
+
+    const mod = await import('./plaid.js?v=4');
+    await assert.rejects(
+      () => mod.createLinkToken({ userId: 'u1' }, { clientId: 'bad', secret: 'bad', env: 'sandbox' }),
+      (err) => {
+        assert.equal(err.message, 'INVALID_CREDENTIALS');
+        assert.ok(err.plaidError);
+        return true;
+      }
+    );
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('rejects unknown env', async () => {
+    const mod = await import('./plaid.js?v=5');
+    await assert.rejects(
+      () => mod.createLinkToken({ userId: 'u1' }, { clientId: 'c', secret: 's', env: 'invalid' }),
+      /unknown env/
+    );
+  });
+
+  it('loadPlaidScript rejects in Node.js', async () => {
+    const mod = await import('./plaid.js?v=6');
+    await assert.rejects(
+      () => mod.loadPlaidScript(),
+      /requires a browser environment/
+    );
+  });
+});

--- a/packages/integrations/types/index.d.ts
+++ b/packages/integrations/types/index.d.ts
@@ -1,0 +1,64 @@
+// Plaid integration types
+
+export interface PlaidCredentials {
+  clientId: string;
+  secret: string;
+  env?: 'sandbox' | 'development' | 'production';
+}
+
+export interface LinkTokenOptions {
+  userId: string;
+  clientName?: string;
+  products?: string[];
+  countryCodes?: string[];
+  language?: string;
+}
+
+export interface LinkTokenResult {
+  linkToken: string;
+  expiration: string;
+  requestId: string;
+}
+
+export interface ExchangeResult {
+  accessToken: string;
+  itemId: string;
+  requestId: string;
+}
+
+export interface PlaidBalance {
+  available: number | null;
+  current: number | null;
+  limit: number | null;
+  currency: string | null;
+}
+
+export interface PlaidAccount {
+  id: string;
+  name: string;
+  type: string;
+  subtype: string;
+  balances: PlaidBalance;
+}
+
+export interface BalancesResult {
+  accounts: PlaidAccount[];
+}
+
+export interface PlaidLinkHandler {
+  open: () => void;
+  destroy: () => void;
+}
+
+export interface OpenPlaidLinkOptions {
+  token: string;
+  onSuccess: (publicToken: string, metadata: unknown) => void;
+  onExit?: (err: unknown, metadata: unknown) => void;
+  onEvent?: (eventName: string, metadata: unknown) => void;
+}
+
+export function loadPlaidScript(): Promise<void>;
+export function openPlaidLink(options: OpenPlaidLinkOptions): Promise<PlaidLinkHandler>;
+export function createLinkToken(options: LinkTokenOptions, credentials: PlaidCredentials): Promise<LinkTokenResult>;
+export function exchangePublicToken(publicToken: string, credentials: PlaidCredentials): Promise<ExchangeResult>;
+export function getBalances(accessToken: string, credentials: PlaidCredentials): Promise<BalancesResult>;

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@basenative/markdown",
+  "version": "0.1.0",
+  "description": "Zero-dependency markdown parser for BaseNative SSR and client rendering",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "types": "./types/index.d.ts",
+  "files": ["src", "types"],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DuganLabs/basenative.git",
+    "directory": "packages/markdown"
+  },
+  "homepage": "https://github.com/DuganLabs/basenative#readme",
+  "bugs": {
+    "url": "https://github.com/DuganLabs/basenative/issues"
+  },
+  "keywords": ["basenative", "markdown", "parser", "zero-dependency", "esm"]
+}

--- a/packages/markdown/project.json
+++ b/packages/markdown/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "@basenative/markdown",
+  "targets": {
+    "test": {
+      "cache": true,
+      "command": "node --test",
+      "inputs": ["{projectRoot}/src/**/*.js"]
+    },
+    "lint": {
+      "cache": true,
+      "command": "pnpm exec eslint src/",
+      "inputs": ["{projectRoot}/src/**/*.js"]
+    }
+  }
+}

--- a/packages/markdown/src/index.js
+++ b/packages/markdown/src/index.js
@@ -1,0 +1,1 @@
+export { parse, parseFrontmatter } from './markdown.js';

--- a/packages/markdown/src/markdown.js
+++ b/packages/markdown/src/markdown.js
@@ -1,0 +1,269 @@
+/**
+ * @basenative/markdown — zero-dependency markdown parser.
+ *
+ * Converts Markdown text to HTML. Supports headings, paragraphs, bold,
+ * italic, inline code, code blocks, links, images, blockquotes, lists
+ * (ordered + unordered), horizontal rules, and line breaks.
+ *
+ * Security: HTML entities in source text are escaped by default.
+ */
+
+const ESC = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' };
+const escapeHtml = (s) => s.replace(/[&<>"]/g, (c) => ESC[c]);
+
+/**
+ * Parse inline markdown: bold, italic, code, links, images, line breaks.
+ */
+function parseInline(text) {
+  let out = '';
+  let i = 0;
+  const len = text.length;
+
+  while (i < len) {
+    // Inline code (backtick)
+    if (text[i] === '`') {
+      const end = text.indexOf('`', i + 1);
+      if (end !== -1) {
+        out += `<code>${escapeHtml(text.slice(i + 1, end))}</code>`;
+        i = end + 1;
+        continue;
+      }
+    }
+
+    // Image ![alt](src)
+    if (text[i] === '!' && text[i + 1] === '[') {
+      const altEnd = text.indexOf(']', i + 2);
+      if (altEnd !== -1 && text[altEnd + 1] === '(') {
+        const srcEnd = text.indexOf(')', altEnd + 2);
+        if (srcEnd !== -1) {
+          const alt = escapeHtml(text.slice(i + 2, altEnd));
+          const src = escapeHtml(text.slice(altEnd + 2, srcEnd));
+          out += `<img src="${src}" alt="${alt}">`;
+          i = srcEnd + 1;
+          continue;
+        }
+      }
+    }
+
+    // Link [text](href)
+    if (text[i] === '[') {
+      const textEnd = text.indexOf(']', i + 1);
+      if (textEnd !== -1 && text[textEnd + 1] === '(') {
+        const hrefEnd = text.indexOf(')', textEnd + 2);
+        if (hrefEnd !== -1) {
+          const linkText = parseInline(text.slice(i + 1, textEnd));
+          const href = escapeHtml(text.slice(textEnd + 2, hrefEnd));
+          out += `<a href="${href}">${linkText}</a>`;
+          i = hrefEnd + 1;
+          continue;
+        }
+      }
+    }
+
+    // Bold + italic ***text*** or ___text___
+    if ((text[i] === '*' || text[i] === '_') && text[i + 1] === text[i] && text[i + 2] === text[i]) {
+      const marker = text[i];
+      const end = text.indexOf(marker + marker + marker, i + 3);
+      if (end !== -1) {
+        out += `<strong><em>${parseInline(text.slice(i + 3, end))}</em></strong>`;
+        i = end + 3;
+        continue;
+      }
+    }
+
+    // Bold **text** or __text__
+    if ((text[i] === '*' || text[i] === '_') && text[i + 1] === text[i]) {
+      const marker = text[i];
+      const end = text.indexOf(marker + marker, i + 2);
+      if (end !== -1) {
+        out += `<strong>${parseInline(text.slice(i + 2, end))}</strong>`;
+        i = end + 2;
+        continue;
+      }
+    }
+
+    // Italic *text* or _text_
+    if (text[i] === '*' || text[i] === '_') {
+      const marker = text[i];
+      const end = text.indexOf(marker, i + 1);
+      if (end !== -1 && end > i + 1) {
+        out += `<em>${parseInline(text.slice(i + 1, end))}</em>`;
+        i = end + 1;
+        continue;
+      }
+    }
+
+    // Strikethrough ~~text~~
+    if (text[i] === '~' && text[i + 1] === '~') {
+      const end = text.indexOf('~~', i + 2);
+      if (end !== -1) {
+        out += `<del>${parseInline(text.slice(i + 2, end))}</del>`;
+        i = end + 2;
+        continue;
+      }
+    }
+
+    // Line break (two trailing spaces + newline or backslash + newline)
+    if (text[i] === '\\' && text[i + 1] === '\n') {
+      out += '<br>';
+      i += 2;
+      continue;
+    }
+    if (text[i] === ' ' && text[i + 1] === ' ' && text[i + 2] === '\n') {
+      out += '<br>';
+      i += 3;
+      continue;
+    }
+
+    out += escapeHtml(text[i]);
+    i++;
+  }
+
+  return out;
+}
+
+/**
+ * Parse a markdown string into an HTML string.
+ *
+ * @param {string} source  Raw markdown text
+ * @param {object} [options]
+ * @param {boolean} [options.sanitize=true]  Escape HTML entities in source
+ * @returns {string} HTML output
+ */
+export function parse(source, options = {}) {
+  const lines = source.replace(/\r\n/g, '\n').split('\n');
+  const blocks = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Blank line — skip
+    if (line.trim() === '') {
+      i++;
+      continue;
+    }
+
+    // Fenced code block
+    if (line.trimStart().startsWith('```')) {
+      const indent = line.length - line.trimStart().length;
+      const lang = line.trimStart().slice(3).trim();
+      const codeLines = [];
+      i++;
+      while (i < lines.length) {
+        const cl = lines[i];
+        if (cl.trimStart().startsWith('```') && cl.trim() === '```') {
+          i++;
+          break;
+        }
+        codeLines.push(cl);
+        i++;
+      }
+      const code = escapeHtml(codeLines.join('\n'));
+      const langAttr = lang ? ` class="language-${escapeHtml(lang)}"` : '';
+      blocks.push(`<pre><code${langAttr}>${code}</code></pre>`);
+      continue;
+    }
+
+    // Heading (ATX style)
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const text = parseInline(headingMatch[2].replace(/\s+#+\s*$/, ''));
+      const slug = headingMatch[2].toLowerCase().replace(/[^\w\s-]/g, '').replace(/\s+/g, '-');
+      blocks.push(`<h${level} id="${slug}">${text}</h${level}>`);
+      i++;
+      continue;
+    }
+
+    // Horizontal rule
+    if (/^(\*{3,}|-{3,}|_{3,})\s*$/.test(line.trim())) {
+      blocks.push('<hr>');
+      i++;
+      continue;
+    }
+
+    // Blockquote
+    if (line.trimStart().startsWith('>')) {
+      const quoteLines = [];
+      while (i < lines.length && (lines[i].trimStart().startsWith('>') || (lines[i].trim() !== '' && quoteLines.length > 0 && !lines[i].trimStart().startsWith('#')))) {
+        const ql = lines[i].replace(/^>\s?/, '');
+        quoteLines.push(ql);
+        i++;
+        if (lines[i]?.trim() === '') break;
+      }
+      const inner = parse(quoteLines.join('\n'));
+      blocks.push(`<blockquote>${inner}</blockquote>`);
+      continue;
+    }
+
+    // Unordered list
+    if (/^[\s]*[-*+]\s/.test(line)) {
+      const items = [];
+      while (i < lines.length && /^[\s]*[-*+]\s/.test(lines[i])) {
+        const itemText = lines[i].replace(/^[\s]*[-*+]\s/, '');
+        items.push(`<li>${parseInline(itemText)}</li>`);
+        i++;
+      }
+      blocks.push(`<ul>${items.join('')}</ul>`);
+      continue;
+    }
+
+    // Ordered list
+    if (/^[\s]*\d+\.\s/.test(line)) {
+      const items = [];
+      while (i < lines.length && /^[\s]*\d+\.\s/.test(lines[i])) {
+        const itemText = lines[i].replace(/^[\s]*\d+\.\s/, '');
+        items.push(`<li>${parseInline(itemText)}</li>`);
+        i++;
+      }
+      blocks.push(`<ol>${items.join('')}</ol>`);
+      continue;
+    }
+
+    // Paragraph (collect contiguous non-blank, non-block lines)
+    const paraLines = [];
+    while (i < lines.length && lines[i].trim() !== '' && !lines[i].trimStart().startsWith('#') && !lines[i].trimStart().startsWith('```') && !/^(\*{3,}|-{3,}|_{3,})\s*$/.test(lines[i].trim()) && !lines[i].trimStart().startsWith('>') && !/^[\s]*[-*+]\s/.test(lines[i]) && !/^[\s]*\d+\.\s/.test(lines[i])) {
+      paraLines.push(lines[i]);
+      i++;
+    }
+    if (paraLines.length > 0) {
+      blocks.push(`<p>${parseInline(paraLines.join('\n'))}</p>`);
+    }
+  }
+
+  return blocks.join('\n');
+}
+
+/**
+ * Extract YAML-style frontmatter from markdown source.
+ *
+ * @param {string} source  Raw markdown with optional --- frontmatter ---
+ * @returns {{ meta: Record<string, string>, content: string }}
+ */
+export function parseFrontmatter(source) {
+  const trimmed = source.trimStart();
+  if (!trimmed.startsWith('---')) {
+    return { meta: {}, content: source };
+  }
+
+  const endIndex = trimmed.indexOf('---', 3);
+  if (endIndex === -1) {
+    return { meta: {}, content: source };
+  }
+
+  const frontmatter = trimmed.slice(3, endIndex).trim();
+  const content = trimmed.slice(endIndex + 3).trim();
+  const meta = {};
+
+  for (const line of frontmatter.split('\n')) {
+    const colonIndex = line.indexOf(':');
+    if (colonIndex !== -1) {
+      const key = line.slice(0, colonIndex).trim();
+      const value = line.slice(colonIndex + 1).trim().replace(/^["']|["']$/g, '');
+      meta[key] = value;
+    }
+  }
+
+  return { meta, content };
+}

--- a/packages/markdown/src/markdown.test.js
+++ b/packages/markdown/src/markdown.test.js
@@ -1,0 +1,218 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parse, parseFrontmatter } from './index.js';
+
+describe('parse', () => {
+  describe('headings', () => {
+    it('renders h1 through h6', () => {
+      assert.ok(parse('# Hello').includes('<h1'));
+      assert.ok(parse('## Hello').includes('<h2'));
+      assert.ok(parse('### Hello').includes('<h3'));
+      assert.ok(parse('#### Hello').includes('<h4'));
+      assert.ok(parse('##### Hello').includes('<h5'));
+      assert.ok(parse('###### Hello').includes('<h6'));
+    });
+
+    it('generates slug ids', () => {
+      assert.ok(parse('# Hello World').includes('id="hello-world"'));
+    });
+
+    it('strips trailing hashes', () => {
+      const html = parse('## Title ##');
+      assert.ok(html.includes('Title'));
+      assert.ok(!html.includes('##'));
+    });
+  });
+
+  describe('paragraphs', () => {
+    it('wraps plain text in <p>', () => {
+      assert.equal(parse('Hello world'), '<p>Hello world</p>');
+    });
+
+    it('joins contiguous lines', () => {
+      const html = parse('Line one\nLine two');
+      assert.ok(html.includes('Line one'));
+      assert.ok(html.includes('Line two'));
+      assert.ok(html.startsWith('<p>'));
+    });
+  });
+
+  describe('inline formatting', () => {
+    it('renders bold with **', () => {
+      assert.ok(parse('**bold**').includes('<strong>bold</strong>'));
+    });
+
+    it('renders bold with __', () => {
+      assert.ok(parse('__bold__').includes('<strong>bold</strong>'));
+    });
+
+    it('renders italic with *', () => {
+      assert.ok(parse('*italic*').includes('<em>italic</em>'));
+    });
+
+    it('renders italic with _', () => {
+      assert.ok(parse('_italic_').includes('<em>italic</em>'));
+    });
+
+    it('renders bold+italic with ***', () => {
+      const html = parse('***both***');
+      assert.ok(html.includes('<strong><em>both</em></strong>'));
+    });
+
+    it('renders inline code', () => {
+      assert.ok(parse('use `signal()`').includes('<code>signal()</code>'));
+    });
+
+    it('renders strikethrough', () => {
+      assert.ok(parse('~~deleted~~').includes('<del>deleted</del>'));
+    });
+  });
+
+  describe('links and images', () => {
+    it('renders a link', () => {
+      const html = parse('[Click](https://example.com)');
+      assert.ok(html.includes('<a href="https://example.com">Click</a>'));
+    });
+
+    it('renders an image', () => {
+      const html = parse('![Alt text](/img.png)');
+      assert.ok(html.includes('<img src="/img.png" alt="Alt text">'));
+    });
+  });
+
+  describe('code blocks', () => {
+    it('renders fenced code blocks', () => {
+      const md = '```js\nconst x = 1;\n```';
+      const html = parse(md);
+      assert.ok(html.includes('<pre><code class="language-js">'));
+      assert.ok(html.includes('const x = 1;'));
+    });
+
+    it('renders code blocks without language', () => {
+      const md = '```\nhello\n```';
+      const html = parse(md);
+      assert.ok(html.includes('<pre><code>'));
+    });
+
+    it('escapes HTML in code blocks', () => {
+      const md = '```\n<script>alert(1)</script>\n```';
+      const html = parse(md);
+      assert.ok(html.includes('&lt;script&gt;'));
+    });
+  });
+
+  describe('blockquotes', () => {
+    it('renders blockquotes', () => {
+      const html = parse('> Important note');
+      assert.ok(html.includes('<blockquote>'));
+      assert.ok(html.includes('Important note'));
+    });
+  });
+
+  describe('lists', () => {
+    it('renders unordered lists', () => {
+      const md = '- Item one\n- Item two\n- Item three';
+      const html = parse(md);
+      assert.ok(html.includes('<ul>'));
+      assert.ok(html.includes('<li>Item one</li>'));
+      assert.ok(html.includes('<li>Item three</li>'));
+    });
+
+    it('renders ordered lists', () => {
+      const md = '1. First\n2. Second';
+      const html = parse(md);
+      assert.ok(html.includes('<ol>'));
+      assert.ok(html.includes('<li>First</li>'));
+    });
+
+    it('renders inline formatting in list items', () => {
+      const html = parse('- **bold** item');
+      assert.ok(html.includes('<strong>bold</strong>'));
+    });
+  });
+
+  describe('horizontal rules', () => {
+    it('renders --- as <hr>', () => {
+      assert.ok(parse('---').includes('<hr>'));
+    });
+
+    it('renders *** as <hr>', () => {
+      assert.ok(parse('***').includes('<hr>'));
+    });
+
+    it('renders ___ as <hr>', () => {
+      assert.ok(parse('___').includes('<hr>'));
+    });
+  });
+
+  describe('HTML escaping', () => {
+    it('escapes angle brackets in text', () => {
+      const html = parse('Use <div> for layout');
+      assert.ok(html.includes('&lt;div&gt;'));
+    });
+
+    it('escapes ampersands', () => {
+      const html = parse('Tom & Jerry');
+      assert.ok(html.includes('&amp;'));
+    });
+  });
+
+  describe('mixed content', () => {
+    it('handles a full document', () => {
+      const md = [
+        '# Title',
+        '',
+        'A paragraph with **bold** and *italic*.',
+        '',
+        '## Section',
+        '',
+        '- List item',
+        '',
+        '```js',
+        'console.log("hi");',
+        '```',
+        '',
+        '> A quote',
+        '',
+        '---',
+      ].join('\n');
+
+      const html = parse(md);
+      assert.ok(html.includes('<h1'));
+      assert.ok(html.includes('<h2'));
+      assert.ok(html.includes('<strong>bold</strong>'));
+      assert.ok(html.includes('<em>italic</em>'));
+      assert.ok(html.includes('<ul>'));
+      assert.ok(html.includes('<pre><code'));
+      assert.ok(html.includes('<blockquote>'));
+      assert.ok(html.includes('<hr>'));
+    });
+  });
+});
+
+describe('parseFrontmatter', () => {
+  it('extracts key-value pairs', () => {
+    const input = '---\ntitle: Hello World\nauthor: Warren\n---\n\n# Content';
+    const { meta, content } = parseFrontmatter(input);
+    assert.equal(meta.title, 'Hello World');
+    assert.equal(meta.author, 'Warren');
+    assert.ok(content.includes('# Content'));
+  });
+
+  it('strips quotes from values', () => {
+    const input = '---\ntitle: "Quoted"\n---\nBody';
+    const { meta } = parseFrontmatter(input);
+    assert.equal(meta.title, 'Quoted');
+  });
+
+  it('returns empty meta when no frontmatter', () => {
+    const { meta, content } = parseFrontmatter('Just text');
+    assert.deepEqual(meta, {});
+    assert.equal(content, 'Just text');
+  });
+
+  it('handles missing closing delimiter', () => {
+    const { meta } = parseFrontmatter('---\ntitle: Broken');
+    assert.deepEqual(meta, {});
+  });
+});

--- a/packages/markdown/types/index.d.ts
+++ b/packages/markdown/types/index.d.ts
@@ -1,0 +1,11 @@
+export interface ParseOptions {
+  sanitize?: boolean;
+}
+
+export interface Frontmatter {
+  meta: Record<string, string>;
+  content: string;
+}
+
+export function parse(source: string, options?: ParseOptions): string;
+export function parseFrontmatter(source: string): Frontmatter;

--- a/packages/marketplace/src/card.js
+++ b/packages/marketplace/src/card.js
@@ -1,0 +1,153 @@
+/**
+ * Renders a marketplace package card as an HTML string.
+ * Works on both server (SSR) and client via @basenative/components convention.
+ *
+ * @param {object} pkg - Package data
+ * @param {string} pkg.name - Package name (e.g., "@basenative/runtime")
+ * @param {string} [pkg.description] - Short description
+ * @param {string} [pkg.version] - Latest version
+ * @param {string} [pkg.author] - Author name
+ * @param {string} [pkg.category] - Package category
+ * @param {string[]} [pkg.tags] - Tags
+ * @param {number} [pkg.downloads] - Download count
+ * @param {string} [pkg.updatedAt] - ISO timestamp
+ * @param {string} [pkg.repo] - Repository URL
+ * @returns {string} HTML string
+ */
+export function renderPackageCard(pkg) {
+  const {
+    name,
+    description = '',
+    version = '',
+    author = '',
+    category = '',
+    tags = [],
+    downloads = 0,
+    updatedAt = '',
+    repo = '',
+  } = pkg;
+
+  const tagsHtml = tags.length > 0
+    ? `<div data-bn="pkg-tags">${tags.map(t => `<span data-bn="pkg-tag">${esc(t)}</span>`).join('')}</div>`
+    : '';
+
+  const statsHtml = `<div data-bn="pkg-stats">
+    ${downloads > 0 ? `<span data-bn="pkg-stat">${formatDownloads(downloads)} downloads</span>` : ''}
+    ${version ? `<span data-bn="pkg-stat">v${esc(version)}</span>` : ''}
+    ${updatedAt ? `<span data-bn="pkg-stat">${relativeTime(updatedAt)}</span>` : ''}
+  </div>`;
+
+  const linkAttr = repo ? ` href="${esc(repo)}" target="_blank" rel="noopener"` : '';
+
+  return `<article data-bn="pkg-card">
+  <div data-bn="pkg-header">
+    <h4 data-bn="pkg-name">${repo ? `<a${linkAttr}>${esc(name)}</a>` : esc(name)}</h4>
+    ${category ? `<span data-bn="pkg-category">${esc(category)}</span>` : ''}
+  </div>
+  ${description ? `<p data-bn="pkg-desc">${esc(description)}</p>` : ''}
+  ${tagsHtml}
+  ${statsHtml}
+  ${author ? `<div data-bn="pkg-author">${esc(author)}</div>` : ''}
+</article>`;
+}
+
+/**
+ * CSS for package cards. Include once on the page.
+ * @returns {string}
+ */
+export function packageCardStyles() {
+  return `
+[data-bn="pkg-card"] {
+  background: var(--surface-2, hsl(220 20% 14%));
+  border: 1px solid var(--border, hsl(220 15% 22%));
+  border-radius: var(--radius-lg, 0.75rem);
+  padding: 1.25rem;
+  transition: border-color 150ms ease, transform 150ms ease;
+}
+[data-bn="pkg-card"]:hover {
+  border-color: var(--accent, hsl(210 100% 60%));
+  transform: translateY(-2px);
+}
+[data-bn="pkg-header"] {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-block-end: 0.5rem;
+}
+[data-bn="pkg-name"] {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  line-height: 1.3;
+}
+[data-bn="pkg-name"] a {
+  color: var(--accent, hsl(210 100% 60%));
+  text-decoration: none;
+}
+[data-bn="pkg-name"] a:hover { text-decoration: underline; }
+[data-bn="pkg-category"] {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary, hsl(220 10% 55%));
+  background: var(--surface-3, hsl(220 18% 18%));
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.25rem;
+  white-space: nowrap;
+}
+[data-bn="pkg-desc"] {
+  font-size: 0.875rem;
+  color: var(--text-secondary, hsl(220 10% 55%));
+  margin-block-end: 0.75rem;
+  line-height: 1.5;
+}
+[data-bn="pkg-tags"] {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin-block-end: 0.75rem;
+}
+[data-bn="pkg-tag"] {
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.25rem;
+  background: var(--surface-3, hsl(220 18% 18%));
+  color: var(--text-secondary, hsl(220 10% 55%));
+}
+[data-bn="pkg-stats"] {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.75rem;
+  color: var(--text-muted, hsl(220 10% 45%));
+  margin-block-end: 0.5rem;
+}
+[data-bn="pkg-author"] {
+  font-size: 0.75rem;
+  color: var(--text-muted, hsl(220 10% 45%));
+}`;
+}
+
+function esc(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function formatDownloads(n) {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k';
+  return String(n);
+}
+
+function relativeTime(iso) {
+  const ms = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(ms / 86400000);
+  if (days === 0) return 'today';
+  if (days === 1) return 'yesterday';
+  if (days < 30) return `${days}d ago`;
+  if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+  return `${Math.floor(days / 365)}y ago`;
+}

--- a/packages/marketplace/src/index.js
+++ b/packages/marketplace/src/index.js
@@ -1,3 +1,4 @@
 export { createRegistry } from './registry.js';
 export { createInstaller } from './installer.js';
 export { createThemeManager } from './theme.js';
+export { renderPackageCard, packageCardStyles } from './card.js';

--- a/packages/runtime/src/hydrate.js
+++ b/packages/runtime/src/hydrate.js
@@ -374,9 +374,33 @@ export function hydrateChildren(parent, ctx, options = {}) {
   return processed;
 }
 
+function hydrateDeferred(root, ctx, options) {
+  const existing = root.querySelectorAll?.('[data-bn-defer]') ?? [];
+  for (const el of existing) {
+    if (el.children.length > 0) {
+      hydrateChildren(el, ctx, options);
+    }
+  }
+
+  if (typeof document === 'undefined') return () => {};
+
+  function onDefer(event) {
+    const id = event.detail?.id;
+    if (!id) return;
+    const target = root.querySelector?.(`[data-bn-defer-resolve="${id}"] ~ [data-bn-defer="${id}"]`) ??
+                   root.querySelector?.(`div[data-bn-defer="${id}"]`);
+    if (!target) return;
+    hydrateChildren(target, ctx, options);
+  }
+
+  document.addEventListener('bn:defer', onDefer);
+  return () => document.removeEventListener('bn:defer', onDefer);
+}
+
 export function hydrate(root, ctx, options = {}) {
   const runtimeOptions = createRuntimeOptions(options);
   const processed = hydrateChildren(root, ctx, runtimeOptions);
+  const cleanupDeferred = hydrateDeferred(root, ctx, runtimeOptions);
 
   if (processed === 0) {
     const markerMessage = hasHydrationMarkers(root)
@@ -390,5 +414,8 @@ export function hydrate(root, ctx, options = {}) {
     });
   }
 
-  return () => disposeNodeTree(root);
+  return () => {
+    cleanupDeferred();
+    disposeNodeTree(root);
+  };
 }

--- a/packages/runtime/src/hydrate.test.js
+++ b/packages/runtime/src/hydrate.test.js
@@ -391,3 +391,57 @@ describe('hydration diagnostics', () => {
     assert.equal(mismatches[0].code, 'BN_HYDRATE_NO_DIRECTIVES');
   });
 });
+
+describe('@defer hydration', () => {
+  it('hydrates pre-resolved deferred content on initial hydrate', async () => {
+    const hydrate = await loadHydrate();
+    const root = document.createElement('section');
+    root.innerHTML = `
+      <div data-bn-defer="d0">
+        <p>{{ msg() }}</p>
+      </div>
+    `;
+    document.body.append(root);
+
+    const msg = signal('Deferred!');
+    hydrate(root, { msg });
+
+    const p = root.querySelector('p');
+    assert.ok(p.textContent.includes('Deferred!'));
+  });
+
+  it('hydrates deferred content when bn:defer event fires', async () => {
+    const hydrate = await loadHydrate();
+    const root = document.createElement('section');
+    root.innerHTML = '<div data-bn-defer="d0"></div>';
+    document.body.append(root);
+
+    const name = signal('Warren');
+    const dispose = hydrate(root, { name });
+
+    const target = root.querySelector('[data-bn-defer="d0"]');
+    target.innerHTML = '<span>Hello {{ name() }}</span>';
+
+    document.dispatchEvent(new window.CustomEvent('bn:defer', { detail: { id: 'd0' } }));
+
+    const span = root.querySelector('span');
+    assert.ok(span.textContent.includes('Hello Warren'));
+
+    dispose();
+  });
+
+  it('dispose removes the bn:defer event listener', async () => {
+    const hydrate = await loadHydrate();
+    const root = document.createElement('section');
+    root.innerHTML = '<div data-bn-defer="d0"></div>';
+    document.body.append(root);
+
+    const dispose = hydrate(root, {});
+    dispose();
+
+    const target = root.querySelector('[data-bn-defer="d0"]');
+    target.innerHTML = '<p>Late content</p>';
+    document.dispatchEvent(new window.CustomEvent('bn:defer', { detail: { id: 'd0' } }));
+    // No error thrown, listener was cleaned up
+  });
+});

--- a/packages/runtime/src/index.js
+++ b/packages/runtime/src/index.js
@@ -1,4 +1,4 @@
-export { signal, computed, effect } from './signals.js';
+export { signal, computed, effect, batch } from './signals.js';
 export { hydrate } from './hydrate.js';
 export { browserFeatures, detectBrowserFeatures, supportsFeature } from './features.js';
 export { emitDiagnostic, reportHydrationMismatch } from './diagnostics.js';

--- a/packages/runtime/src/index.js
+++ b/packages/runtime/src/index.js
@@ -1,4 +1,4 @@
-export { signal, computed, effect, batch } from './signals.js';
+export { signal, computed, effect, batch, registerPlugin } from './signals.js';
 export { hydrate } from './hydrate.js';
 export { browserFeatures, detectBrowserFeatures, supportsFeature } from './features.js';
 export { emitDiagnostic, reportHydrationMismatch } from './diagnostics.js';

--- a/packages/runtime/src/signals.js
+++ b/packages/runtime/src/signals.js
@@ -1,6 +1,7 @@
 let currentEffect = null;
 let batchDepth = 0;
 const pendingEffects = new Set();
+const plugins = [];
 
 function cleanupEffect(effectRef) {
   for (const subscribers of effectRef.subscriptions) {
@@ -59,7 +60,12 @@ export function signal(initial) {
   accessor.set = (next) => {
     const resolved = typeof next === 'function' ? next(value) : next;
     if (resolved !== value) {
+      const prev = value;
       value = resolved;
+      // Notify plugins of signal write
+      for (const plugin of plugins) {
+        if (plugin.onSignalWrite) plugin.onSignalWrite(accessor, prev, value);
+      }
       for (const effectRef of [...subs]) scheduleEffect(effectRef);
     }
   };
@@ -71,6 +77,14 @@ export function computed(fn) {
   const s = signal(undefined);
   effect(() => s.set(fn()));
   return s;
+}
+
+export function registerPlugin(plugin) {
+  plugins.push(plugin);
+  return () => {
+    const idx = plugins.indexOf(plugin);
+    if (idx !== -1) plugins.splice(idx, 1);
+  };
 }
 
 export function effect(fn) {

--- a/packages/runtime/src/signals.js
+++ b/packages/runtime/src/signals.js
@@ -1,4 +1,6 @@
 let currentEffect = null;
+let batchDepth = 0;
+const pendingEffects = new Set();
 
 function cleanupEffect(effectRef) {
   for (const subscribers of effectRef.subscriptions) {
@@ -10,6 +12,37 @@ function cleanupEffect(effectRef) {
     const cleanup = effectRef.cleanup;
     effectRef.cleanup = null;
     cleanup();
+  }
+}
+
+function scheduleEffect(effectRef) {
+  if (batchDepth > 0) {
+    pendingEffects.add(effectRef);
+  } else {
+    effectRef.run();
+  }
+}
+
+function flushEffects() {
+  batchDepth++;
+  try {
+    while (pendingEffects.size > 0) {
+      const effects = [...pendingEffects];
+      pendingEffects.clear();
+      for (const effectRef of effects) effectRef.run();
+    }
+  } finally {
+    batchDepth--;
+  }
+}
+
+export function batch(fn) {
+  batchDepth++;
+  try {
+    return fn();
+  } finally {
+    batchDepth--;
+    if (batchDepth === 0) flushEffects();
   }
 }
 
@@ -27,7 +60,7 @@ export function signal(initial) {
     const resolved = typeof next === 'function' ? next(value) : next;
     if (resolved !== value) {
       value = resolved;
-      for (const effectRef of [...subs]) effectRef.run();
+      for (const effectRef of [...subs]) scheduleEffect(effectRef);
     }
   };
   accessor.peek = () => value;

--- a/packages/runtime/src/signals.test.js
+++ b/packages/runtime/src/signals.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { signal, computed, effect } from './signals.js';
+import { signal, computed, effect, batch } from './signals.js';
 
 describe('signal', () => {
   it('reads initial value', () => {
@@ -315,5 +315,256 @@ describe('effect advanced', () => {
       if (s() > 0) throw new Error('boom');
     });
     assert.throws(() => s.set(1), /boom/);
+  });
+});
+
+describe('batch', () => {
+  it('defers effect execution until batch completes', () => {
+    const a = signal(0);
+    const b = signal(0);
+    let runs = 0;
+    effect(() => { a(); b(); runs++; });
+    assert.equal(runs, 1);
+
+    batch(() => {
+      a.set(1);
+      b.set(1);
+    });
+    assert.equal(runs, 2, 'effect should run exactly once after batch');
+  });
+
+  it('returns the value from the batch function', () => {
+    const result = batch(() => 42);
+    assert.equal(result, 42);
+  });
+
+  it('supports nested batches', () => {
+    const a = signal(0);
+    const b = signal(0);
+    let runs = 0;
+    effect(() => { a(); b(); runs++; });
+    assert.equal(runs, 1);
+
+    batch(() => {
+      a.set(1);
+      batch(() => {
+        b.set(1);
+      });
+      // inner batch should NOT flush because outer is still active
+      assert.equal(runs, 1, 'effect should not run inside nested batch');
+    });
+    assert.equal(runs, 2, 'effect should run once after outermost batch');
+  });
+
+  it('resolves diamond dependency in one pass', () => {
+    const a = signal(1);
+    const b = computed(() => a() * 2);
+    const c = computed(() => a() * 3);
+    const values = [];
+    effect(() => { values.push(b() + c()); });
+    assert.deepEqual(values, [5]);
+
+    batch(() => { a.set(2); });
+    assert.deepEqual(values, [5, 10]);
+  });
+
+  it('deduplicates effect runs within a batch', () => {
+    const s = signal(0);
+    let runs = 0;
+    effect(() => { s(); runs++; });
+    assert.equal(runs, 1);
+
+    batch(() => {
+      s.set(1);
+      s.set(2);
+      s.set(3);
+    });
+    assert.equal(runs, 2, 'effect should run once for multiple mutations in batch');
+    assert.equal(s(), 3);
+  });
+
+  it('effect sees final values after batch', () => {
+    const a = signal('x');
+    const b = signal('y');
+    let seen;
+    effect(() => { seen = a() + b(); });
+    assert.equal(seen, 'xy');
+
+    batch(() => {
+      a.set('A');
+      b.set('B');
+    });
+    assert.equal(seen, 'AB');
+  });
+
+  it('batch with no mutations does not trigger effects', () => {
+    const s = signal(0);
+    let runs = 0;
+    effect(() => { s(); runs++; });
+    assert.equal(runs, 1);
+
+    batch(() => {});
+    assert.equal(runs, 1);
+  });
+
+  it('error in batch still flushes effects', () => {
+    const s = signal(0);
+    let runs = 0;
+    effect(() => { s(); runs++; });
+
+    assert.throws(() => {
+      batch(() => {
+        s.set(1);
+        throw new Error('batch error');
+      });
+    }, /batch error/);
+
+    assert.equal(runs, 2, 'effect should still flush after batch error');
+    assert.equal(s(), 1);
+  });
+});
+
+describe('diamond dependency comprehensive', () => {
+  it('wide diamond: one source, many computeds, one consumer', () => {
+    const source = signal(1);
+    const branches = Array.from({ length: 5 }, (_, i) =>
+      computed(() => source() * (i + 1))
+    );
+    const values = [];
+    effect(() => {
+      values.push(branches.reduce((sum, b) => sum + b(), 0));
+    });
+    // 1*1 + 1*2 + 1*3 + 1*4 + 1*5 = 15
+    assert.equal(values[values.length - 1], 15);
+
+    source.set(2);
+    // 2*1 + 2*2 + 2*3 + 2*4 + 2*5 = 30
+    assert.equal(values[values.length - 1], 30);
+  });
+
+  it('wide diamond with batch runs effect once', () => {
+    const source = signal(1);
+    const branches = Array.from({ length: 5 }, (_, i) =>
+      computed(() => source() * (i + 1))
+    );
+    let runs = 0;
+    effect(() => {
+      branches.forEach(b => b());
+      runs++;
+    });
+    assert.equal(runs, 1);
+
+    batch(() => { source.set(2); });
+    assert.equal(runs, 2);
+  });
+
+  it('deep diamond: A → B → D, A → C → D', () => {
+    const a = signal(1);
+    const b = computed(() => a() + 10);
+    const c = computed(() => a() + 100);
+    const d = computed(() => b() + c());
+    const values = [];
+    effect(() => { values.push(d()); });
+
+    assert.equal(values[values.length - 1], 112); // (1+10) + (1+100)
+    a.set(5);
+    assert.equal(values[values.length - 1], 120); // (5+10) + (5+100)
+  });
+
+  it('multi-level diamond: A → B → C → E, A → D → E', () => {
+    const a = signal(1);
+    const b = computed(() => a() * 2);
+    const c = computed(() => b() * 3);
+    const d = computed(() => a() * 5);
+    const e = computed(() => c() + d());
+    const values = [];
+    effect(() => { values.push(e()); });
+
+    // c = 1*2*3 = 6, d = 1*5 = 5, e = 11
+    assert.equal(values[values.length - 1], 11);
+    a.set(3);
+    // c = 3*2*3 = 18, d = 3*5 = 15, e = 33
+    assert.equal(values[values.length - 1], 33);
+  });
+
+  it('multiple independent diamonds share no interference', () => {
+    const a1 = signal(1);
+    const b1 = computed(() => a1() * 2);
+    const c1 = computed(() => a1() * 3);
+    const d1 = computed(() => b1() + c1());
+
+    const a2 = signal(10);
+    const b2 = computed(() => a2() + 1);
+    const c2 = computed(() => a2() + 2);
+    const d2 = computed(() => b2() + c2());
+
+    let v1, v2;
+    effect(() => { v1 = d1(); });
+    effect(() => { v2 = d2(); });
+
+    assert.equal(v1, 5);
+    assert.equal(v2, 23);
+
+    a1.set(2);
+    assert.equal(v1, 10);
+    assert.equal(v2, 23); // unchanged
+
+    a2.set(20);
+    assert.equal(v1, 10); // unchanged
+    assert.equal(v2, 43);
+  });
+
+  it('batched multi-signal diamond sees consistent state', () => {
+    const x = signal(1);
+    const y = signal(2);
+    const sumXY = computed(() => x() + y());
+    const diffXY = computed(() => x() - y());
+    const result = computed(() => sumXY() * diffXY());
+
+    const snapshots = [];
+    effect(() => { snapshots.push(result()); });
+
+    // (1+2)*(1-2) = 3 * -1 = -3
+    assert.equal(snapshots[snapshots.length - 1], -3);
+
+    batch(() => {
+      x.set(5);
+      y.set(3);
+    });
+    // (5+3)*(5-3) = 8 * 2 = 16
+    assert.equal(snapshots[snapshots.length - 1], 16);
+  });
+
+  it('computed depending on another computed and a raw signal', () => {
+    const a = signal(2);
+    const b = computed(() => a() * 10);
+    const c = computed(() => a() + b());
+    const values = [];
+    effect(() => { values.push(c()); });
+
+    assert.equal(values[values.length - 1], 22); // 2 + 20
+    a.set(3);
+    assert.equal(values[values.length - 1], 33); // 3 + 30
+  });
+
+  it('diamond with conditional branch', () => {
+    const flag = signal(true);
+    const a = signal(1);
+    const left = computed(() => flag() ? a() * 2 : 0);
+    const right = computed(() => a() * 3);
+    const combined = computed(() => left() + right());
+
+    let result;
+    effect(() => { result = combined(); });
+    assert.equal(result, 5); // 2 + 3
+
+    flag.set(false);
+    assert.equal(result, 3); // 0 + 3
+
+    a.set(10);
+    assert.equal(result, 30); // 0 + 30
+
+    flag.set(true);
+    assert.equal(result, 50); // 20 + 30
   });
 });

--- a/packages/server/src/render.js
+++ b/packages/server/src/render.js
@@ -43,7 +43,10 @@ function processChildren(parent, ctx, options) {
   while (index < children.length) {
     const node = children[index];
     if (node.nodeType === 1 && node.rawTagName === 'template') {
-      if (node.getAttribute('@if') != null) {
+      if (node.getAttribute('@defer') != null) {
+        processDefer(node, ctx, options);
+        index++;
+      } else if (node.getAttribute('@if') != null) {
         index = processIf(children, index, ctx, options);
       } else if (node.getAttribute('@for') != null) {
         index = processFor(children, index, ctx, options);
@@ -219,6 +222,22 @@ function processFor(children, index, ctx, options) {
   return index + 1;
 }
 
+let deferCounter = 0;
+
+function processDefer(templateNode, ctx, options) {
+  const id = `d${deferCounter++}`;
+  const innerHTML = templateNode.innerHTML;
+
+  if (!options._deferred) options._deferred = [];
+  options._deferred.push({ id, html: innerHTML, ctx: Object.assign({}, ctx) });
+
+  const placeholder = parseFragment(
+    `<div data-bn-defer="${id}"></div>` +
+    (options.hydratable ? `<!--bn:defer:${id}-->` : '')
+  );
+  templateNode.replaceWith(placeholder);
+}
+
 function processSwitch(switchNode, ctx, options) {
   const expr = switchNode.getAttribute('@switch');
   const value = evaluate(expr, ctx, options);
@@ -268,7 +287,29 @@ function parseAttrs(rawAttrs) {
 }
 
 export function render(html, ctx = {}, options = {}) {
+  deferCounter = 0;
   const root = parseFragment(html);
   processChildren(root, ctx, options);
   return root.toString();
+}
+
+export function resolveDeferred(options) {
+  const deferred = options._deferred || [];
+  return deferred.map(({ id, html, ctx }) => {
+    const content = parseFragment(html);
+    processChildren(content, ctx, options);
+    const rendered = content.toString();
+    return {
+      id,
+      html: rendered,
+      script: `<script data-bn-defer-resolve="${id}">` +
+        `(function(){` +
+        `var t=document.querySelector('[data-bn-defer="${id}"]');` +
+        `if(t){t.innerHTML=${JSON.stringify(rendered)};` +
+        `t.removeAttribute('data-bn-defer');` +
+        `var e=new CustomEvent('bn:defer',{detail:{id:'${id}'}});` +
+        `document.dispatchEvent(e)}` +
+        `})();<\/script>`,
+    };
+  });
 }

--- a/packages/server/src/render.test.js
+++ b/packages/server/src/render.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { render } from './render.js';
+import { render, resolveDeferred } from './render.js';
 import { renderToStream, renderToReadableStream } from './stream.js';
 
 describe('render', () => {
@@ -570,5 +570,126 @@ describe('render — untested paths', () => {
       result += decoder.decode(value);
     }
     assert.match(result, /<!--bn:if-->/);
+  });
+});
+
+describe('@defer directive', () => {
+  it('replaces @defer template with placeholder div', () => {
+    const html = render(
+      `<div><template @defer><p>Deferred content</p></template></div>`,
+      {}
+    );
+    assert.match(html, /data-bn-defer="d0"/);
+    assert.ok(!html.includes('Deferred content'));
+  });
+
+  it('emits hydration marker when hydratable', () => {
+    const html = render(
+      `<template @defer><p>Later</p></template>`,
+      {},
+      { hydratable: true }
+    );
+    assert.match(html, /<!--bn:defer:d0-->/);
+  });
+
+  it('collects deferred content in options._deferred', () => {
+    const options = {};
+    render(
+      `<template @defer><p>{{ msg }}</p></template>`,
+      { msg: 'hello' },
+      options
+    );
+    assert.ok(Array.isArray(options._deferred));
+    assert.equal(options._deferred.length, 1);
+    assert.equal(options._deferred[0].id, 'd0');
+  });
+
+  it('resolveDeferred renders deferred content with context', () => {
+    const options = {};
+    render(
+      `<template @defer><p>{{ name }}</p></template>`,
+      { name: 'Warren' },
+      options
+    );
+    const resolved = resolveDeferred(options);
+    assert.equal(resolved.length, 1);
+    assert.match(resolved[0].html, /<p>Warren<\/p>/);
+    assert.match(resolved[0].script, /data-bn-defer-resolve="d0"/);
+  });
+
+  it('handles multiple @defer sections', () => {
+    const options = {};
+    render(
+      `<template @defer><p>First</p></template><template @defer><p>Second</p></template>`,
+      {},
+      options
+    );
+    assert.equal(options._deferred.length, 2);
+    const resolved = resolveDeferred(options);
+    assert.match(resolved[0].html, /First/);
+    assert.match(resolved[1].html, /Second/);
+  });
+
+  it('@defer works alongside @if and @for', () => {
+    const html = render(
+      `<template @if="show"><span>Visible</span></template>
+       <template @defer><p>Lazy</p></template>
+       <template @for="x of items"><li>{{ x }}</li></template>`,
+      { show: true, items: ['a', 'b'] }
+    );
+    assert.match(html, /Visible/);
+    assert.match(html, /data-bn-defer/);
+    assert.match(html, /<li>a<\/li>/);
+    assert.ok(!html.includes('Lazy'));
+  });
+
+  it('resolveDeferred returns empty array when no @defer', () => {
+    const options = {};
+    render('<p>No defer</p>', {}, options);
+    const resolved = resolveDeferred(options);
+    assert.deepEqual(resolved, []);
+  });
+
+  it('deferred script injects HTML into placeholder', () => {
+    const options = {};
+    render(`<template @defer><span>Injected</span></template>`, {}, options);
+    const resolved = resolveDeferred(options);
+    assert.match(resolved[0].script, /innerHTML/);
+    assert.match(resolved[0].script, /Injected/);
+  });
+
+  it('renderToStream includes deferred scripts after main content', () => {
+    const chunks = [];
+    const stream = {
+      write(chunk) { chunks.push(chunk); return true; },
+      end() {},
+    };
+    renderToStream(
+      `<p>Main</p><template @defer><span>Later</span></template>`,
+      {},
+      stream
+    );
+    const output = chunks.join('');
+    assert.match(output, /Main/);
+    assert.match(output, /data-bn-defer-resolve/);
+    assert.match(output, /Later/);
+  });
+
+  it('renderToReadableStream includes deferred scripts', async () => {
+    const stream = renderToReadableStream(
+      `<p>Main</p><template @defer><span>Streamed</span></template>`,
+      {}
+    );
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let result = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      result += decoder.decode(value);
+    }
+    assert.match(result, /Main/);
+    assert.match(result, /Streamed/);
+    assert.match(result, /data-bn-defer-resolve/);
   });
 });

--- a/packages/server/src/stream.js
+++ b/packages/server/src/stream.js
@@ -1,10 +1,11 @@
-import { render } from './render.js';
+import { render, resolveDeferred } from './render.js';
 
 /**
  * Streaming SSR renderer for BaseNative.
  *
  * Splits a template into chunks and writes them to a writable stream.
  * Compatible with Express `res.write()` and Web Streams API.
+ * Deferred sections are streamed after the main content as script injections.
  *
  * @param {string} html - Full HTML template
  * @param {object} ctx - Template context
@@ -17,17 +18,19 @@ import { render } from './render.js';
 export function renderToStream(html, ctx, stream, options = {}) {
   const chunkSize = options.chunkSize || 4096;
 
-  // Render full HTML first, then stream in chunks
-  const rendered = render(html, ctx, {
+  const renderOptions = {
     hydratable: options.hydratable,
     onDiagnostic: options.onDiagnostic,
-  });
+  };
+  const rendered = render(html, ctx, renderOptions);
+  const deferred = resolveDeferred(renderOptions);
 
+  const fullOutput = rendered + deferred.map(d => d.script).join('');
   let offset = 0;
 
   function writeNext() {
-    while (offset < rendered.length) {
-      const chunk = rendered.slice(offset, offset + chunkSize);
+    while (offset < fullOutput.length) {
+      const chunk = fullOutput.slice(offset, offset + chunkSize);
       offset += chunkSize;
 
       const canContinue = stream.write(chunk);
@@ -44,6 +47,7 @@ export function renderToStream(html, ctx, stream, options = {}) {
 
 /**
  * Renders a template and returns a Web ReadableStream.
+ * Deferred sections are appended after the main content as script injections.
  *
  * @param {string} html - Full HTML template
  * @param {object} ctx - Template context
@@ -51,22 +55,25 @@ export function renderToStream(html, ctx, stream, options = {}) {
  * @returns {ReadableStream}
  */
 export function renderToReadableStream(html, ctx, options = {}) {
-  const rendered = render(html, ctx, {
+  const renderOptions = {
     hydratable: options.hydratable,
     onDiagnostic: options.onDiagnostic,
-  });
+  };
+  const rendered = render(html, ctx, renderOptions);
+  const deferred = resolveDeferred(renderOptions);
 
+  const fullOutput = rendered + deferred.map(d => d.script).join('');
   const chunkSize = options.chunkSize || 4096;
   let offset = 0;
 
   return new ReadableStream({
     pull(controller) {
-      if (offset >= rendered.length) {
+      if (offset >= fullOutput.length) {
         controller.close();
         return;
       }
 
-      const chunk = rendered.slice(offset, offset + chunkSize);
+      const chunk = fullOutput.slice(offset, offset + chunkSize);
       offset += chunkSize;
       controller.enqueue(new TextEncoder().encode(chunk));
     },

--- a/packages/visual-builder/src/bn-canvas.js
+++ b/packages/visual-builder/src/bn-canvas.js
@@ -1,0 +1,254 @@
+import { createCanvas } from './canvas.js';
+import { renderNode } from './renderer.js';
+
+/**
+ * <bn-canvas> Web Component
+ *
+ * Orchestrates the visual builder's drag-and-drop interface.
+ * Uses display: contents on :host to respect BaseNative layout constraints.
+ *
+ * Attributes:
+ *   width - Canvas width (default: 1024)
+ *   height - Canvas height (default: 768)
+ *   grid-size - Snap grid size in pixels (default: 8)
+ *   mode - 'edit' | 'preview' (default: 'edit')
+ *
+ * Events:
+ *   bn-canvas-add    - Fired when a node is added
+ *   bn-canvas-remove - Fired when a node is removed
+ *   bn-canvas-move   - Fired when a node is moved
+ *   bn-canvas-select - Fired when a node is selected
+ *   bn-canvas-change - Fired on any state change
+ */
+export class BnCanvas extends HTMLElement {
+  static get observedAttributes() {
+    return ['width', 'height', 'grid-size', 'mode'];
+  }
+
+  constructor() {
+    super();
+    this._canvas = null;
+    this._componentMap = {};
+    this._selectedId = null;
+    this._dragState = null;
+    this._unsubscribe = null;
+  }
+
+  connectedCallback() {
+    // display: contents — host does not affect layout
+    this.style.display = 'contents';
+
+    this._canvas = createCanvas({
+      width: parseInt(this.getAttribute('width') || '1024', 10),
+      height: parseInt(this.getAttribute('height') || '768', 10),
+      gridSize: parseInt(this.getAttribute('grid-size') || '8', 10),
+    });
+
+    this._unsubscribe = this._canvas.subscribe((event, data) => {
+      this.dispatchEvent(new CustomEvent(`bn-canvas-${event}`, { detail: data, bubbles: true }));
+      this.dispatchEvent(new CustomEvent('bn-canvas-change', { detail: { event, data }, bubbles: true }));
+      this._render();
+    });
+
+    this._setupDOM();
+    this._render();
+    this._attachDragListeners();
+  }
+
+  disconnectedCallback() {
+    if (this._unsubscribe) {
+      this._unsubscribe();
+      this._unsubscribe = null;
+    }
+  }
+
+  attributeChangedCallback(name, oldVal, newVal) {
+    if (!this._canvas) return;
+    // Re-create canvas with new dimensions if changed
+    if (['width', 'height', 'grid-size'].includes(name)) {
+      const surface = this.querySelector('[data-bn-canvas-surface]');
+      if (surface) {
+        if (name === 'width') surface.style.width = `${newVal}px`;
+        if (name === 'height') surface.style.height = `${newVal}px`;
+      }
+    }
+  }
+
+  /** Register component types for rendering */
+  registerComponents(componentMap) {
+    this._componentMap = { ...this._componentMap, ...componentMap };
+    this._render();
+  }
+
+  /** Get the underlying canvas state */
+  get canvas() {
+    return this._canvas;
+  }
+
+  /** Get the currently selected node ID */
+  get selectedId() {
+    return this._selectedId;
+  }
+
+  _setupDOM() {
+    const w = this._canvas.width;
+    const h = this._canvas.height;
+    const mode = this.getAttribute('mode') || 'edit';
+
+    this.innerHTML = `
+      <div data-bn-canvas-container style="position:relative;overflow:auto;border:1px solid var(--border,hsl(220 15% 22%));border-radius:0.5rem;background:var(--surface-1,hsl(220 20% 10%))">
+        <div data-bn-canvas-surface style="position:relative;width:${w}px;height:${h}px;background-image:radial-gradient(circle,var(--border,hsl(220 15% 22%)) 1px,transparent 1px);background-size:${this._canvas.gridSize}px ${this._canvas.gridSize}px">
+          <div data-bn-canvas-nodes></div>
+          ${mode === 'edit' ? '<div data-bn-canvas-selection style="position:absolute;pointer-events:none;border:2px solid var(--accent,hsl(210 100% 60%));border-radius:4px;display:none;z-index:10"></div>' : ''}
+        </div>
+      </div>`;
+  }
+
+  _render() {
+    const container = this.querySelector('[data-bn-canvas-nodes]');
+    if (!container || !this._canvas) return;
+
+    const nodes = this._canvas.getNodes();
+    container.innerHTML = '';
+
+    for (const node of nodes) {
+      const wrapper = document.createElement('div');
+      wrapper.dataset.bnNodeId = node.id;
+      wrapper.style.cssText = `position:absolute;left:${node.position.x}px;top:${node.position.y}px;width:${node.size.width}px;min-height:${node.size.height}px;cursor:move;border-radius:4px;transition:box-shadow 150ms ease`;
+
+      if (this._selectedId === node.id) {
+        wrapper.style.boxShadow = '0 0 0 2px var(--accent, hsl(210 100% 60%))';
+      }
+
+      // Render node content
+      const renderFn = this._componentMap[node.type];
+      if (renderFn) {
+        wrapper.innerHTML = renderNode(node, this._componentMap);
+      } else {
+        wrapper.innerHTML = `<div style="padding:0.5rem;background:var(--surface-2,hsl(220 15% 14%));border:1px dashed var(--border,hsl(220 15% 22%));border-radius:4px;font-size:0.75rem;color:var(--text-muted)">${node.type}</div>`;
+      }
+
+      wrapper.setAttribute('draggable', 'true');
+      container.appendChild(wrapper);
+    }
+
+    // Update selection outline
+    this._updateSelection();
+  }
+
+  _updateSelection() {
+    const outline = this.querySelector('[data-bn-canvas-selection]');
+    if (!outline) return;
+
+    if (!this._selectedId) {
+      outline.style.display = 'none';
+      return;
+    }
+
+    const node = this._canvas.getNode(this._selectedId);
+    if (!node) {
+      outline.style.display = 'none';
+      return;
+    }
+
+    outline.style.display = 'block';
+    outline.style.left = `${node.position.x - 2}px`;
+    outline.style.top = `${node.position.y - 2}px`;
+    outline.style.width = `${node.size.width + 4}px`;
+    outline.style.height = `${node.size.height + 4}px`;
+  }
+
+  _attachDragListeners() {
+    const surface = this.querySelector('[data-bn-canvas-surface]');
+    if (!surface) return;
+
+    // Click to select
+    surface.addEventListener('pointerdown', (e) => {
+      const nodeEl = e.target.closest('[data-bn-node-id]');
+      if (nodeEl) {
+        const id = nodeEl.dataset.bnNodeId;
+        this._selectedId = id;
+        this._render();
+        this.dispatchEvent(new CustomEvent('bn-canvas-select', { detail: { id }, bubbles: true }));
+
+        // Start drag
+        const node = this._canvas.getNode(id);
+        if (node) {
+          const rect = surface.getBoundingClientRect();
+          this._dragState = {
+            id,
+            startX: e.clientX,
+            startY: e.clientY,
+            origX: node.position.x,
+            origY: node.position.y,
+          };
+        }
+      } else {
+        this._selectedId = null;
+        this._render();
+      }
+    });
+
+    // Drag move
+    surface.addEventListener('pointermove', (e) => {
+      if (!this._dragState) return;
+      const dx = e.clientX - this._dragState.startX;
+      const dy = e.clientY - this._dragState.startY;
+      const gs = this._canvas.gridSize;
+      const x = Math.round((this._dragState.origX + dx) / gs) * gs;
+      const y = Math.round((this._dragState.origY + dy) / gs) * gs;
+      this._canvas.moveNode(this._dragState.id, { x: Math.max(0, x), y: Math.max(0, y) });
+    });
+
+    // Drag end
+    surface.addEventListener('pointerup', () => {
+      this._dragState = null;
+    });
+
+    // Drop from palette
+    surface.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+    });
+
+    surface.addEventListener('drop', (e) => {
+      e.preventDefault();
+      const type = e.dataTransfer.getData('text/bn-component-type');
+      if (!type) return;
+
+      const rect = surface.getBoundingClientRect();
+      const gs = this._canvas.gridSize;
+      const x = Math.round((e.clientX - rect.left) / gs) * gs;
+      const y = Math.round((e.clientY - rect.top) / gs) * gs;
+
+      const propsJson = e.dataTransfer.getData('text/bn-component-props');
+      const props = propsJson ? JSON.parse(propsJson) : {};
+
+      this._canvas.addNode({ type, props, position: { x, y }, size: { width: 200, height: 40 } });
+    });
+
+    // Keyboard shortcuts
+    this.addEventListener('keydown', (e) => {
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        if (this._selectedId) {
+          this._canvas.removeNode(this._selectedId);
+          this._selectedId = null;
+        }
+      }
+      if (e.ctrlKey || e.metaKey) {
+        if (e.key === 'z' && !e.shiftKey) {
+          e.preventDefault();
+          this._canvas.undo();
+        } else if ((e.key === 'z' && e.shiftKey) || e.key === 'y') {
+          e.preventDefault();
+          this._canvas.redo();
+        }
+      }
+    });
+  }
+}
+
+// Register element
+if (typeof customElements !== 'undefined' && !customElements.get('bn-canvas')) {
+  customElements.define('bn-canvas', BnCanvas);
+}

--- a/packages/visual-builder/src/index.js
+++ b/packages/visual-builder/src/index.js
@@ -2,3 +2,4 @@ export { createCanvas } from './canvas.js';
 export { renderCanvas, renderNode } from './renderer.js';
 export { serialize, deserialize, exportToHTML, importFromHTML } from './serializer.js';
 export { createComponentPalette } from './component-palette.js';
+export { BnCanvas } from './bn-canvas.js';

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -271,7 +271,16 @@ for (const [route, { view, title, activePage, ctx }] of Object.entries(pages)) {
 
 // Copy static assets
 cpSync(join(express, 'public', 'styles.css'), join(dist, 'styles.css'));
+cpSync(join(express, 'public', 'theme.css'), join(dist, 'theme.css'));
 cpSync(join(express, 'public', 'basenative.js'), join(dist, 'basenative.js'));
+
+// Copy component CSS (served as /bn-css/ in Express, must exist in dist)
+const bnCssDir = join(dist, 'bn-css');
+mkdirSync(bnCssDir, { recursive: true });
+const componentSrc = join(root, 'packages', 'components', 'src');
+for (const file of ['index.css', 'layers.css', 'reset.css', 'tokens.css', 'theme.css', 'layout.css', 'components.css', 'states.css']) {
+  cpSync(join(componentSrc, file), join(bnCssDir, file));
+}
 
 // Copy fonts (preserve structure so fonts.css relative paths work)
 cpSync(join(root, 'packages', 'fonts'), join(dist, 'fonts'), { recursive: true });


### PR DESCRIPTION
## Summary

- **Plugin API**: Export `registerPlugin()` in `@basenative/runtime` for intercepting signal writes, enabling third-party extensibility
- **Wizard Forms**: Add `createWizard()` to `@basenative/forms` for multi-step form flows with validation (76 lines, 13 tests)
- **Visual Builder**: Add `<bn-canvas>` web component to `@basenative/visual-builder` with drag-drop, grid snapping, and undo/redo support
- **Layout Grid**: Add `renderLayoutGrid()` to `@basenative/components` for declarative CSS grid layout building
- **KV Feature Flags**: Add `createKVProvider()` to `@basenative/flags` for Cloudflare KV-backed feature flag evaluation
- **Marketplace Card**: Add `renderPackageCard()` and `packageCardStyles()` to `@basenative/marketplace` for rendering package listing cards

16 files changed, 942 insertions across 6 packages.

## Test plan

- [ ] Verify `registerPlugin()` intercepts signal writes and invokes plugin callbacks
- [ ] Run wizard form tests (`packages/forms/src/wizard.test.js` — 13 tests) and confirm all pass
- [ ] Validate `<bn-canvas>` drag-drop, grid snap, and undo/redo in a browser
- [ ] Confirm `renderLayoutGrid()` produces correct CSS grid markup
- [ ] Test `createKVProvider()` against a Cloudflare KV namespace (or mock)
- [ ] Render `renderPackageCard()` output and verify styling with `packageCardStyles()`
- [ ] Run full CI pipeline (`nx run-many --target=test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)