### PR TITLE
ci: explicit npmrc auth for publish

### DIFF
--- a/.github/workflows/publish-direct.yml
+++ b/.github/workflows/publish-direct.yml
@@ -38,8 +38,17 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@basenative'
+
+      # Write .npmrc explicitly so pnpm uses GH Packages with the workflow's
+      # GITHUB_TOKEN. setup-node@v4's registry-url + scope sometimes doesn't
+      # propagate auth into pnpm's per-publish env reliably.
+      - name: Configure .npmrc for GH Packages
+        run: |
+          cat > ~/.npmrc <<EOF
+          @basenative:registry=https://npm.pkg.github.com/
+          //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
+          always-auth=true
+          EOF
 
       - run: pnpm install --frozen-lockfile
 
@@ -49,6 +58,7 @@ jobs:
       - name: Publish loop
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
           PUBLISHED=()

--- a/.github/workflows/publish-direct.yml
+++ b/.github/workflows/publish-direct.yml
@@ -1,0 +1,101 @@
+name: publish-direct
+
+# Direct publish to GitHub Packages, bypassing changesets/action.
+# Use case: changesets's pre-publish `npm info` lookup 403s for older packages
+# that don't have a GH Packages installation record. This workflow loops
+# explicit packages and runs `pnpm publish` per-dir, which DOES work.
+#
+# Trigger: workflow_dispatch (manual). On each run, lists which packages it
+# would publish (dry-run) or actually publishes them (publish=true).
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        type: boolean
+        default: false
+        description: "Actually publish (false = dry-run)"
+      packages:
+        type: string
+        default: "og-image keyboard auth-webauthn admin persist share wrangler-preset doppler favicon combobox claude-config eslint-config tsconfig cli"
+        description: "Space-separated package basenames (under packages/) to publish"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@basenative'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build types
+        run: pnpm exec nx run-many --target=build --skip-nx-cache || true   # not all packages have build
+
+      - name: Publish loop
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          PUBLISHED=()
+          SKIPPED=()
+          FAILED=()
+          for pkg in ${{ inputs.packages }}; do
+            dir="packages/$pkg"
+            if [ ! -f "$dir/package.json" ]; then
+              echo "::warning::No package.json at $dir — skipping"
+              SKIPPED+=("$pkg (no package.json)")
+              continue
+            fi
+            name=$(jq -r '.name' "$dir/package.json")
+            version=$(jq -r '.version' "$dir/package.json")
+            private=$(jq -r '.private // false' "$dir/package.json")
+            if [ "$private" = "true" ]; then
+              SKIPPED+=("$name@$version (private:true)")
+              continue
+            fi
+            echo "::group::$name@$version"
+            if [ "${{ inputs.publish }}" = "true" ]; then
+              if (cd "$dir" && pnpm publish --no-git-checks --access=public 2>&1); then
+                PUBLISHED+=("$name@$version")
+              else
+                FAILED+=("$name@$version")
+              fi
+            else
+              echo "(dry-run) would publish $name@$version"
+              PUBLISHED+=("$name@$version (dry)")
+            fi
+            echo "::endgroup::"
+          done
+          {
+            echo "## Publish summary"
+            echo ""
+            echo "Mode: $([ "${{ inputs.publish }}" = "true" ] && echo "PUBLISH" || echo "DRY-RUN")"
+            echo ""
+            echo "### Published (${#PUBLISHED[@]})"
+            for x in "${PUBLISHED[@]}"; do echo "- $x"; done
+            echo ""
+            echo "### Skipped (${#SKIPPED[@]})"
+            for x in "${SKIPPED[@]}"; do echo "- $x"; done
+            echo ""
+            echo "### Failed (${#FAILED[@]})"
+            for x in "${FAILED[@]}"; do echo "- $x"; done
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ ${#FAILED[@]} -gt 0 ]; then
+            echo "::error::${#FAILED[@]} package(s) failed to publish"
+            exit 1
+          fi

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/admin",
   "version": "1.0.0",
-  "description": "Pluggable admin & moderation surface — protected-route helpers, role/permission primitives, audit-log middleware, and queue-review UI components for BaseNative apps",
+  "description": "Pluggable admin & moderation surface \u2014 protected-route helpers, role/permission primitives, audit-log middleware, and queue-review UI components for BaseNative apps",
   "type": "module",
   "exports": {
     ".": {
@@ -39,12 +39,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DuganLabs/basenative.git",
+    "url": "git+https://github.com/DuganLabs/BaseNative.git",
     "directory": "packages/admin"
   },
-  "homepage": "https://github.com/DuganLabs/basenative#readme",
+  "homepage": "https://github.com/DuganLabs/BaseNative#readme",
   "bugs": {
-    "url": "https://github.com/DuganLabs/basenative/issues"
+    "url": "https://github.com/DuganLabs/BaseNative/issues"
   },
   "keywords": [
     "basenative",

--- a/packages/auth-webauthn/package.json
+++ b/packages/auth-webauthn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/auth-webauthn",
   "version": "1.0.0",
-  "description": "WebAuthn (passkey) adapter for @basenative/auth — server, client, and Cloudflare Workers/Pages handlers",
+  "description": "WebAuthn (passkey) adapter for @basenative/auth \u2014 server, client, and Cloudflare Workers/Pages handlers",
   "type": "module",
   "exports": {
     ".": {
@@ -38,12 +38,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DuganLabs/basenative.git",
+    "url": "git+https://github.com/DuganLabs/BaseNative.git",
     "directory": "packages/auth-webauthn"
   },
   "homepage": "https://basenative.dev",
   "bugs": {
-    "url": "https://github.com/DuganLabs/basenative/issues"
+    "url": "https://github.com/DuganLabs/BaseNative/issues"
   },
   "keywords": [
     "basenative",

--- a/packages/claude-config/package.json
+++ b/packages/claude-config/package.json
@@ -22,12 +22,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DuganLabs/basenative.git",
+    "url": "git+https://github.com/DuganLabs/BaseNative.git",
     "directory": "packages/claude-config"
   },
-  "homepage": "https://github.com/DuganLabs/basenative#readme",
+  "homepage": "https://github.com/DuganLabs/BaseNative#readme",
   "bugs": {
-    "url": "https://github.com/DuganLabs/basenative/issues"
+    "url": "https://github.com/DuganLabs/BaseNative/issues"
   },
   "keywords": [
     "basenative",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/cli",
   "version": "0.4.0",
-  "description": "The bn CLI — front door for BaseNative / DuganLabs projects (create, prd, speckit, gh, nx, deploy, doctor)",
+  "description": "The bn CLI \u2014 front door for BaseNative / DuganLabs projects (create, prd, speckit, gh, nx, deploy, doctor)",
   "type": "module",
   "bin": {
     "bn": "./src/index.js",
@@ -22,12 +22,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DuganLabs/basenative.git",
+    "url": "git+https://github.com/DuganLabs/BaseNative.git",
     "directory": "packages/cli"
   },
-  "homepage": "https://github.com/DuganLabs/basenative#readme",
+  "homepage": "https://github.com/DuganLabs/BaseNative#readme",
   "bugs": {
-    "url": "https://github.com/DuganLabs/basenative/issues"
+    "url": "https://github.com/DuganLabs/BaseNative/issues"
   },
   "keywords": [
     "basenative",

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/combobox",
   "version": "1.0.0",
-  "description": "Accessible combobox primitive — typeahead input that filters an existing list and lets the user create a new entry. WAI-ARIA combobox listbox pattern.",
+  "description": "Accessible combobox primitive \u2014 typeahead input that filters an existing list and lets the user create a new entry. WAI-ARIA combobox listbox pattern.",
   "type": "module",
   "exports": {
     ".": {
@@ -22,12 +22,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DuganLabs/basenative.git",
+    "url": "git+https://github.com/DuganLabs/BaseNative.git",
     "directory": "packages/combobox"
   },
-  "homepage": "https://github.com/DuganLabs/basenative#readme",
+  "homepage": "https://github.com/DuganLabs/BaseNative#readme",
   "bugs": {
-    "url": "https://github.com/DuganLabs/basenative/issues"
+    "url": "https://github.com/DuganLabs/BaseNative/issues"
   },
   "keywords": [
     "basenative",

--- a/packages/doppler/package.json
+++ b/packages/doppler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/doppler",
   "version": "0.2.0",
-  "description": "Thin developer-experience layer around Doppler — local-dev wrapper, CI helper, project bootstrap, environment validation. BaseNative ships plumbing, never values.",
+  "description": "Thin developer-experience layer around Doppler \u2014 local-dev wrapper, CI helper, project bootstrap, environment validation. BaseNative ships plumbing, never values.",
   "type": "module",
   "bin": {
     "bn-doppler": "./src/cli.js"
@@ -25,12 +25,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DuganLabs/basenative.git",
+    "url": "git+https://github.com/DuganLabs/BaseNative.git",
     "directory": "packages/doppler"
   },
-  "homepage": "https://github.com/DuganLabs/basenative#readme",
+  "homepage": "https://github.com/DuganLabs/BaseNative#readme",
   "bugs": {
-    "url": "https://github.com/DuganLabs/basenative/issues"
+    "url": "https://github.com/DuganLabs/BaseNative/issues"
   },
   "keywords": [
     "basenative",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/eslint-config",
   "version": "0.2.0",
-  "description": "Shared ESLint flat-config for DuganLabs projects — security, hygiene, zero-noise defaults",
+  "description": "Shared ESLint flat-config for DuganLabs projects \u2014 security, hygiene, zero-noise defaults",
   "type": "module",
   "exports": {
     ".": "./src/index.js",
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/DuganLabs/basenative.git",
+    "url": "git+https://github.com/DuganLabs/BaseNative.git",
     "directory": "packages/eslint-config"
   },
   "homepage": "https://github.com/DuganLabs/basenative/tree/main/packages/eslint-config#readme",

--- a/packages/favicon/package.json
+++ b/packages/favicon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/favicon",
   "version": "1.0.0",
-  "description": "SVG-first favicon generator + design primitives — apple-touch-icon, maskable, manifest, and the right <link> tags for every DuganLabs project",
+  "description": "SVG-first favicon generator + design primitives \u2014 apple-touch-icon, maskable, manifest, and the right <link> tags for every DuganLabs project",
   "type": "module",
   "bin": {
     "bn-favicon": "./src/cli.js"
@@ -46,12 +46,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DuganLabs/basenative.git",
+    "url": "git+https://github.com/DuganLabs/BaseNative.git",
     "directory": "packages/favicon"
   },
-  "homepage": "https://github.com/DuganLabs/basenative#readme",
+  "homepage": "https://github.com/DuganLabs/BaseNative#readme",
   "bugs": {
-    "url": "https://github.com/DuganLabs/basenative/issues"
+    "url": "https://github.com/DuganLabs/BaseNative/issues"
   },
   "keywords": [
     "basenative",

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/keyboard",
   "version": "1.0.0",
-  "description": "Accessible mobile-first on-screen virtual keyboard primitive — layout-agnostic, signal-driven key state coloring, themable",
+  "description": "Accessible mobile-first on-screen virtual keyboard primitive \u2014 layout-agnostic, signal-driven key state coloring, themable",
   "type": "module",
   "exports": {
     ".": {
@@ -22,12 +22,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DuganLabs/basenative.git",
+    "url": "git+https://github.com/DuganLabs/BaseNative.git",
     "directory": "packages/keyboard"
   },
-  "homepage": "https://github.com/DuganLabs/basenative#readme",
+  "homepage": "https://github.com/DuganLabs/BaseNative#readme",
   "bugs": {
-    "url": "https://github.com/DuganLabs/basenative/issues"
+    "url": "https://github.com/DuganLabs/BaseNative/issues"
   },
   "keywords": [
     "basenative",

--- a/packages/og-image/package.json
+++ b/packages/og-image/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/og-image",
   "version": "0.2.0",
-  "description": "Worker-runtime OG / social share PNG renderer — satori + resvg-wasm with KV-cached fonts and themable scene presets",
+  "description": "Worker-runtime OG / social share PNG renderer \u2014 satori + resvg-wasm with KV-cached fonts and themable scene presets",
   "type": "module",
   "exports": {
     ".": {
@@ -25,12 +25,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DuganLabs/basenative.git",
+    "url": "git+https://github.com/DuganLabs/BaseNative.git",
     "directory": "packages/og-image"
   },
-  "homepage": "https://github.com/DuganLabs/basenative#readme",
+  "homepage": "https://github.com/DuganLabs/BaseNative#readme",
   "bugs": {
-    "url": "https://github.com/DuganLabs/basenative/issues"
+    "url": "https://github.com/DuganLabs/BaseNative/issues"
   },
   "keywords": [
     "basenative",

--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -25,12 +25,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DuganLabs/basenative.git",
+    "url": "git+https://github.com/DuganLabs/BaseNative.git",
     "directory": "packages/persist"
   },
-  "homepage": "https://github.com/DuganLabs/basenative#readme",
+  "homepage": "https://github.com/DuganLabs/BaseNative#readme",
   "bugs": {
-    "url": "https://github.com/DuganLabs/basenative/issues"
+    "url": "https://github.com/DuganLabs/BaseNative/issues"
   },
   "keywords": [
     "basenative",

--- a/packages/share/package.json
+++ b/packages/share/package.json
@@ -31,12 +31,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DuganLabs/basenative.git",
+    "url": "git+https://github.com/DuganLabs/BaseNative.git",
     "directory": "packages/share"
   },
-  "homepage": "https://github.com/DuganLabs/basenative#readme",
+  "homepage": "https://github.com/DuganLabs/BaseNative#readme",
   "bugs": {
-    "url": "https://github.com/DuganLabs/basenative/issues"
+    "url": "https://github.com/DuganLabs/BaseNative/issues"
   },
   "keywords": [
     "basenative",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@basenative/tsconfig",
   "version": "0.2.0",
-  "description": "Shared base tsconfigs for DuganLabs projects — strict, modern, runtime-targeted",
+  "description": "Shared base tsconfigs for DuganLabs projects \u2014 strict, modern, runtime-targeted",
   "type": "module",
   "exports": {
     ".": "./base.json",
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DuganLabs/basenative.git",
+    "url": "git+https://github.com/DuganLabs/BaseNative.git",
     "directory": "packages/tsconfig"
   },
   "homepage": "https://github.com/DuganLabs/basenative/tree/main/packages/tsconfig#readme",

--- a/packages/wrangler-preset/package.json
+++ b/packages/wrangler-preset/package.json
@@ -29,12 +29,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DuganLabs/basenative.git",
+    "url": "git+https://github.com/DuganLabs/BaseNative.git",
     "directory": "packages/wrangler-preset"
   },
-  "homepage": "https://github.com/DuganLabs/basenative#readme",
+  "homepage": "https://github.com/DuganLabs/BaseNative#readme",
   "bugs": {
-    "url": "https://github.com/DuganLabs/basenative/issues"
+    "url": "https://github.com/DuganLabs/BaseNative/issues"
   },
   "keywords": [
     "basenative",


### PR DESCRIPTION
Setup-node+pnpm wasn't reliably propagating auth. Write .npmrc directly.