### PR TITLE
fix(auth-webauthn): per-subpath .d.ts (1.0.1)

### DIFF
--- a/packages/auth-webauthn/package.json
+++ b/packages/auth-webauthn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basenative/auth-webauthn",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "WebAuthn (passkey) adapter for @basenative/auth \u2014 server, client, and Cloudflare Workers/Pages handlers",
   "type": "module",
   "exports": {
@@ -9,23 +9,23 @@
       "default": "./src/server.js"
     },
     "./server": {
-      "types": "./types/index.d.ts",
+      "types": "./types/server.d.ts",
       "default": "./src/server.js"
     },
     "./client": {
-      "types": "./types/index.d.ts",
+      "types": "./types/client.d.ts",
       "default": "./src/client.js"
     },
     "./handlers": {
-      "types": "./types/index.d.ts",
+      "types": "./types/handlers.d.ts",
       "default": "./src/handlers.js"
     },
     "./d1-stores": {
-      "types": "./types/index.d.ts",
+      "types": "./types/d1-stores.d.ts",
       "default": "./src/d1-stores.js"
     },
     "./seed-role": {
-      "types": "./types/index.d.ts",
+      "types": "./types/seed-role.d.ts",
       "default": "./src/seed-role.js"
     }
   },

--- a/packages/auth-webauthn/types/client.d.ts
+++ b/packages/auth-webauthn/types/client.d.ts
@@ -1,0 +1,4 @@
+// Re-export the barrel so subpath imports type-check under
+// moduleResolution: bundler (which follows the exports.types field
+// per-subpath instead of falling back to the package root types).
+export * from './index.js';

--- a/packages/auth-webauthn/types/d1-stores.d.ts
+++ b/packages/auth-webauthn/types/d1-stores.d.ts
@@ -1,0 +1,4 @@
+// Re-export the barrel so subpath imports type-check under
+// moduleResolution: bundler (which follows the exports.types field
+// per-subpath instead of falling back to the package root types).
+export * from './index.js';

--- a/packages/auth-webauthn/types/handlers.d.ts
+++ b/packages/auth-webauthn/types/handlers.d.ts
@@ -1,0 +1,4 @@
+// Re-export the barrel so subpath imports type-check under
+// moduleResolution: bundler (which follows the exports.types field
+// per-subpath instead of falling back to the package root types).
+export * from './index.js';

--- a/packages/auth-webauthn/types/seed-role.d.ts
+++ b/packages/auth-webauthn/types/seed-role.d.ts
@@ -1,0 +1,4 @@
+// Re-export the barrel so subpath imports type-check under
+// moduleResolution: bundler (which follows the exports.types field
+// per-subpath instead of falling back to the package root types).
+export * from './index.js';

--- a/packages/auth-webauthn/types/server.d.ts
+++ b/packages/auth-webauthn/types/server.d.ts
@@ -1,0 +1,4 @@
+// Re-export the barrel so subpath imports type-check under
+// moduleResolution: bundler (which follows the exports.types field
+// per-subpath instead of falling back to the package root types).
+export * from './index.js';


### PR DESCRIPTION
PendingBusiness CI typecheck blocked on `Cannot find module @basenative/auth-webauthn/client`. TS Bundler resolution reads `exports.types` per subpath; previously they all pointed to the same `index.d.ts` which apparently confuses some resolution paths. Add per-subpath re-exporting .d.ts files.