### PR TITLE
feat(integrations): plaid server client + yield optimization (Epic 1C)

### DIFF
--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -4,7 +4,8 @@
   "description": "Headless third-party integration wrappers for BaseNative apps",
   "type": "module",
   "exports": {
-    "./plaid": "./src/plaid.js"
+    "./plaid": "./src/plaid.js",
+    "./yield": "./src/yield.js"
   },
   "types": "./types/index.d.ts",
   "files": ["src", "types"],

--- a/packages/integrations/src/plaid.js
+++ b/packages/integrations/src/plaid.js
@@ -1,16 +1,14 @@
 /**
  * @basenative/integrations/plaid — headless Plaid Link wrapper.
  *
- * Client-side: loadPlaidLink() injects the Plaid Link script and
- * returns a handler for opening the Link flow.
- *
- * Server-side: createLinkToken() and exchangePublicToken() wrap the
- * Plaid API for Cloudflare Worker / Node.js environments.
+ * Client-side: createPlaidLink() wraps the Plaid Link initialization with signals.
+ * Server-side: createPlaidClient() provides account/balance/transfer APIs.
+ * Yield optimization: findBestYieldAccount() computes optimal float allocation.
  */
 
 const PLAID_LINK_CDN = 'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
 
-// ---------- Client-side ----------
+// ---------- Client-side: Signal-based Link initialization ----------
 
 /**
  * Load the Plaid Link drop-in script if not already present.
@@ -47,7 +45,55 @@ export function loadPlaidScript() {
 }
 
 /**
- * Open Plaid Link with the given link token.
+ * Create a signal-based Plaid Link handler.
+ * Returns signals for linkToken, linkStatus, and accounts.
+ *
+ * @param {object} config
+ * @param {string} config.token         Link token from createLinkToken()
+ * @param {function} config.onSuccess   Called with (publicToken, metadata)
+ * @param {function} [config.onExit]    Called when user exits Link
+ * @param {function} [config.onEvent]   Called on Link events
+ * @param {object} [config.signals]     Signals object with signal(), computed() functions
+ * @returns {Promise<{ linkToken: object, linkStatus: object, handler: object }>}
+ */
+export async function createPlaidLink(config) {
+  const { token, onSuccess, onExit, onEvent, signals } = config;
+
+  await loadPlaidScript();
+
+  if (!window.Plaid) {
+    throw new Error('@basenative/integrations/plaid: Plaid Link script failed to initialize');
+  }
+
+  // If signals are provided, create signal-based state
+  const linkTokenSignal = signals?.signal ? signals.signal(token) : null;
+  const linkStatusSignal = signals?.signal ? signals.signal('ready') : null;
+
+  const handler = window.Plaid.create({
+    token,
+    onSuccess: (publicToken, metadata) => {
+      if (linkStatusSignal) linkStatusSignal.set('success');
+      if (onSuccess) onSuccess(publicToken, metadata);
+    },
+    onExit: (err, metadata) => {
+      if (linkStatusSignal) linkStatusSignal.set('exit');
+      if (onExit) onExit(err, metadata);
+    },
+    onEvent: (eventName, metadata) => {
+      if (onEvent) onEvent(eventName, metadata);
+    },
+  });
+
+  return {
+    linkToken: linkTokenSignal,
+    linkStatus: linkStatusSignal,
+    open: () => handler.open(),
+    destroy: () => handler.destroy(),
+  };
+}
+
+/**
+ * Open Plaid Link with the given link token (legacy API).
  *
  * @param {object} options
  * @param {string} options.token         Link token from createLinkToken()
@@ -84,7 +130,7 @@ export async function openPlaidLink(options) {
   };
 }
 
-// ---------- Server-side ----------
+// ---------- Server-side: Plaid Client Factory ----------
 
 const PLAID_ENVS = {
   sandbox: 'https://sandbox.plaid.com',
@@ -126,6 +172,32 @@ async function plaidRequest(path, body, credentials) {
   }
 
   return data;
+}
+
+/**
+ * Create a Plaid API client factory with server methods.
+ * Works in Cloudflare Workers and Node.js environments.
+ *
+ * @param {object} config
+ * @param {string} config.clientId
+ * @param {string} config.secret
+ * @param {string} [config.environment='sandbox']
+ * @returns {object}
+ */
+export function createPlaidClient(config) {
+  const credentials = {
+    clientId: config.clientId,
+    secret: config.secret,
+    env: config.environment || 'sandbox',
+  };
+
+  return {
+    exchangePublicToken: (publicToken) => exchangePublicToken(publicToken, credentials),
+    getAccounts: (accessToken) => getAccounts(accessToken, credentials),
+    getBalance: (accessToken) => getBalance(accessToken, credentials),
+    createTransfer: (params) => createTransfer(params, credentials),
+    getTransferStatus: (transferId) => getTransferStatus(transferId, credentials),
+  };
 }
 
 /**
@@ -179,6 +251,28 @@ export async function exchangePublicToken(publicToken, credentials) {
 }
 
 /**
+ * Fetch linked accounts (without balance details).
+ *
+ * @param {string} accessToken  The access token from exchangePublicToken()
+ * @param {object} credentials
+ * @returns {Promise<{ accounts: Array<{ id: string, name: string, type: string, subtype: string }> }>}
+ */
+export async function getAccounts(accessToken, credentials) {
+  const data = await plaidRequest('/accounts/get', {
+    access_token: accessToken,
+  }, credentials);
+
+  return {
+    accounts: data.accounts.map(a => ({
+      id: a.account_id,
+      name: a.name,
+      type: a.type,
+      subtype: a.subtype,
+    })),
+  };
+}
+
+/**
  * Fetch account balances for a linked item.
  *
  * @param {string} accessToken  The access token from exchangePublicToken()
@@ -203,5 +297,107 @@ export async function getBalances(accessToken, credentials) {
         currency: a.balances.iso_currency_code,
       },
     })),
+  };
+}
+
+/**
+ * Alias for getBalances() for consistency.
+ *
+ * @param {string} accessToken
+ * @param {object} credentials
+ * @returns {Promise<object>}
+ */
+export async function getBalance(accessToken, credentials) {
+  return getBalances(accessToken, credentials);
+}
+
+/**
+ * Initiate a transfer via Plaid Transfer API.
+ * Supports FedNow instant transfers (network: "rtp") with graceful fallback to ACH.
+ *
+ * @param {object} params
+ * @param {string} params.accessToken        Access token for the source account
+ * @param {string} params.accountId          Account to transfer from
+ * @param {string} params.type               Transfer type ("debit" or "credit")
+ * @param {number} params.amount             Amount in cents
+ * @param {string} params.description        Transfer description
+ * @param {string} [params.network]          "rtp" (RTP/FedNow) or "ach" (default: auto-detect)
+ * @param {object} [params.user]             User info { name, email }
+ * @param {object} credentials
+ * @returns {Promise<{ transferId: string, status: string, network: string }>}
+ */
+export async function createTransfer(params, credentials) {
+  const {
+    accessToken,
+    accountId,
+    type,
+    amount,
+    description,
+    network,
+    user,
+  } = params;
+
+  const body = {
+    access_token: accessToken,
+    account_id: accountId,
+    type,
+    amount: amount / 100, // Convert cents to dollars
+    description: description || 'Transfer via PendingBusiness',
+  };
+
+  // If network is explicitly set to "rtp" (RTP/FedNow), use it
+  // Otherwise, let Plaid auto-detect or default to ACH
+  if (network === 'rtp') {
+    body.network = 'rtp';
+  }
+
+  if (user) {
+    body.user = {
+      name: user.name,
+      email_address: user.email,
+    };
+  }
+
+  try {
+    const data = await plaidRequest('/transfer/create', body, credentials);
+
+    return {
+      transferId: data.transfer_id,
+      status: data.status,
+      network: data.network || 'ach', // Default to ACH if not specified
+    };
+  } catch (err) {
+    // If FedNow fails, retry with ACH
+    if (network === 'rtp' && err.plaidError?.error_code === 'INVALID_REQUEST') {
+      const achBody = { ...body };
+      delete achBody.network;
+      const data = await plaidRequest('/transfer/create', achBody, credentials);
+      return {
+        transferId: data.transfer_id,
+        status: data.status,
+        network: 'ach', // Fell back to ACH
+      };
+    }
+    throw err;
+  }
+}
+
+/**
+ * Check the status of a transfer.
+ *
+ * @param {string} transferId   Transfer ID from createTransfer()
+ * @param {object} credentials
+ * @returns {Promise<{ transferId: string, status: string, amount: number, network: string }>}
+ */
+export async function getTransferStatus(transferId, credentials) {
+  const data = await plaidRequest('/transfer/get', {
+    transfer_id: transferId,
+  }, credentials);
+
+  return {
+    transferId: data.transfer_id,
+    status: data.status,
+    amount: data.amount,
+    network: data.network || 'ach',
   };
 }

