### PR TITLE
Add @basenative/eslint-config + @basenative/tsconfig

### DIFF
--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,0 +1,61 @@
+# @basenative/eslint-config
+
+Shared ESLint flat-config preset for DuganLabs projects. One opinion, one source.
+
+## Install
+
+```bash
+pnpm add -D eslint @basenative/eslint-config
+```
+
+## Use
+
+Pick the preset matching your runtime. In `eslint.config.js`:
+
+```js
+// SPA / browser
+import config from "@basenative/eslint-config/browser";
+export default config;
+
+// Node / scripts
+import config from "@basenative/eslint-config/node";
+export default config;
+
+// Cloudflare Workers / Pages Functions
+import config from "@basenative/eslint-config/worker";
+export default config;
+
+// React
+import config from "@basenative/eslint-config/react";
+export default config;
+```
+
+## Compose
+
+The presets export an array — extend it:
+
+```js
+import base from "@basenative/eslint-config/browser";
+
+export default [
+  ...base,
+  {
+    rules: {
+      "no-console": "warn",
+    },
+  },
+];
+```
+
+## What's in it
+
+- `@eslint/js` recommended set
+- Underscore-prefix exempt for unused vars / args / caught errors
+- `no-eval` / `no-implied-eval` / `no-new-func` (security baseline)
+- `eqeqeq` smart, `no-var`, `prefer-const`
+- Worker preset blocks Node-only globals (`process`, `Buffer`, `__dirname`, `__filename`)
+- Prettier compatibility — formatting rules disabled
+
+## License
+
+Apache-2.0

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@basenative/eslint-config",
+  "version": "0.1.0",
+  "description": "Shared ESLint flat-config for DuganLabs projects — security, hygiene, zero-noise defaults",
+  "type": "module",
+  "exports": {
+    ".":         "./src/index.js",
+    "./browser": "./src/browser.js",
+    "./node":    "./src/node.js",
+    "./worker":  "./src/worker.js",
+    "./react":   "./src/react.js"
+  },
+  "files": ["src"],
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "eslint": ">=9.0.0"
+  },
+  "dependencies": {
+    "@eslint/js": "^10.0.1",
+    "eslint-config-prettier": "^10.1.8",
+    "globals": "^17.4.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DuganLabs/basenative.git",
+    "directory": "packages/eslint-config"
+  },
+  "homepage": "https://github.com/DuganLabs/basenative/tree/main/packages/eslint-config#readme",
+  "keywords": ["basenative", "eslint", "eslint-config", "flat-config", "shared"]
+}

--- a/packages/eslint-config/src/browser.js
+++ b/packages/eslint-config/src/browser.js
@@ -1,0 +1,14 @@
+/* Browser preset — adds browser globals on top of the base config.
+   Use for SPA / Vite / static client code. */
+
+import globals from "globals";
+import base from "./index.js";
+
+export default [
+  ...base,
+  {
+    languageOptions: {
+      globals: { ...globals.browser },
+    },
+  },
+];

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -1,0 +1,47 @@
+/* @basenative/eslint-config — base flat-config preset.
+   Universal rules that apply everywhere (browser, node, workers).
+   Compose with one of the runtime-specific exports for environment globals. */
+
+import js from "@eslint/js";
+import prettier from "eslint-config-prettier";
+
+export default [
+  js.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 2024,
+      sourceType: "module",
+    },
+    rules: {
+      // Allow underscore-prefixed unused — useful for destructuring + caught errors.
+      "no-unused-vars": ["error", {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
+      }],
+      "no-empty": ["error", { allowEmptyCatch: true }],
+      // Security baseline — no codegen-from-strings.
+      "no-eval": "error",
+      "no-implied-eval": "error",
+      "no-new-func": "error",
+      // Hygiene
+      "eqeqeq": ["error", "smart"],
+      "no-var": "error",
+      "prefer-const": ["warn", { destructuring: "all" }],
+    },
+  },
+  // Disable rules that conflict with Prettier — we delegate formatting.
+  prettier,
+  {
+    ignores: [
+      "dist/",
+      "build/",
+      "out/",
+      ".next/",
+      ".vite/",
+      "node_modules/",
+      "coverage/",
+      "*.min.js",
+    ],
+  },
+];

