### PR TITLE
fix(auth-webauthn): re-export parseHandleList (1.0.2)

### DIFF
--- a/packages/auth-webauthn/package.json
+++ b/packages/auth-webauthn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basenative/auth-webauthn",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "WebAuthn (passkey) adapter for @basenative/auth \u2014 server, client, and Cloudflare Workers/Pages handlers",
   "type": "module",
   "exports": {

--- a/packages/auth-webauthn/src/server.js
+++ b/packages/auth-webauthn/src/server.js
@@ -373,4 +373,4 @@ function validateStores(stores) {
 
 // Re-exports so consumers don't have to import multiple sub-paths.
 export { d1WebAuthnStores } from './d1-stores.js';
-export { seedRoles } from './seed-role.js';
+export { seedRoles, parseHandleList } from './seed-role.js';


### PR DESCRIPTION
PB worker imports parseHandleList from root entry — was only in seed-role subpath. Add to server.js re-export line. Already published 1.0.2 to GH Packages.