### PR TITLE
fix(site): counter example interpolation, favicon, mobile meta

### DIFF
--- a/examples/express/public/favicon.svg
+++ b/examples/express/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <title>BaseNative</title>
+  <rect x="2" y="2" width="28" height="28" rx="6" fill="#0a0a0c"/>
+  <rect x="6" y="6" width="20" height="9" rx="2" fill="#e8a44a"/>
+  <rect x="6" y="17" width="20" height="9" rx="2" fill="#e8a44a" opacity="0.55"/>
+</svg>

--- a/examples/express/views/home.html
+++ b/examples/express/views/home.html
@@ -40,7 +40,7 @@
   <article>
     <header><h3>Reactive counter in 6 lines</h3></header>
     <pre><code><span class="tag">&lt;button</span> <span class="attr">@click</span>=<span class="str">"incrementCount()"</span><span class="tag">&gt;</span>
-  Clicked {{ count() }} times
+  Clicked &#123;&#123; count() &#125;&#125; times
 <span class="tag">&lt;/button&gt;</span>
 
 <span class="tag">&lt;script</span> <span class="attr">type</span>=<span class="str">"module"</span><span class="tag">&gt;</span>

--- a/examples/express/views/layout.html
+++ b/examples/express/views/layout.html
@@ -3,7 +3,13 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#0a0a0c">
+<meta name="color-scheme" content="dark">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-title" content="BaseNative">
 <title><!--TITLE--> — BaseNative</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="stylesheet" href="/bn-css/index.css">
 <link rel="stylesheet" href="/fonts/fonts.css">
 <link rel="stylesheet" href="/theme.css">

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -273,6 +273,7 @@ for (const [route, { view, title, activePage, ctx }] of Object.entries(pages)) {
 cpSync(join(express, 'public', 'styles.css'), join(dist, 'styles.css'));
 cpSync(join(express, 'public', 'theme.css'), join(dist, 'theme.css'));
 cpSync(join(express, 'public', 'basenative.js'), join(dist, 'basenative.js'));
+cpSync(join(express, 'public', 'favicon.svg'), join(dist, 'favicon.svg'));
 
 // Copy component CSS (served as /bn-css/ in Express, must exist in dist)
 const bnCssDir = join(dist, 'bn-css');


### PR DESCRIPTION
## Summary
- Home page counter example was rendering \`Clicked  times\` instead of \`Clicked {{ count() }} times\` — the literal template expression in the \`<pre><code>\` block was being interpreted by the SSR renderer and stripped to nothing. Escape the curly braces with HTML entities (\`&#123;\` / \`&#125;\`) so the source is shown verbatim.
- Adds \`favicon.svg\` (golden BN layered mark on dark) — was 404 in production.
- Adds mobile/apple PWA meta tags + theme-color so install behavior is consistent.
- Wires \`favicon.svg\` into \`build-pages.js\` so it ends up in \`dist/\`.

## Test plan
- [x] \`node scripts/build-pages.js\` clean, dist/index.html contains \`Clicked &#123;&#123; count() &#125;&#125; times\` and the favicon link
- [x] \`dist/favicon.svg\` exists post-build
- [ ] Verify post-deploy: \`curl https://basenative.com/favicon.svg\` returns 200, home page shows the counter example with \`{{ count() }}\` literal

🤖 Generated with [Claude Code](https://claude.com/claude-code)