--- a/packages/eslint-config/src/node.js
+++ b/packages/eslint-config/src/node.js
@@ -1,0 +1,13 @@
+/* Node preset — adds Node globals + import hygiene rules. */
+
+import globals from "globals";
+import base from "./index.js";
+
+export default [
+  ...base,
+  {
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
+];

--- a/packages/eslint-config/src/react.js
+++ b/packages/eslint-config/src/react.js
@@ -1,0 +1,25 @@
+/* React preset — browser globals + React-friendly rules.
+   Pure flat-config; assumes consumer brings eslint-plugin-react if they want
+   JSX-specific rules. We keep this minimal to avoid hard React peer-dep. */
+
+import globals from "globals";
+import base from "./index.js";
+
+export default [
+  ...base,
+  {
+    languageOptions: {
+      globals: { ...globals.browser },
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    rules: {
+      "no-unused-vars": ["error", {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^[_A-Z]",  // Allow uppercase (React components) to be unused-imported.
+        caughtErrorsIgnorePattern: "^_",
+      }],
+    },
+  },
+];

--- a/packages/eslint-config/src/worker.js
+++ b/packages/eslint-config/src/worker.js
@@ -1,0 +1,29 @@
+/* Cloudflare Worker preset — Service Worker globals + Worker-friendly rules.
+   Use for Cloudflare Workers and Pages Functions code. */
+
+import globals from "globals";
+import base from "./index.js";
+
+export default [
+  ...base,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.serviceworker,
+        // Workers expose a few extras beyond strict service-worker globals.
+        crypto: "readonly",
+        caches: "readonly",
+        WebAssembly: "readonly",
+      },
+    },
+    rules: {
+      // Workers cannot use most Node APIs; warn about common pitfalls.
+      "no-restricted-globals": ["error",
+        { name: "process", message: "Workers do not have a Node process global. Use env bindings instead." },
+        { name: "Buffer",  message: "Workers do not have Buffer. Use Uint8Array / TextEncoder." },
+        { name: "__dirname", message: "Workers do not have __dirname." },
+        { name: "__filename", message: "Workers do not have __filename." },
+      ],
+    },
+  },
+];

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -1,0 +1,47 @@
+# @basenative/tsconfig
+
+Shared base tsconfigs for DuganLabs projects. Strict, modern, runtime-targeted.
+
+## Install
+
+```bash
+pnpm add -D @basenative/tsconfig
+```
+
+## Use
+
+Pick the variant matching your runtime in `tsconfig.json`:
+
+```json
+{ "extends": "@basenative/tsconfig/base" }
+```
+
+```json
+{ "extends": "@basenative/tsconfig/browser" }
+```
+
+```json
+{ "extends": "@basenative/tsconfig/node" }
+```
+
+```json
+{ "extends": "@basenative/tsconfig/worker" }
+```
+
+```json
+{ "extends": "@basenative/tsconfig/react" }
+```
+
+Then add your own `include` / `exclude` and any project-specific overrides.
+
+## What's in `base`
+
+- `target: ES2022`, `module: ESNext`, `moduleResolution: Bundler`
+- `strict: true` plus the modern strictness extras: `noUncheckedIndexedAccess`, `noImplicitOverride`, `noFallthroughCasesInSwitch`, `exactOptionalPropertyTypes`
+- `verbatimModuleSyntax`, `isolatedModules`, `esModuleInterop`
+- `allowJs: true` (DuganLabs projects mix JS + TS)
+- `skipLibCheck: true`, `forceConsistentCasingInFileNames: true`
+
+## License
+
+Apache-2.0

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "useDefineForClassFields": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "allowJs": true,
+    "checkJs": false
+  }
+}

--- a/packages/tsconfig/browser.json
+++ b/packages/tsconfig/browser.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "preserve"
+  }
+}

--- a/packages/tsconfig/node.json
+++ b/packages/tsconfig/node.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  }
+}

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@basenative/tsconfig",
+  "version": "0.1.0",
+  "description": "Shared base tsconfigs for DuganLabs projects — strict, modern, runtime-targeted",
+  "type": "module",
+  "exports": {
+    ".":         "./base.json",
+    "./base":    "./base.json",
+    "./browser": "./browser.json",
+    "./node":    "./node.json",
+    "./worker":  "./worker.json",
+    "./react":   "./react.json"
+  },
+  "files": ["base.json", "browser.json", "node.json", "worker.json", "react.json"],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DuganLabs/basenative.git",
+    "directory": "packages/tsconfig"
+  },
+  "homepage": "https://github.com/DuganLabs/basenative/tree/main/packages/tsconfig#readme",
+  "keywords": ["basenative", "tsconfig", "typescript", "shared"]
+}

--- a/packages/tsconfig/react.json
+++ b/packages/tsconfig/react.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./browser.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["react", "react-dom"]
+  }
+}

--- a/packages/tsconfig/worker.json
+++ b/packages/tsconfig/worker.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "WebWorker"],
+    "types": ["@cloudflare/workers-types"]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,21 @@ importers:
 
   packages/db: {}
 
+  packages/eslint-config:
+    dependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.0.3)
+      eslint:
+        specifier: '>=9.0.0'
+        version: 10.0.3
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@10.0.3)
+      globals:
+        specifier: ^17.4.0
+        version: 17.4.0
+
   packages/fetch:
     dependencies:
       '@basenative/runtime':
@@ -273,6 +288,8 @@ importers:
         version: 7.1.0
 
   packages/tenant: {}
+
+  packages/tsconfig: {}
 
   packages/upload: {}
 


### PR DESCRIPTION
## Summary

Two foundational shared packages so every DuganLabs project can extend the same lint and TS posture instead of reinventing per-repo.

- **@basenative/eslint-config** — flat-config presets (base, browser, node, worker, react). Worker preset blocks Node-only globals. Prettier-compatible.
- **@basenative/tsconfig** — strict + modern (ES2022, Bundler resolution, exactOptionalPropertyTypes, noUncheckedIndexedAccess). Variants for browser, node, worker, react.

Part of the BaseNative-as-meta-repo program — alongside the org-wide reusable workflows in DuganLabs/.github.

## Test plan
- [ ] \`pnpm install\` clean
- [ ] One sibling project successfully extends @basenative/eslint-config
- [ ] One sibling project successfully extends @basenative/tsconfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)