### PR TITLE
Publish @basenative/* to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,10 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          registry-url: 'https://registry.npmjs.org'
+          # GitHub Packages: open-source projects in DuganLabs publish here
+          # for free; consumers auth with a fine-grained PAT or GITHUB_TOKEN.
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@basenative'
 
       - run: pnpm install --frozen-lockfile
 
@@ -45,5 +48,7 @@ jobs:
           version: pnpm exec changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Changesets reads NODE_AUTH_TOKEN for the publish step. GITHUB_TOKEN
+          # has packages:write within this repo, which is exactly what we need
+          # for @basenative/* on GitHub Packages.
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,5 @@
+# Default registry stays npmjs.org for the wider deps tree.
+# @basenative/* publishes to GitHub Packages — open-source projects in
+# DuganLabs use it for free, consumers auth with a fine-grained PAT.
 registry=https://registry.npmjs.org/
-@basenative:registry=https://registry.npmjs.org/
+@basenative:registry=https://npm.pkg.github.com/

--- a/docs/CONSUMING-FROM-GH-PACKAGES.md
+++ b/docs/CONSUMING-FROM-GH-PACKAGES.md
@@ -1,0 +1,83 @@
+# Consuming `@basenative/*` from GitHub Packages
+
+BaseNative publishes to **GitHub Packages**, not npmjs.org. This is deliberate — open-source projects in the DuganLabs org get unlimited free Actions minutes and bandwidth on GH Packages, so it's the right home for our shared libraries.
+
+## One-time setup (per developer / per CI)
+
+### 1. Create a fine-grained PAT with `read:packages`
+
+`https://github.com/settings/tokens?type=beta` → New token →
+- Resource owner: `DuganLabs`
+- Repository access: All repositories (or specifically the consuming repo)
+- Permissions: **Account permissions → Packages: read**
+
+Save the token securely.
+
+### 2. Configure your project's `.npmrc`
+
+In the consuming repo (e.g. `t4bs`, `pendingbusiness`, etc.), add a project-local `.npmrc`:
+
+```
+@basenative:registry=https://npm.pkg.github.com/
+```
+
+### 3. Auth at install time
+
+Two patterns:
+
+**Local dev:** add to `~/.npmrc`:
+```
+//npm.pkg.github.com/:_authToken=ghp_yourTokenHere
+```
+
+**CI:** set `NODE_AUTH_TOKEN` env when calling `npm/pnpm install`. With GitHub Actions on a DuganLabs repo, you can use the built-in `GITHUB_TOKEN`:
+
+```yaml
+- uses: actions/setup-node@v4
+  with:
+    node-version: 20
+    registry-url: 'https://npm.pkg.github.com'
+    scope: '@basenative'
+- run: npm ci
+  env:
+    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+For non-DuganLabs repos pulling these packages, mint a deploy-scoped PAT and add as a repo secret.
+
+## Consuming a package
+
+```bash
+npm install @basenative/og-image
+```
+
+```js
+import { renderPng, scoreCardPreset } from '@basenative/og-image';
+```
+
+That's it.
+
+## What's available
+
+After the next release tag, all of these will be on GitHub Packages:
+
+| Package | Purpose |
+|---|---|
+| `@basenative/runtime` | signal-based runtime (<5KB) |
+| `@basenative/server`, `router`, `components`, `forms`, `fetch`, `realtime` | app stack |
+| `@basenative/auth`, `auth-webauthn` | auth + passkeys |
+| `@basenative/db`, `middleware`, `upload`, `tenant`, `flags`, `notify`, `i18n`, `date`, `markdown` | backend + utility |
+| `@basenative/og-image`, `keyboard`, `admin`, `persist`, `share`, `combobox`, `favicon` | UX primitives |
+| `@basenative/wrangler-preset`, `doppler` | infra |
+| `@basenative/eslint-config`, `tsconfig` | shared configs |
+| `@basenative/cli` | the `bn` CLI |
+| `@basenative/claude-config` | Claude Code agents/skills bundle |
+
+## Publishing flow
+
+The Release workflow runs on every push to `main`:
+1. Lint + test all packages
+2. If a Changeset bumps any version, open a "Version Packages" PR
+3. When that PR merges, publish bumped packages to GitHub Packages
+
+To cut a release: `pnpm changeset` → describe the change → commit + push → CI does the rest.

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/admin",
   "version": "0.1.0",
-  "description": "Pluggable admin & moderation surface — protected-route helpers, role/permission primitives, audit-log middleware, and queue-review UI components for BaseNative apps",
+  "description": "Pluggable admin & moderation surface \u2014 protected-route helpers, role/permission primitives, audit-log middleware, and queue-review UI components for BaseNative apps",
   "type": "module",
   "exports": {
     ".": "./src/index.js",
@@ -13,7 +13,11 @@
     "./migrations/0001": "./migrations/0001_audit_and_roles.sql"
   },
   "types": "./types/index.d.ts",
-  "files": ["src", "types", "migrations"],
+  "files": [
+    "src",
+    "types",
+    "migrations"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -37,6 +41,12 @@
     "@basenative/auth": "workspace:*"
   },
   "peerDependenciesMeta": {
-    "@basenative/auth": { "optional": true }
+    "@basenative/auth": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   }
 }

--- a/packages/auth-webauthn/package.json
+++ b/packages/auth-webauthn/package.json
@@ -1,18 +1,40 @@
 {
   "name": "@basenative/auth-webauthn",
   "version": "0.1.0",
-  "description": "WebAuthn (passkey) adapter for @basenative/auth — server, client, and Cloudflare Workers/Pages handlers",
+  "description": "WebAuthn (passkey) adapter for @basenative/auth \u2014 server, client, and Cloudflare Workers/Pages handlers",
   "type": "module",
   "exports": {
-    ".": "./src/server.js",
-    "./server": "./src/server.js",
-    "./client": "./src/client.js",
-    "./handlers": "./src/handlers.js",
-    "./d1-stores": "./src/d1-stores.js",
-    "./seed-role": "./src/seed-role.js"
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./src/server.js"
+    },
+    "./server": {
+      "types": "./types/index.d.ts",
+      "default": "./src/server.js"
+    },
+    "./client": {
+      "types": "./types/index.d.ts",
+      "default": "./src/client.js"
+    },
+    "./handlers": {
+      "types": "./types/index.d.ts",
+      "default": "./src/handlers.js"
+    },
+    "./d1-stores": {
+      "types": "./types/index.d.ts",
+      "default": "./src/d1-stores.js"
+    },
+    "./seed-role": {
+      "types": "./types/index.d.ts",
+      "default": "./src/seed-role.js"
+    }
   },
   "types": "./types/index.d.ts",
-  "files": ["src", "types", "migrations"],
+  "files": [
+    "src",
+    "types",
+    "migrations"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -39,9 +61,15 @@
     "@simplewebauthn/server": "^11.0.0"
   },
   "peerDependenciesMeta": {
-    "@simplewebauthn/server": { "optional": false }
+    "@simplewebauthn/server": {
+      "optional": false
+    }
   },
   "optionalDependencies": {
     "@simplewebauthn/browser": "^11.0.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   }
 }

--- a/packages/claude-config/package.json
+++ b/packages/claude-config/package.json
@@ -38,5 +38,9 @@
     "slash-commands",
     "hooks",
     "duganlabs"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/cli",
   "version": "0.3.0",
-  "description": "The bn CLI — front door for BaseNative / DuganLabs projects (create, prd, speckit, gh, nx, deploy, doctor)",
+  "description": "The bn CLI \u2014 front door for BaseNative / DuganLabs projects (create, prd, speckit, gh, nx, deploy, doctor)",
   "type": "module",
   "bin": {
     "bn": "./src/index.js",
@@ -12,7 +12,13 @@
     "./manifest": "./manifest.json"
   },
   "types": "./types/index.d.ts",
-  "files": ["src", "types", "templates", "manifest.json", "CHANGELOG.md"],
+  "files": [
+    "src",
+    "types",
+    "templates",
+    "manifest.json",
+    "CHANGELOG.md"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -23,5 +29,16 @@
   "bugs": {
     "url": "https://github.com/DuganLabs/basenative/issues"
   },
-  "keywords": ["basenative", "web-components", "signals", "cli", "scaffolding", "create"]
+  "keywords": [
+    "basenative",
+    "web-components",
+    "signals",
+    "cli",
+    "scaffolding",
+    "create"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  }
 }

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/combobox",
   "version": "0.1.0",
-  "description": "Accessible combobox primitive — typeahead input that filters an existing list and lets the user create a new entry. WAI-ARIA combobox listbox pattern.",
+  "description": "Accessible combobox primitive \u2014 typeahead input that filters an existing list and lets the user create a new entry. WAI-ARIA combobox listbox pattern.",
   "type": "module",
   "exports": {
     ".": "./src/index.js",
@@ -12,7 +12,10 @@
   "peerDependencies": {
     "@basenative/runtime": "workspace:*"
   },
-  "files": ["src", "types"],
+  "files": [
+    "src",
+    "types"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -23,5 +26,19 @@
   "bugs": {
     "url": "https://github.com/DuganLabs/basenative/issues"
   },
-  "keywords": ["basenative", "combobox", "typeahead", "autocomplete", "a11y", "wcag", "aria", "ssr", "signals"]
+  "keywords": [
+    "basenative",
+    "combobox",
+    "typeahead",
+    "autocomplete",
+    "a11y",
+    "wcag",
+    "aria",
+    "ssr",
+    "signals"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  }
 }

--- a/packages/doppler/package.json
+++ b/packages/doppler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/doppler",
   "version": "0.1.0",
-  "description": "Thin developer-experience layer around Doppler — local-dev wrapper, CI helper, project bootstrap, environment validation. BaseNative ships plumbing, never values.",
+  "description": "Thin developer-experience layer around Doppler \u2014 local-dev wrapper, CI helper, project bootstrap, environment validation. BaseNative ships plumbing, never values.",
   "type": "module",
   "bin": {
     "bn-doppler": "./src/cli.js"
@@ -10,7 +10,10 @@
     ".": "./src/index.js",
     "./required": "./src/required.js"
   },
-  "files": ["src", "templates"],
+  "files": [
+    "src",
+    "templates"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -29,5 +32,9 @@
     "cloudflare",
     "wrangler",
     "infra"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,16 +1,18 @@
 {
   "name": "@basenative/eslint-config",
   "version": "0.1.0",
-  "description": "Shared ESLint flat-config for DuganLabs projects — security, hygiene, zero-noise defaults",
+  "description": "Shared ESLint flat-config for DuganLabs projects \u2014 security, hygiene, zero-noise defaults",
   "type": "module",
   "exports": {
-    ".":         "./src/index.js",
+    ".": "./src/index.js",
     "./browser": "./src/browser.js",
-    "./node":    "./src/node.js",
-    "./worker":  "./src/worker.js",
-    "./react":   "./src/react.js"
+    "./node": "./src/node.js",
+    "./worker": "./src/worker.js",
+    "./react": "./src/react.js"
   },
-  "files": ["src"],
+  "files": [
+    "src"
+  ],
   "license": "Apache-2.0",
   "peerDependencies": {
     "eslint": ">=9.0.0"
@@ -26,5 +28,15 @@
     "directory": "packages/eslint-config"
   },
   "homepage": "https://github.com/DuganLabs/basenative/tree/main/packages/eslint-config#readme",
-  "keywords": ["basenative", "eslint", "eslint-config", "flat-config", "shared"]
+  "keywords": [
+    "basenative",
+    "eslint",
+    "eslint-config",
+    "flat-config",
+    "shared"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  }
 }

--- a/packages/favicon/package.json
+++ b/packages/favicon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/favicon",
   "version": "0.1.0",
-  "description": "SVG-first favicon generator + design primitives — apple-touch-icon, maskable, manifest, and the right <link> tags for every DuganLabs project",
+  "description": "SVG-first favicon generator + design primitives \u2014 apple-touch-icon, maskable, manifest, and the right <link> tags for every DuganLabs project",
   "type": "module",
   "bin": {
     "bn-favicon": "./src/cli.js"
@@ -16,7 +16,12 @@
     "./png": "./src/png.js"
   },
   "types": "./types/index.d.ts",
-  "files": ["src", "types", "templates", "CHANGELOG.md"],
+  "files": [
+    "src",
+    "types",
+    "templates",
+    "CHANGELOG.md"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -44,5 +49,9 @@
     "@basenative/og-image": {
       "optional": true
     }
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   }
 }

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/keyboard",
   "version": "0.1.0",
-  "description": "Accessible mobile-first on-screen virtual keyboard primitive — layout-agnostic, signal-driven key state coloring, themable",
+  "description": "Accessible mobile-first on-screen virtual keyboard primitive \u2014 layout-agnostic, signal-driven key state coloring, themable",
   "type": "module",
   "exports": {
     ".": "./src/index.js",
@@ -12,7 +12,10 @@
   "peerDependencies": {
     "@basenative/runtime": "workspace:*"
   },
-  "files": ["src", "types"],
+  "files": [
+    "src",
+    "types"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -23,5 +26,19 @@
   "bugs": {
     "url": "https://github.com/DuganLabs/basenative/issues"
   },
-  "keywords": ["basenative", "keyboard", "virtual-keyboard", "mobile", "a11y", "wcag", "qwerty", "numpad", "signals"]
+  "keywords": [
+    "basenative",
+    "keyboard",
+    "virtual-keyboard",
+    "mobile",
+    "a11y",
+    "wcag",
+    "qwerty",
+    "numpad",
+    "signals"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  }
 }

--- a/packages/og-image/package.json
+++ b/packages/og-image/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/og-image",
   "version": "0.1.0",
-  "description": "Worker-runtime OG / social share PNG renderer — satori + resvg-wasm with KV-cached fonts and themable scene presets",
+  "description": "Worker-runtime OG / social share PNG renderer \u2014 satori + resvg-wasm with KV-cached fonts and themable scene presets",
   "type": "module",
   "exports": {
     ".": "./src/index.js",
@@ -9,7 +9,10 @@
     "./scene": "./src/scene.js"
   },
   "types": "./types/index.d.ts",
-  "files": ["src", "types"],
+  "files": [
+    "src",
+    "types"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,5 +35,9 @@
   "dependencies": {
     "satori": "^0.10.14",
     "@resvg/resvg-wasm": "^2.6.2"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   }
 }

--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -9,7 +9,10 @@
     "./ttl": "./src/ttl.js"
   },
   "types": "./types/index.d.ts",
-  "files": ["src", "types"],
+  "files": [
+    "src",
+    "types"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -33,6 +36,12 @@
     "@basenative/runtime": "workspace:*"
   },
   "peerDependenciesMeta": {
-    "@basenative/runtime": { "optional": true }
+    "@basenative/runtime": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   }
 }

--- a/packages/share/package.json
+++ b/packages/share/package.json
@@ -11,7 +11,11 @@
     "./migrations/0001": "./migrations/0001_share_cards.sql"
   },
   "types": "./types/index.d.ts",
-  "files": ["src", "types", "migrations"],
+  "files": [
+    "src",
+    "types",
+    "migrations"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -35,6 +39,12 @@
     "@basenative/og-image": "workspace:*"
   },
   "peerDependenciesMeta": {
-    "@basenative/og-image": { "optional": true }
+    "@basenative/og-image": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   }
 }

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,17 +1,23 @@
 {
   "name": "@basenative/tsconfig",
   "version": "0.1.0",
-  "description": "Shared base tsconfigs for DuganLabs projects — strict, modern, runtime-targeted",
+  "description": "Shared base tsconfigs for DuganLabs projects \u2014 strict, modern, runtime-targeted",
   "type": "module",
   "exports": {
-    ".":         "./base.json",
-    "./base":    "./base.json",
+    ".": "./base.json",
+    "./base": "./base.json",
     "./browser": "./browser.json",
-    "./node":    "./node.json",
-    "./worker":  "./worker.json",
-    "./react":   "./react.json"
+    "./node": "./node.json",
+    "./worker": "./worker.json",
+    "./react": "./react.json"
   },
-  "files": ["base.json", "browser.json", "node.json", "worker.json", "react.json"],
+  "files": [
+    "base.json",
+    "browser.json",
+    "node.json",
+    "worker.json",
+    "react.json"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -19,5 +25,14 @@
     "directory": "packages/tsconfig"
   },
   "homepage": "https://github.com/DuganLabs/basenative/tree/main/packages/tsconfig#readme",
-  "keywords": ["basenative", "tsconfig", "typescript", "shared"]
+  "keywords": [
+    "basenative",
+    "tsconfig",
+    "typescript",
+    "shared"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  }
 }

--- a/packages/wrangler-preset/package.json
+++ b/packages/wrangler-preset/package.json
@@ -11,7 +11,10 @@
     "./defaults": "./src/index.js",
     "./toml": "./src/index.js"
   },
-  "files": ["src", "templates"],
+  "files": [
+    "src",
+    "templates"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -33,5 +36,9 @@
   ],
   "dependencies": {
     "wrangler": "^4.85.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   }
 }


### PR DESCRIPTION
Open-source projects in DuganLabs get unlimited free Actions minutes and bandwidth on GH Packages. Consumer guide at docs/CONSUMING-FROM-GH-PACKAGES.md.

Switches:
- release.yml registry-url to npm.pkg.github.com
- NODE_AUTH_TOKEN to GITHUB_TOKEN (no NPM_TOKEN needed)
- 14 packages get publishConfig.registry
- .npmrc routes @basenative scope to GH Packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)