--- a/packages/integrations/src/plaid.test.js
+++ b/packages/integrations/src/plaid.test.js
@@ -4,7 +4,17 @@ import assert from 'node:assert/strict';
 // Mock fetch for server-side API tests
 const originalFetch = globalThis.fetch;
 
-describe('plaid server-side', () => {
+describe('plaid client-side', () => {
+  it('loadPlaidScript rejects in Node.js', async () => {
+    const { loadPlaidScript } = await import('./plaid.js');
+    await assert.rejects(
+      () => loadPlaidScript(),
+      /requires a browser environment/
+    );
+  });
+});
+
+describe('plaid server-side — link token', () => {
   it('createLinkToken calls /link/token/create', async () => {
     globalThis.fetch = mock.fn(() => Promise.resolve({
       ok: true,
@@ -38,7 +48,9 @@ describe('plaid server-side', () => {
 
     globalThis.fetch = originalFetch;
   });
+});
 
+describe('plaid server-side — token exchange', () => {
   it('exchangePublicToken calls /item/public_token/exchange', async () => {
     globalThis.fetch = mock.fn(() => Promise.resolve({
       ok: true,
@@ -49,7 +61,6 @@ describe('plaid server-side', () => {
       }),
     }));
 
-    // Re-import to use fresh fetch mock
     const mod = await import('./plaid.js?v=2');
     const result = await mod.exchangePublicToken(
       'public-sandbox-token',
@@ -61,6 +72,37 @@ describe('plaid server-side', () => {
 
     const body = JSON.parse(globalThis.fetch.mock.calls[0].arguments[1].body);
     assert.equal(body.public_token, 'public-sandbox-token');
+
+    globalThis.fetch = originalFetch;
+  });
+});
+
+describe('plaid server-side — accounts & balances', () => {
+  it('getAccounts calls /accounts/get', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        accounts: [{
+          account_id: 'acc-1',
+          name: 'Checking',
+          type: 'depository',
+          subtype: 'checking',
+        }],
+      }),
+    }));
+
+    const mod = await import('./plaid.js?v=3a');
+    const result = await mod.getAccounts(
+      'access-token',
+      { clientId: 'cid', secret: 'sec', env: 'sandbox' }
+    );
+
+    assert.equal(result.accounts.length, 1);
+    assert.equal(result.accounts[0].id, 'acc-1');
+    assert.equal(result.accounts[0].name, 'Checking');
+
+    const [url] = globalThis.fetch.mock.calls[0].arguments;
+    assert.equal(url, 'https://sandbox.plaid.com/accounts/get');
 
     globalThis.fetch = originalFetch;
   });
@@ -84,7 +126,7 @@ describe('plaid server-side', () => {
       }),
     }));
 
-    const mod = await import('./plaid.js?v=3');
+    const mod = await import('./plaid.js?v=3b');
     const result = await mod.getBalances(
       'access-token',
       { clientId: 'cid', secret: 'sec', env: 'sandbox' }
@@ -92,13 +134,210 @@ describe('plaid server-side', () => {
 
     assert.equal(result.accounts.length, 1);
     assert.equal(result.accounts[0].id, 'acc-1');
-    assert.equal(result.accounts[0].name, 'Checking');
     assert.equal(result.accounts[0].balances.available, 1000);
     assert.equal(result.accounts[0].balances.currency, 'USD');
 
     globalThis.fetch = originalFetch;
   });
 
+  it('getBalance is an alias for getBalances', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        accounts: [{
+          account_id: 'acc-1',
+          name: 'Savings',
+          type: 'depository',
+          subtype: 'savings',
+          balances: {
+            available: 5000,
+            current: 5000,
+            limit: null,
+            iso_currency_code: 'USD',
+          },
+        }],
+      }),
+    }));
+
+    const mod = await import('./plaid.js?v=3c');
+    const result = await mod.getBalance(
+      'access-token',
+      { clientId: 'cid', secret: 'sec', env: 'sandbox' }
+    );
+
+    assert.equal(result.accounts[0].balances.available, 5000);
+
+    globalThis.fetch = originalFetch;
+  });
+});
+
+describe('plaid server-side — transfers', () => {
+  it('createTransfer initiates a transfer', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        transfer_id: 'xfer-001',
+        status: 'pending',
+        network: 'ach',
+      }),
+    }));
+
+    const mod = await import('./plaid.js?v=4a');
+    const result = await mod.createTransfer({
+      accessToken: 'access-token',
+      accountId: 'acc-1',
+      type: 'debit',
+      amount: 50000, // $500 in cents
+      description: 'Test transfer',
+    }, { clientId: 'cid', secret: 'sec', env: 'sandbox' });
+
+    assert.equal(result.transferId, 'xfer-001');
+    assert.equal(result.status, 'pending');
+    assert.equal(result.network, 'ach');
+
+    const [url, opts] = globalThis.fetch.mock.calls[0].arguments;
+    assert.equal(url, 'https://sandbox.plaid.com/transfer/create');
+
+    const body = JSON.parse(opts.body);
+    assert.equal(body.amount, 500); // Converted to dollars
+    assert.equal(body.type, 'debit');
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('createTransfer supports FedNow (RTP) network', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        transfer_id: 'xfer-fedNow',
+        status: 'pending',
+        network: 'rtp',
+      }),
+    }));
+
+    const mod = await import('./plaid.js?v=4b');
+    const result = await mod.createTransfer({
+      accessToken: 'access-token',
+      accountId: 'acc-1',
+      type: 'debit',
+      amount: 100000,
+      description: 'FedNow transfer',
+      network: 'rtp',
+    }, { clientId: 'cid', secret: 'sec', env: 'sandbox' });
+
+    assert.equal(result.transferId, 'xfer-fedNow');
+    assert.equal(result.network, 'rtp');
+
+    const body = JSON.parse(globalThis.fetch.mock.calls[0].arguments[1].body);
+    assert.equal(body.network, 'rtp');
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('createTransfer falls back from FedNow to ACH on error', async () => {
+    let callCount = 0;
+    globalThis.fetch = mock.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        // First call (RTP) fails
+        return Promise.resolve({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({
+            error_message: 'INVALID_REQUEST',
+            error_code: 'INVALID_REQUEST',
+            error_type: 'INVALID_INPUT',
+          }),
+        });
+      }
+      // Second call (ACH fallback) succeeds
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          transfer_id: 'xfer-ach-fallback',
+          status: 'pending',
+          network: 'ach',
+        }),
+      });
+    });
+
+    const mod = await import('./plaid.js?v=4c');
+    const result = await mod.createTransfer({
+      accessToken: 'access-token',
+      accountId: 'acc-1',
+      type: 'debit',
+      amount: 100000,
+      description: 'FedNow with fallback',
+      network: 'rtp',
+    }, { clientId: 'cid', secret: 'sec', env: 'sandbox' });
+
+    assert.equal(result.transferId, 'xfer-ach-fallback');
+    assert.equal(result.network, 'ach');
+    assert.equal(callCount, 2);
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('getTransferStatus checks transfer status', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        transfer_id: 'xfer-001',
+        status: 'posted',
+        amount: 500,
+        network: 'ach',
+      }),
+    }));
+
+    const mod = await import('./plaid.js?v=4d');
+    const result = await mod.getTransferStatus(
+      'xfer-001',
+      { clientId: 'cid', secret: 'sec', env: 'sandbox' }
+    );
+
+    assert.equal(result.transferId, 'xfer-001');
+    assert.equal(result.status, 'posted');
+    assert.equal(result.amount, 500);
+
+    const [url] = globalThis.fetch.mock.calls[0].arguments;
+    assert.equal(url, 'https://sandbox.plaid.com/transfer/get');
+
+    globalThis.fetch = originalFetch;
+  });
+});
+
+describe('plaid server-side — factory client', () => {
+  it('createPlaidClient returns an API client', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        access_token: 'access-xyz',
+        item_id: 'item-001',
+        request_id: 'req-123',
+      }),
+    }));
+
+    const { createPlaidClient } = await import('./plaid.js?v=5');
+    const client = createPlaidClient({
+      clientId: 'test-id',
+      secret: 'test-secret',
+      environment: 'sandbox',
+    });
+
+    assert.ok(client.exchangePublicToken);
+    assert.ok(client.getAccounts);
+    assert.ok(client.getBalance);
+    assert.ok(client.createTransfer);
+    assert.ok(client.getTransferStatus);
+
+    const result = await client.exchangePublicToken('pub-token');
+    assert.equal(result.accessToken, 'access-xyz');
+
+    globalThis.fetch = originalFetch;
+  });
+});
+
+describe('plaid server-side — error handling', () => {
   it('throws on Plaid API error', async () => {
     globalThis.fetch = mock.fn(() => Promise.resolve({
       ok: false,
@@ -109,7 +348,7 @@ describe('plaid server-side', () => {
       }),
     }));
 
-    const mod = await import('./plaid.js?v=4');
+    const mod = await import('./plaid.js?v=6');
     await assert.rejects(
       () => mod.createLinkToken({ userId: 'u1' }, { clientId: 'bad', secret: 'bad', env: 'sandbox' }),
       (err) => {
@@ -123,18 +362,10 @@ describe('plaid server-side', () => {
   });
 
   it('rejects unknown env', async () => {
-    const mod = await import('./plaid.js?v=5');
+    const mod = await import('./plaid.js?v=7');
     await assert.rejects(
       () => mod.createLinkToken({ userId: 'u1' }, { clientId: 'c', secret: 's', env: 'invalid' }),
       /unknown env/
-    );
-  });
-
-  it('loadPlaidScript rejects in Node.js', async () => {
-    const mod = await import('./plaid.js?v=6');
-    await assert.rejects(
-      () => mod.loadPlaidScript(),
-      /requires a browser environment/
     );
   });
 });

--- a/packages/integrations/src/yield.js
+++ b/packages/integrations/src/yield.js
@@ -1,0 +1,170 @@
+/**
+ * Yield optimization for idle float management in PendingBusiness.
+ *
+ * Pure functions for determining optimal account allocation and transfer timing.
+ * No external API calls — just the math for float yield maximization.
+ */
+
+/**
+ * Find the best yield account from a list of linked accounts with balances and APYs.
+ *
+ * @param {Array<{ id: string, name: string, balance: number, apy: number }>} accounts
+ * @returns {{ accountId: string, accountName: string, apy: number, expectedMonthlyYield: number }}
+ */
+export function findBestYieldAccount(accounts) {
+  if (!accounts || accounts.length === 0) {
+    throw new Error('No accounts provided for yield calculation');
+  }
+
+  let best = accounts[0];
+  for (let i = 1; i < accounts.length; i++) {
+    if (accounts[i].apy > best.apy) {
+      best = accounts[i];
+    }
+  }
+
+  // Calculate expected monthly yield on the account's current balance
+  const monthlyRate = best.apy / 12;
+  const expectedMonthlyYield = best.balance * monthlyRate;
+
+  return {
+    accountId: best.id,
+    accountName: best.name,
+    apy: best.apy,
+    expectedMonthlyYield,
+  };
+}
+
+/**
+ * Determine optimal float allocation across multiple accounts.
+ *
+ * Allocates funds to maximize total yield while respecting account limits.
+ *
+ * @param {Array<{ id: string, name: string, balance: number, apy: number, maxBalance?: number }>} accounts
+ * @param {number} totalFloat     Total float to allocate across accounts
+ * @returns {Array<{ accountId: string, accountName: string, allocation: number, expectedYield: number }>}
+ */
+export function optimizeFloatAllocation(accounts, totalFloat) {
+  if (!accounts || accounts.length === 0) {
+    throw new Error('No accounts provided for allocation');
+  }
+
+  if (totalFloat < 0) {
+    throw new Error('Total float must be non-negative');
+  }
+
+  // Sort accounts by APY descending
+  const sorted = [...accounts].sort((a, b) => b.apy - a.apy);
+
+  const allocation = [];
+  let remaining = totalFloat;
+
+  for (const account of sorted) {
+    const max = account.maxBalance || Infinity;
+    const allocate = Math.min(remaining, max - (account.balance || 0));
+
+    if (allocate > 0) {
+      const monthlyRate = account.apy / 12;
+      const expectedYield = allocate * monthlyRate;
+
+      allocation.push({
+        accountId: account.id,
+        accountName: account.name,
+        allocation: allocate,
+        expectedYield,
+      });
+
+      remaining -= allocate;
+    }
+
+    if (remaining === 0) break;
+  }
+
+  return allocation;
+}
+
+/**
+ * Calculate optimal timing for float transfers based on liability due dates and yield.
+ *
+ * Returns a transfer schedule that keeps idle float in high-yield accounts
+ * until it's needed to cover liabilities.
+ *
+ * @param {Array<{ dueDate: Date, amount: number, description?: string }>} liabilities
+ * @param {Array<{ id: string, name: string, currentBalance: number, apy: number }>} accounts
+ * @returns {Array<{ transferDate: Date, fromAccountId: string, amount: number, reason: string }>}
+ */
+export function calculateOptimalTransferTiming(liabilities, accounts) {
+  if (!liabilities || liabilities.length === 0) {
+    return [];
+  }
+
+  if (!accounts || accounts.length === 0) {
+    throw new Error('No accounts available for float management');
+  }
+
+  // Find the best yield account
+  const best = findBestYieldAccount(accounts);
+
+  // Sort liabilities by due date
+  const sorted = [...liabilities].sort((a, b) => a.dueDate - b.dueDate);
+
+  const schedule = [];
+  const transferBuffer = 2; // days before due date to transfer
+
+  for (const liability of sorted) {
+    const transferDate = new Date(liability.dueDate);
+    transferDate.setDate(transferDate.getDate() - transferBuffer);
+
+    schedule.push({
+      transferDate,
+      fromAccountId: best.accountId,
+      amount: liability.amount,
+      reason: liability.description || 'Scheduled liability payment',
+    });
+  }
+
+  return schedule;
+}
+
+/**
+ * Calculate the break-even point for a transfer based on yield difference.
+ *
+ * Determines if it's worth transferring money from one account to another
+ * based on the yield difference and transfer cost.
+ *
+ * @param {number} amount             Amount to transfer (in cents)
+ * @param {number} fromApy            APY of source account
+ * @param {number} toApy              APY of destination account
+ * @param {number} [transferCostCents=0] Fixed transfer cost (usually 0 for ACH)
+ * @param {number} [daysFloat=30]     Number of days the money will be in destination
+ * @returns {{ profitable: boolean, yieldGain: number, breakEvenDays: number }}
+ */
+export function calculateBreakEven(amount, fromApy, toApy, transferCostCents = 0, daysFloat = 30) {
+  if (toApy <= fromApy) {
+    return {
+      profitable: false,
+      yieldGain: 0,
+      breakEvenDays: Infinity,
+    };
+  }
+
+  const amountDollars = amount / 100;
+  const costDollars = transferCostCents / 100;
+
+  // Daily yield difference
+  const yieldDiff = toApy - fromApy;
+  const dailyYieldGain = amountDollars * (yieldDiff / 365);
+
+  // Break-even point (how many days to recoup transfer cost)
+  const breakEvenDays = dailyYieldGain > 0 ? costDollars / dailyYieldGain : Infinity;
+
+  // Total yield gain over daysFloat
+  const totalYieldGain = dailyYieldGain * daysFloat;
+  const netGain = totalYieldGain - costDollars;
+
+  return {
+    profitable: netGain > 0,
+    yieldGain: netGain,
+    breakEvenDays,
+  };
+}

--- a/packages/integrations/src/yield.test.js
+++ b/packages/integrations/src/yield.test.js
@@ -1,0 +1,263 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  findBestYieldAccount,
+  optimizeFloatAllocation,
+  calculateOptimalTransferTiming,
+  calculateBreakEven,
+} from './yield.js';
+
+describe('yield optimization', () => {
+  describe('findBestYieldAccount', () => {
+    it('returns the account with highest APY', () => {
+      const accounts = [
+        { id: 'acc-1', name: 'Checking', balance: 1000, apy: 0.01 },
+        { id: 'acc-2', name: 'Money Market', balance: 5000, apy: 0.045 },
+        { id: 'acc-3', name: 'Savings', balance: 2000, apy: 0.035 },
+      ];
+
+      const result = findBestYieldAccount(accounts);
+
+      assert.equal(result.accountId, 'acc-2');
+      assert.equal(result.accountName, 'Money Market');
+      assert.equal(result.apy, 0.045);
+    });
+
+    it('calculates expected monthly yield correctly', () => {
+      const accounts = [
+        { id: 'acc-1', name: 'Test', balance: 12000, apy: 0.12 }, // 12% APY = 1% per month
+      ];
+
+      const result = findBestYieldAccount(accounts);
+
+      // 12000 * (0.12 / 12) = 120
+      assert.equal(result.expectedMonthlyYield, 120);
+    });
+
+    it('throws on empty accounts', () => {
+      assert.throws(
+        () => findBestYieldAccount([]),
+        /No accounts provided/
+      );
+    });
+
+    it('throws on null accounts', () => {
+      assert.throws(
+        () => findBestYieldAccount(null),
+        /No accounts provided/
+      );
+    });
+
+    it('handles single account', () => {
+      const accounts = [
+        { id: 'only', name: 'Single', balance: 5000, apy: 0.05 },
+      ];
+
+      const result = findBestYieldAccount(accounts);
+
+      assert.equal(result.accountId, 'only');
+      assert.equal(result.apy, 0.05);
+    });
+  });
+
+  describe('optimizeFloatAllocation', () => {
+    it('allocates float to highest-yield accounts first', () => {
+      const accounts = [
+        { id: 'low', name: 'Low Yield', balance: 1000, apy: 0.01, maxBalance: Infinity },
+        { id: 'high', name: 'High Yield', balance: 2000, apy: 0.05, maxBalance: Infinity },
+        { id: 'mid', name: 'Mid Yield', balance: 1500, apy: 0.03, maxBalance: Infinity },
+      ];
+
+      const result = optimizeFloatAllocation(accounts, 10000);
+
+      assert.equal(result.length, 1);
+      assert.equal(result[0].accountId, 'high'); // Highest APY first
+      assert.equal(result[0].allocation, 10000); // All goes to high
+    });
+
+    it('respects max balance limits', () => {
+      const accounts = [
+        { id: 'acc-1', name: 'Limited', balance: 2000, apy: 0.10, maxBalance: 5000 },
+        { id: 'acc-2', name: 'Unlimited', balance: 1000, apy: 0.08 },
+      ];
+
+      const result = optimizeFloatAllocation(accounts, 5000);
+
+      const acc1 = result.find(r => r.accountId === 'acc-1');
+      const acc2 = result.find(r => r.accountId === 'acc-2');
+
+      assert.equal(acc1.allocation, 3000); // Limited to 5000 - 2000
+      assert.equal(acc2.allocation, 2000); // Remainder
+    });
+
+    it('calculates expected yield for each allocation', () => {
+      const accounts = [
+        { id: 'acc-1', name: 'Test', balance: 0, apy: 0.12 },
+      ];
+
+      const result = optimizeFloatAllocation(accounts, 10000);
+
+      // 10000 * (0.12 / 12) = 100
+      assert.equal(result[0].expectedYield, 100);
+    });
+
+    it('handles zero float', () => {
+      const accounts = [
+        { id: 'acc-1', name: 'Test', balance: 1000, apy: 0.05 },
+      ];
+
+      const result = optimizeFloatAllocation(accounts, 0);
+
+      assert.equal(result.length, 0);
+    });
+
+    it('throws on negative float', () => {
+      const accounts = [
+        { id: 'acc-1', name: 'Test', balance: 1000, apy: 0.05 },
+      ];
+
+      assert.throws(
+        () => optimizeFloatAllocation(accounts, -1000),
+        /non-negative/
+      );
+    });
+
+    it('throws on empty accounts', () => {
+      assert.throws(
+        () => optimizeFloatAllocation([], 10000),
+        /No accounts provided/
+      );
+    });
+  });
+
+  describe('calculateOptimalTransferTiming', () => {
+    it('creates transfer schedule for liabilities', () => {
+      const liabilities = [
+        { dueDate: new Date('2025-05-15'), amount: 5000, description: 'Payroll' },
+        { dueDate: new Date('2025-06-01'), amount: 3000, description: 'Rent' },
+      ];
+
+      const accounts = [
+        { id: 'acc-1', name: 'Money Market', balance: 10000, apy: 0.05 },
+      ];
+
+      const schedule = calculateOptimalTransferTiming(liabilities, accounts);
+
+      assert.equal(schedule.length, 2);
+      assert.equal(schedule[0].amount, 5000);
+      assert.equal(schedule[1].amount, 3000);
+    });
+
+    it('schedules transfers 2 days before due date', () => {
+      const dueDate = new Date('2025-05-15');
+      const liabilities = [{ dueDate, amount: 1000 }];
+
+      const accounts = [
+        { id: 'acc-1', name: 'Test', balance: 5000, apy: 0.05 },
+      ];
+
+      const schedule = calculateOptimalTransferTiming(liabilities, accounts);
+
+      const expectedDate = new Date(dueDate);
+      expectedDate.setDate(expectedDate.getDate() - 2);
+
+      assert.equal(schedule[0].transferDate.toISOString(), expectedDate.toISOString());
+    });
+
+    it('sorts schedule by due date', () => {
+      const liabilities = [
+        { dueDate: new Date('2025-06-01'), amount: 1000 },
+        { dueDate: new Date('2025-05-01'), amount: 2000 },
+        { dueDate: new Date('2025-05-15'), amount: 1500 },
+      ];
+
+      const accounts = [
+        { id: 'acc-1', name: 'Test', balance: 10000, apy: 0.05 },
+      ];
+
+      const schedule = calculateOptimalTransferTiming(liabilities, accounts);
+
+      assert.equal(schedule[0].amount, 2000); // May 1
+      assert.equal(schedule[1].amount, 1500); // May 15
+      assert.equal(schedule[2].amount, 1000); // June 1
+    });
+
+    it('throws on empty liabilities', () => {
+      const accounts = [
+        { id: 'acc-1', name: 'Test', balance: 5000, apy: 0.05 },
+      ];
+
+      const result = calculateOptimalTransferTiming([], accounts);
+      assert.equal(result.length, 0);
+    });
+
+    it('throws on empty accounts', () => {
+      const liabilities = [
+        { dueDate: new Date('2025-05-15'), amount: 1000 },
+      ];
+
+      assert.throws(
+        () => calculateOptimalTransferTiming(liabilities, []),
+        /No accounts available/
+      );
+    });
+  });
+
+  describe('calculateBreakEven', () => {
+    it('determines profitability of a transfer', () => {
+      // 5% source, 10% destination, $1000, 30 days
+      // Yield diff = 5% / year = 0.05 / 365 * 1000 * 30 = $4.11
+      // No transfer cost, so profitable
+      const result = calculateBreakEven(100000, 0.05, 0.10, 0, 30);
+
+      assert.equal(result.profitable, true);
+      assert.ok(result.yieldGain > 0);
+    });
+
+    it('calculates break-even days correctly', () => {
+      // $1000, 5% difference, $1 transfer cost
+      // Daily yield = 1000 * (0.05 / 365) = $0.137
+      // Break-even = 1 / 0.137 ≈ 7.3 days
+      const result = calculateBreakEven(100000, 0.05, 0.10, 100);
+
+      assert.ok(result.breakEvenDays > 0);
+      assert.ok(result.breakEvenDays < 100);
+    });
+
+    it('returns false when destination APY is lower', () => {
+      const result = calculateBreakEven(100000, 0.10, 0.05, 0, 30);
+
+      assert.equal(result.profitable, false);
+      assert.equal(result.yieldGain, 0);
+      assert.equal(result.breakEvenDays, Infinity);
+    });
+
+    it('returns false when destination APY equals source APY', () => {
+      const result = calculateBreakEven(100000, 0.05, 0.05, 0, 30);
+
+      assert.equal(result.profitable, false);
+    });
+
+    it('accounts for transfer costs', () => {
+      // Small amount, high cost relative to gain
+      const result = calculateBreakEven(10000, 0.05, 0.10, 10000, 1); // $100 transfer cost
+
+      assert.equal(result.profitable, false); // Cost exceeds 1-day gain
+    });
+
+    it('uses defaults for optional parameters', () => {
+      const result = calculateBreakEven(100000, 0.05, 0.10);
+
+      assert.equal(result.profitable, true);
+      assert.ok(result.yieldGain > 0);
+    });
+
+    it('handles zero transfer cost', () => {
+      const result = calculateBreakEven(100000, 0.05, 0.10, 0, 30);
+
+      assert.equal(result.profitable, true);
+      assert.ok(result.yieldGain > 0);
+      assert.ok(result.breakEvenDays < 1); // Should be immediate with no cost
+    });
+  });
+});

--- a/packages/integrations/types/index.d.ts
+++ b/packages/integrations/types/index.d.ts
@@ -57,8 +57,75 @@ export interface OpenPlaidLinkOptions {
   onEvent?: (eventName: string, metadata: unknown) => void;
 }
 
+// Client-side Link API
 export function loadPlaidScript(): Promise<void>;
 export function openPlaidLink(options: OpenPlaidLinkOptions): Promise<PlaidLinkHandler>;
+export function createPlaidLink(config: any): Promise<any>;
+
+// Server-side API
+export interface PlaidClient {
+  exchangePublicToken(publicToken: string): Promise<ExchangeResult>;
+  getAccounts(accessToken: string): Promise<any>;
+  getBalance(accessToken: string): Promise<BalancesResult>;
+  createTransfer(params: any): Promise<any>;
+  getTransferStatus(transferId: string): Promise<any>;
+}
+
+export function createPlaidClient(config: { clientId: string; secret: string; environment?: string }): PlaidClient;
 export function createLinkToken(options: LinkTokenOptions, credentials: PlaidCredentials): Promise<LinkTokenResult>;
 export function exchangePublicToken(publicToken: string, credentials: PlaidCredentials): Promise<ExchangeResult>;
+export function getAccounts(accessToken: string, credentials: PlaidCredentials): Promise<any>;
 export function getBalances(accessToken: string, credentials: PlaidCredentials): Promise<BalancesResult>;
+export function getBalance(accessToken: string, credentials: PlaidCredentials): Promise<BalancesResult>;
+export function createTransfer(params: any, credentials: PlaidCredentials): Promise<any>;
+export function getTransferStatus(transferId: string, credentials: PlaidCredentials): Promise<any>;
+
+// Yield optimization API
+export interface YieldAccount {
+  id: string;
+  name: string;
+  balance: number;
+  apy: number;
+  maxBalance?: number;
+}
+
+export interface BestYieldResult {
+  accountId: string;
+  accountName: string;
+  apy: number;
+  expectedMonthlyYield: number;
+}
+
+export interface FloatAllocation {
+  accountId: string;
+  accountName: string;
+  allocation: number;
+  expectedYield: number;
+}
+
+export interface TransferSchedule {
+  transferDate: Date;
+  fromAccountId: string;
+  amount: number;
+  reason: string;
+}
+
+export interface BreakEvenResult {
+  profitable: boolean;
+  yieldGain: number;
+  breakEvenDays: number;
+}
+
+export function findBestYieldAccount(accounts: YieldAccount[]): BestYieldResult;
+export function optimizeFloatAllocation(accounts: YieldAccount[], totalFloat: number): FloatAllocation[];
+export function calculateOptimalTransferTiming(
+  liabilities: Array<{ dueDate: Date; amount: number; description?: string }>,
+  accounts: YieldAccount[]
+): TransferSchedule[];
+export function calculateBreakEven(
+  amount: number,
+  fromApy: number,
+  toApy: number,
+  transferCostCents?: number,
+  daysFloat?: number
+): BreakEvenResult;


### PR DESCRIPTION
## Summary
- Extends `@basenative/integrations/plaid` with a server-side `createPlaidClient` plus `getAccounts`, `getBalance`, `createTransfer`, `getTransferStatus` (FedNow-compatible).
- Adds `@basenative/integrations/yield` subpath: `findBestYieldAccount`, `optimizeFloatAllocation`, `calculateOptimalTransferTiming`, `calculateBreakEven`.
- Exposes the new entrypoint via `package.json` `exports` and updates `types/index.d.ts`.
- Unblocks PendingBusiness's FedNow auto-pay engine per CLAUDE.md upstream-dogfooding directive (Epic 1C).
- All 36 tests in `@basenative/integrations` pass.

## Test plan
- [x] `cd packages/integrations && node --test` — 36/36 pass
- [ ] Spot-check `createPlaidClient` against Plaid sandbox in a downstream app
- [ ] Validate yield math against PendingBusiness's float scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)