### PR TITLE
feat(builder): visual builder engine with drag-drop canvas, codegen, and 74 tests (Epic 4)

### DIFF
--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -1,0 +1,170 @@
+# @basenative/builder
+
+Signal-based drag-and-drop component builder for BaseNative. Compose layouts visually, edit props through a reactive inspector, and generate clean BaseNative template code as output.
+
+- **Zero dependencies** beyond `@basenative/runtime`.
+- **Dogfoods BaseNative signals** — every piece of builder state is a `signal()`.
+- **Native HTML5 drag-and-drop** — no shadow DOM, no custom DnD layer.
+- **Semantic HTML** with full ARIA roles (`role="tree"`, `role="application"`, `role="toolbar"`).
+- **`display: contents` on every host element** — wrappers do not affect layout.
+- **CSP-safe code generation** — output is plain HTML/templates; no `eval`.
+
+## Install
+
+```bash
+pnpm add @basenative/builder
+```
+
+## Quick start (programmatic)
+
+```js
+import { createBuilderState, defaultPalette, generateBaseNative } from '@basenative/builder';
+
+const palette = defaultPalette();
+const state = createBuilderState();
+
+const hero = state.addNode(null, { type: 'section', props: { class: 'hero' } });
+state.addNode(hero.id, { type: 'heading', props: { level: 'h1', text: 'Welcome' } });
+state.addNode(hero.id, { type: 'text', props: { text: 'A quiet runtime.' } });
+
+console.log(generateBaseNative(state, { palette }));
+```
+
+Output:
+
+```html
+<section class="hero" role="region">
+  <h1>Welcome</h1>
+  <p>A quiet runtime.</p>
+</section>
+```
+
+## Quick start (in the browser)
+
+```html
+<bn-builder></bn-builder>
+
+<script type="module">
+  import '@basenative/builder';
+
+  const builder = document.querySelector('bn-builder');
+  builder.addEventListener('bn-builder-export', (e) => {
+    console.log(e.detail.code);
+  });
+</script>
+```
+
+The `<bn-builder>` element mounts four panes:
+
+| Element | Role |
+| --- | --- |
+| `<bn-builder-palette>` | Drag source for components |
+| `<bn-builder-canvas>` | Drop target — live preview of the tree |
+| `<bn-builder-tree>` | Hierarchical outline of nodes |
+| `<bn-builder-inspector>` | Reactive form for editing props and signal bindings |
+
+## Signal bindings
+
+Each node has a `bindings` map that wires a prop name to a signal in user scope. The codegen emits this as a BaseNative directive:
+
+```js
+const node = state.addNode(null, { type: 'input' });
+state.setBinding(node.id, 'value', { ref: 'username' });
+
+generateBaseNative(state, { palette, signals: { username: '' } });
+```
+
+Output:
+
+```html
+<script type="module">
+  import { signal } from '@basenative/runtime';
+
+  const username = signal("");
+</script>
+<input type="text" @bind="username" />
+```
+
+For text content:
+
+```js
+state.setBinding(id, 'text', { ref: 'count' });
+// → <span>{{ count() }}</span>
+```
+
+## Public API
+
+```ts
+createBuilderState(options?): BuilderState
+createPalette(): ComponentPalette
+defaultPalette(): ComponentPalette
+generateBaseNative(state, options?): string
+renderTreeView(state): string
+renderInspector(state, palette): string
+```
+
+`BuilderState` exposes signals (`tree`, `selection`, `hover`, `canUndo`, `canRedo`) and actions (`addNode`, `removeNode`, `updateProps`, `setBinding`, `moveNode`, `duplicateNode`, `select`, `undo`, `redo`, `clear`, `toJSON`, `fromJSON`, `subscribe`).
+
+The signals are first-class — wire them into your own `effect()` to react to user edits:
+
+```js
+import { effect } from '@basenative/runtime';
+
+effect(() => console.log('Tree size:', state.tree().length));
+```
+
+## Default palette
+
+| Type | Tag | Container | Category |
+| --- | --- | --- | --- |
+| `section` | `<section role="region">` | yes | layout |
+| `stack` | `<div>` | yes | layout |
+| `grid` | `<div>` | yes | layout |
+| `heading` | `<h1>`–`<h6>` | no | text |
+| `text` | `<p>` | no | text |
+| `button` | `<button>` | no | inputs |
+| `input` | `<input>` | no | inputs |
+| `textarea` | `<textarea>` | no | inputs |
+| `checkbox` | `<input type="checkbox">` | no | inputs |
+| `label` | `<label>` | yes | inputs |
+| `form` | `<form>` | yes | inputs |
+| `link` | `<a>` | no | navigation |
+| `image` | `<img>` | no | media |
+| `signal-text` | `<span>{{ … }}</span>` | no | reactive |
+
+Register your own:
+
+```js
+palette.register({
+  type: 'kbd',
+  tag: 'kbd',
+  category: 'text',
+  props: [{ name: 'text', kind: 'string', label: 'Key' }],
+  defaults: { text: '⌘K' },
+});
+```
+
+## Persistence
+
+```js
+const json = state.toJSON();
+// store somewhere
+
+state.fromJSON(json); // wipes history, hydrates tree
+```
+
+## Keyboard shortcuts (canvas)
+
+| Keys | Action |
+| --- | --- |
+| `Delete` / `Backspace` | Remove selected node |
+| `Cmd/Ctrl + Z` | Undo |
+| `Cmd/Ctrl + Shift + Z` / `Cmd/Ctrl + Y` | Redo |
+
+## Tests
+
+```bash
+cd packages/builder && node --test
+```
+
+Tests are written with `node:test` — no Jest, no Vitest, no browser harness required for the pure logic. Web component tests require a DOM and are exercised in downstream apps.

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@basenative/builder",
+  "version": "0.1.0",
+  "description": "Signal-based drag-and-drop component builder for BaseNative — composes layouts, generates clean BaseNative code",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "types": "./types/index.d.ts",
+  "dependencies": {
+    "@basenative/runtime": "workspace:*"
+  },
+  "files": [
+    "src",
+    "types"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DuganLabs/basenative.git",
+    "directory": "packages/builder"
+  },
+  "homepage": "https://github.com/DuganLabs/basenative#readme",
+  "bugs": {
+    "url": "https://github.com/DuganLabs/basenative/issues"
+  },
+  "keywords": [
+    "basenative",
+    "builder",
+    "visual-builder",
+    "drag-and-drop",
+    "signals",
+    "code-generation",
+    "no-code",
+    "zero-dependencies"
+  ]
+}

--- a/packages/builder/project.json
+++ b/packages/builder/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "@basenative/builder",
+  "targets": {
+    "test": {
+      "cache": true,
+      "command": "node --test",
+      "inputs": ["{projectRoot}/src/**/*.js"]
+    },
+    "lint": {
+      "cache": true,
+      "command": "pnpm exec eslint src/",
+      "inputs": ["{projectRoot}/src/**/*.js"]
+    }
+  }
+}

--- a/packages/builder/src/builder-element.js
+++ b/packages/builder/src/builder-element.js
@@ -1,0 +1,101 @@
+import { createBuilderState } from './state.js';
+import { defaultPalette } from './palette.js';
+import { generateBaseNative } from './codegen.js';
+import { BnBuilderCanvas } from './canvas-element.js';
+import { BnBuilderPalette } from './palette-element.js';
+import { BnBuilderTree } from './tree-element.js';
+import { BnBuilderInspector } from './inspector-element.js';
+
+const TAG = 'bn-builder';
+
+const LAYOUT_HTML = `
+<div class="bn-builder">
+  <header class="bn-builder__toolbar" role="toolbar" aria-label="Builder actions">
+    <button type="button" data-bn-builder-action="undo" class="bn-builder__btn">Undo</button>
+    <button type="button" data-bn-builder-action="redo" class="bn-builder__btn">Redo</button>
+    <button type="button" data-bn-builder-action="clear" class="bn-builder__btn">Clear</button>
+    <button type="button" data-bn-builder-action="export" class="bn-builder__btn">Export Code</button>
+  </header>
+  <div class="bn-builder__panes">
+    <aside class="bn-builder__pane bn-builder__pane--palette" aria-label="Components">
+      <bn-builder-palette></bn-builder-palette>
+    </aside>
+    <main class="bn-builder__pane bn-builder__pane--canvas">
+      <bn-builder-canvas></bn-builder-canvas>
+    </main>
+    <aside class="bn-builder__pane bn-builder__pane--side" aria-label="Inspector and tree">
+      <bn-builder-inspector></bn-builder-inspector>
+      <bn-builder-tree></bn-builder-tree>
+    </aside>
+  </div>
+</div>`;
+
+export class BnBuilder extends HTMLElement {
+  constructor() {
+    super();
+    this.state = null;
+    this.palette = null;
+  }
+
+  connectedCallback() {
+    this.style.display = 'contents';
+    this.setAttribute('role', 'application');
+    this.setAttribute('aria-label', 'BaseNative visual builder');
+
+    if (!this.state) this.state = createBuilderState();
+    if (!this.palette) this.palette = defaultPalette();
+
+    if (!this._mounted) {
+      this.innerHTML = LAYOUT_HTML;
+      this._mounted = true;
+    }
+
+    const palette = this.querySelector('bn-builder-palette');
+    const canvas = this.querySelector('bn-builder-canvas');
+    const tree = this.querySelector('bn-builder-tree');
+    const inspector = this.querySelector('bn-builder-inspector');
+
+    if (palette && palette.attach) palette.attach(this.palette);
+    if (canvas && canvas.attach) canvas.attach(this.state, this.palette);
+    if (tree && tree.attach) tree.attach(this.state);
+    if (inspector && inspector.attach) inspector.attach(this.state, this.palette);
+
+    this._wireToolbar();
+  }
+
+  attach({ state, palette }) {
+    if (state) this.state = state;
+    if (palette) this.palette = palette;
+    if (this.isConnected) this.connectedCallback();
+  }
+
+  generateCode(options) {
+    if (!this.state) return '';
+    return generateBaseNative(this.state, { palette: this.palette, ...options });
+  }
+
+  _wireToolbar() {
+    if (this._toolbarWired) return;
+    this._toolbarWired = true;
+    this.addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-bn-builder-action]');
+      if (!btn) return;
+      const action = btn.dataset.bnBuilderAction;
+      if (action === 'undo') this.state.undo();
+      else if (action === 'redo') this.state.redo();
+      else if (action === 'clear') this.state.clear();
+      else if (action === 'export') {
+        const code = this.generateCode();
+        this.dispatchEvent(new CustomEvent('bn-builder-export', { detail: { code }, bubbles: true }));
+      }
+    });
+  }
+}
+
+if (typeof customElements !== 'undefined') {
+  if (!customElements.get('bn-builder-palette')) customElements.define('bn-builder-palette', BnBuilderPalette);
+  if (!customElements.get('bn-builder-canvas')) customElements.define('bn-builder-canvas', BnBuilderCanvas);
+  if (!customElements.get('bn-builder-tree')) customElements.define('bn-builder-tree', BnBuilderTree);
+  if (!customElements.get('bn-builder-inspector')) customElements.define('bn-builder-inspector', BnBuilderInspector);
+  if (!customElements.get(TAG)) customElements.define(TAG, BnBuilder);
+}

--- a/packages/builder/src/canvas-element.js
+++ b/packages/builder/src/canvas-element.js
@@ -1,0 +1,196 @@
+import { effect } from '@basenative/runtime';
+import { renderNodeToElement, renderEmptyPlaceholder } from './dom-render.js';
+
+const CANVAS_TAG = 'bn-builder-canvas';
+
+export class BnBuilderCanvas extends HTMLElement {
+  constructor() {
+    super();
+    this.state = null;
+    this.palette = null;
+    this._root = null;
+    this._effect = null;
+    this._dragOverId = null;
+  }
+
+  connectedCallback() {
+    this.style.display = 'contents';
+    this.setAttribute('role', 'application');
+    this.setAttribute('aria-label', 'Builder canvas');
+
+    if (!this._root) {
+      this._root = document.createElement('div');
+      this._root.className = 'bn-builder__canvas-surface';
+      this._root.tabIndex = 0;
+      this.appendChild(this._root);
+    }
+
+    this._wireSurfaceEvents();
+    this._render();
+
+    if (this.state && !this._effect) {
+      this._effect = effect(() => {
+        this.state.tree();
+        this.state.selection();
+        this.state.hover();
+        this._render();
+      });
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._effect) {
+      this._effect.dispose();
+      this._effect = null;
+    }
+  }
+
+  attach(state, palette) {
+    this.state = state;
+    this.palette = palette;
+    if (this.isConnected) {
+      if (this._effect) this._effect.dispose();
+      this._effect = effect(() => {
+        state.tree();
+        state.selection();
+        state.hover();
+        this._render();
+      });
+    }
+  }
+
+  _render() {
+    if (!this._root || !this.state || !this.palette) return;
+    const tree = this.state.tree();
+    this._root.replaceChildren();
+
+    if (tree.length === 0) {
+      const empty = renderEmptyPlaceholder(document, 'Drag a component here to start building.');
+      empty.dataset.bnDropzone = 'root';
+      this._root.appendChild(empty);
+      return;
+    }
+
+    for (const node of tree) {
+      const el = renderNodeToElement(document, node, this.palette);
+      this._decorate(el, node);
+      this._root.appendChild(el);
+    }
+  }
+
+  _decorate(el, node) {
+    if (this.state.selection() === node.id) {
+      el.dataset.bnSelected = 'true';
+    } else {
+      delete el.dataset.bnSelected;
+    }
+    if (this.state.hover() === node.id) {
+      el.dataset.bnHover = 'true';
+    }
+    el.setAttribute('draggable', 'true');
+    if (node.children) {
+      for (let i = 0; i < node.children.length; i++) {
+        const childEl = el.querySelector(`[data-bn-node="${node.children[i].id}"]`);
+        if (childEl) this._decorate(childEl, node.children[i]);
+      }
+    }
+  }
+
+  _wireSurfaceEvents() {
+    if (this._root._bnWired) return;
+    this._root._bnWired = true;
+
+    this._root.addEventListener('click', (e) => {
+      const el = e.target.closest('[data-bn-node]');
+      if (!el) {
+        this.state.select(null);
+        return;
+      }
+      e.stopPropagation();
+      this.state.select(el.dataset.bnNode);
+    });
+
+    this._root.addEventListener('mouseover', (e) => {
+      const el = e.target.closest('[data-bn-node]');
+      if (el) this.state.hoverNode(el.dataset.bnNode);
+    });
+
+    this._root.addEventListener('mouseleave', () => {
+      this.state.hoverNode(null);
+    });
+
+    this._root.addEventListener('dragstart', (e) => {
+      const el = e.target.closest('[data-bn-node]');
+      if (!el) return;
+      e.dataTransfer.setData('application/x-bn-node-id', el.dataset.bnNode);
+      e.dataTransfer.effectAllowed = 'move';
+    });
+
+    this._root.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+    });
+
+    this._root.addEventListener('drop', (e) => {
+      e.preventDefault();
+      const moveId = e.dataTransfer.getData('application/x-bn-node-id');
+      const newType = e.dataTransfer.getData('application/x-bn-component-type');
+      const target = e.target.closest('[data-bn-node]');
+      const targetId = target ? target.dataset.bnNode : null;
+
+      if (newType) {
+        const def = this.palette.get(newType);
+        if (!def) return;
+        const parentId = target && this._isContainer(target) ? targetId : null;
+        this.state.addNode(parentId, { type: newType, props: { ...def.defaults } });
+        return;
+      }
+
+      if (moveId) {
+        if (moveId === targetId) return;
+        const targetNode = targetId ? this.state.getNode(targetId) : null;
+        if (target && targetNode && this._isContainer(target)) {
+          this.state.moveNode(moveId, targetId);
+        } else if (targetNode) {
+          const parent = this.state.getParent(targetId);
+          const parentId = parent ? parent.id : null;
+          const siblings = parent ? parent.children : this.state.tree();
+          const idx = siblings.findIndex((n) => n.id === targetId);
+          this.state.moveNode(moveId, parentId, idx + 1);
+        } else {
+          this.state.moveNode(moveId, null);
+        }
+      }
+    });
+
+    this.addEventListener('keydown', (e) => {
+      if (!this.state) return;
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        const id = this.state.selection();
+        if (id) {
+          e.preventDefault();
+          this.state.removeNode(id);
+        }
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') {
+        e.preventDefault();
+        if (e.shiftKey) this.state.redo();
+        else this.state.undo();
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'y') {
+        e.preventDefault();
+        this.state.redo();
+      }
+    });
+  }
+
+  _isContainer(el) {
+    if (!el) return false;
+    const def = this.palette.get(el.dataset.bnType);
+    return def ? def.container : false;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get(CANVAS_TAG)) {
+  customElements.define(CANVAS_TAG, BnBuilderCanvas);
+}

--- a/packages/builder/src/codegen.js
+++ b/packages/builder/src/codegen.js
@@ -1,0 +1,159 @@
+import { escapeHtml, escapeAttr, isValidIdentifier } from './escape.js';
+
+const VOID_ELEMENTS = new Set([
+  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr',
+]);
+
+const ATTR_PROPS = new Set([
+  'class', 'id', 'name', 'href', 'src', 'alt', 'placeholder', 'action', 'method', 'target',
+  'aria-label', 'aria-labelledby', 'aria-describedby', 'role', 'rows', 'cols', 'width', 'height',
+  'min', 'max', 'step', 'maxlength', 'minlength', 'pattern', 'autocomplete', 'for',
+]);
+
+const BOOL_ATTRS = new Set(['disabled', 'required', 'readonly', 'checked', 'selected', 'multiple', 'autofocus', 'hidden']);
+
+function attrName(key) {
+  return key.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+}
+
+function renderAttr(key, value) {
+  if (value === false || value == null) return '';
+  if (value === true) return ` ${attrName(key)}`;
+  return ` ${attrName(key)}="${escapeAttr(value)}"`;
+}
+
+function renderBoundAttr(key, binding) {
+  if (!isValidIdentifier(binding.ref)) {
+    throw new Error(`Invalid signal ref "${binding.ref}" — must be a JavaScript identifier`);
+  }
+  const expr = binding.expr || `${binding.ref}()`;
+  return ` :${attrName(key)}="${escapeAttr(expr)}"`;
+}
+
+function defaultTagFor(node, def) {
+  if (node.type === 'heading' && typeof node.props.level === 'string') return node.props.level;
+  if (def?.tag) return def.tag;
+  return node.type;
+}
+
+function renderText(node) {
+  if (node.bindings && node.bindings.text) {
+    const b = node.bindings.text;
+    if (!isValidIdentifier(b.ref)) {
+      throw new Error(`Invalid signal ref "${b.ref}"`);
+    }
+    return `{{ ${b.expr || `${b.ref}()`} }}`;
+  }
+  if (typeof node.props.text === 'string') return escapeHtml(node.props.text);
+  return '';
+}
+
+function renderNode(node, palette, depth, indent) {
+  const def = palette ? palette.get(node.type) : null;
+  const tag = defaultTagFor(node, def);
+  const isVoid = VOID_ELEMENTS.has(tag);
+  const isContainer = def ? def.container : !isVoid;
+  const pad = indent.repeat(depth);
+
+  let attrs = '';
+
+  if (def && def.role && !node.props.role) {
+    attrs += renderAttr('role', def.role);
+  }
+
+  for (const key of Object.keys(node.props)) {
+    if (key === 'text' || key === 'children' || key === 'level') continue;
+    if (node.bindings && node.bindings[key]) continue;
+    const value = node.props[key];
+    if (BOOL_ATTRS.has(key)) {
+      if (value) attrs += ` ${attrName(key)}`;
+    } else if (ATTR_PROPS.has(key) || /^data-/.test(key)) {
+      attrs += renderAttr(key, value);
+    } else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      attrs += renderAttr(key, value);
+    }
+  }
+
+  if (node.bindings) {
+    for (const key of Object.keys(node.bindings)) {
+      if (key === 'text' || key === 'value' || key === 'checked') continue;
+      attrs += renderBoundAttr(key, node.bindings[key]);
+    }
+  }
+
+  if (node.bindings?.value && (tag === 'input' || tag === 'textarea' || tag === 'select')) {
+    const b = node.bindings.value;
+    if (!isValidIdentifier(b.ref)) throw new Error(`Invalid signal ref "${b.ref}"`);
+    attrs += ` @bind="${escapeAttr(b.ref)}"`;
+  }
+
+  if (node.bindings?.checked && tag === 'input') {
+    const b = node.bindings.checked;
+    if (!isValidIdentifier(b.ref)) throw new Error(`Invalid signal ref "${b.ref}"`);
+    attrs += ` @bind="${escapeAttr(b.ref)}"`;
+  }
+
+  if (isVoid) {
+    return `${pad}<${tag}${attrs} />`;
+  }
+
+  const open = `<${tag}${attrs}>`;
+  const close = `</${tag}>`;
+
+  if (node.children && node.children.length > 0) {
+    const childLines = node.children.map((c) => renderNode(c, palette, depth + 1, indent));
+    return `${pad}${open}\n${childLines.join('\n')}\n${pad}${close}`;
+  }
+
+  if (!isContainer || node.props.text != null || node.bindings?.text) {
+    const text = renderText(node);
+    if (text) return `${pad}${open}${text}${close}`;
+  }
+
+  if (node.type === 'label' && typeof node.props.text === 'string') {
+    return `${pad}${open}${escapeHtml(node.props.text)}${close}`;
+  }
+
+  return `${pad}${open}${close}`;
+}
+
+function renderSignalDeclarations(signals, indent) {
+  if (!signals || Object.keys(signals).length === 0) return '';
+  const lines = ['<script type="module">', `${indent}import { signal } from '@basenative/runtime';`, ''];
+  for (const name of Object.keys(signals)) {
+    if (!isValidIdentifier(name)) {
+      throw new Error(`Invalid signal name "${name}"`);
+    }
+    const value = signals[name];
+    lines.push(`${indent}const ${name} = signal(${JSON.stringify(value)});`);
+  }
+  lines.push('</script>');
+  return lines.join('\n') + '\n';
+}
+
+export function generateBaseNative(state, options = {}) {
+  const { indent = '  ', document: asDocument = false, title = 'BaseNative Page', signals, palette } = options;
+  const tree = state.tree.peek ? state.tree.peek() : state.tree();
+
+  const body = tree.map((node) => renderNode(node, palette || null, 0, indent)).join('\n');
+  const script = renderSignalDeclarations(signals, indent);
+
+  if (!asDocument) {
+    return script ? `${script}${body}` : body;
+  }
+
+  return [
+    '<!DOCTYPE html>',
+    '<html lang="en">',
+    '<head>',
+    `${indent}<meta charset="UTF-8">`,
+    `${indent}<meta name="viewport" content="width=device-width, initial-scale=1.0">`,
+    `${indent}<title>${escapeHtml(title)}</title>`,
+    '</head>',
+    '<body>',
+    script ? script.trimEnd() : '',
+    body,
+    '</body>',
+    '</html>',
+  ].filter(Boolean).join('\n');
+}

--- a/packages/builder/src/codegen.test.js
+++ b/packages/builder/src/codegen.test.js
@@ -1,0 +1,137 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createBuilderState } from './state.js';
+import { defaultPalette } from './palette.js';
+import { generateBaseNative } from './codegen.js';
+
+describe('generateBaseNative', () => {
+  test('renders empty state as empty string', () => {
+    const s = createBuilderState();
+    const code = generateBaseNative(s);
+    assert.equal(code, '');
+  });
+
+  test('renders a heading', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    s.addNode(null, { type: 'heading', props: { level: 'h1', text: 'Welcome' } });
+    const code = generateBaseNative(s, { palette });
+    assert.equal(code, '<h1>Welcome</h1>');
+  });
+
+  test('escapes HTML in text content', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    s.addNode(null, { type: 'text', props: { text: '<script>x</script>' } });
+    const code = generateBaseNative(s, { palette });
+    assert.ok(code.includes('&lt;script&gt;'));
+    assert.ok(!code.includes('<script>'));
+  });
+
+  test('renders a button with attributes', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    s.addNode(null, { type: 'button', props: { text: 'Save', type: 'submit', disabled: true } });
+    const code = generateBaseNative(s, { palette });
+    assert.ok(code.includes('<button'));
+    assert.ok(code.includes('type="submit"'));
+    assert.ok(code.includes('disabled'));
+    assert.ok(code.includes('>Save</button>'));
+  });
+
+  test('renders a void element with self-closing slash', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    s.addNode(null, { type: 'image', props: { src: '/x.png', alt: 'X' } });
+    const code = generateBaseNative(s, { palette });
+    assert.ok(code.endsWith('/>'));
+    assert.ok(code.includes('src="/x.png"'));
+    assert.ok(code.includes('alt="X"'));
+  });
+
+  test('renders a nested container', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    const root = s.addNode(null, { type: 'section', props: { class: 'hero' } });
+    s.addNode(root.id, { type: 'heading', props: { level: 'h1', text: 'Hi' } });
+    s.addNode(root.id, { type: 'text', props: { text: 'World' } });
+    const code = generateBaseNative(s, { palette });
+    assert.ok(code.startsWith('<section'));
+    assert.ok(code.includes('class="hero"'));
+    assert.ok(code.includes('role="region"'));
+    assert.ok(code.includes('<h1>Hi</h1>'));
+    assert.ok(code.includes('<p>World</p>'));
+    assert.ok(code.endsWith('</section>'));
+  });
+
+  test('renders signal-text binding as {{ }} interpolation', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    const n = s.addNode(null, { type: 'signal-text' });
+    s.setBinding(n.id, 'text', { ref: 'count' });
+    const code = generateBaseNative(s, { palette });
+    assert.equal(code, '<span>{{ count() }}</span>');
+  });
+
+  test('renders custom expr in binding', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    const n = s.addNode(null, { type: 'signal-text' });
+    s.setBinding(n.id, 'text', { ref: 'count', expr: 'count() * 2' });
+    const code = generateBaseNative(s, { palette });
+    assert.ok(code.includes('{{ count() * 2 }}'));
+  });
+
+  test('renders @bind for input value signal', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    const n = s.addNode(null, { type: 'input', props: { type: 'text' } });
+    s.setBinding(n.id, 'value', { ref: 'name' });
+    const code = generateBaseNative(s, { palette });
+    assert.ok(code.includes('@bind="name"'));
+    assert.ok(code.includes('type="text"'));
+  });
+
+  test('rejects invalid signal identifiers', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    const n = s.addNode(null, { type: 'signal-text' });
+    s.setBinding(n.id, 'text', { ref: 'bad-ref!' });
+    assert.throws(() => generateBaseNative(s, { palette }));
+  });
+
+  test('document mode wraps body in HTML shell', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    s.addNode(null, { type: 'heading', props: { level: 'h1', text: 'Hi' } });
+    const code = generateBaseNative(s, { palette, document: true, title: 'Demo' });
+    assert.ok(code.includes('<!DOCTYPE html>'));
+    assert.ok(code.includes('<title>Demo</title>'));
+    assert.ok(code.includes('<h1>Hi</h1>'));
+    assert.ok(code.includes('</html>'));
+  });
+
+  test('signals option emits import + signal declarations', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    s.addNode(null, { type: 'signal-text' });
+    const code = generateBaseNative(s, { palette, signals: { count: 0, name: 'Ada' } });
+    assert.ok(code.includes("import { signal } from '@basenative/runtime'"));
+    assert.ok(code.includes('const count = signal(0)'));
+    assert.ok(code.includes('const name = signal("Ada")'));
+  });
+
+  test('rejects invalid signal names in declarations', () => {
+    const s = createBuilderState();
+    assert.throws(() => generateBaseNative(s, { signals: { 'bad name': 1 } }));
+  });
+
+  test('respects custom indent option', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    const root = s.addNode(null, { type: 'section' });
+    s.addNode(root.id, { type: 'text', props: { text: 'Hi' } });
+    const code = generateBaseNative(s, { palette, indent: '\t' });
+    assert.ok(code.includes('\t<p>Hi</p>'));
+  });
+});

--- a/packages/builder/src/dom-render.js
+++ b/packages/builder/src/dom-render.js
@@ -1,0 +1,59 @@
+import { escapeHtml } from './escape.js';
+
+const VOID_ELEMENTS = new Set([
+  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr',
+]);
+
+function tagFor(node, def) {
+  if (node.type === 'heading' && typeof node.props.level === 'string') return node.props.level;
+  if (def?.tag) return def.tag;
+  return node.type;
+}
+
+export function renderNodeToElement(doc, node, palette) {
+  const def = palette.get(node.type);
+  const tag = tagFor(node, def);
+  const isVoid = VOID_ELEMENTS.has(tag);
+
+  const el = doc.createElement(tag);
+  el.dataset.bnNode = node.id;
+  el.dataset.bnType = node.type;
+
+  if (def?.role && !node.props.role) {
+    el.setAttribute('role', def.role);
+  }
+
+  for (const key of Object.keys(node.props)) {
+    if (key === 'text' || key === 'level') continue;
+    const value = node.props[key];
+    if (value === false || value == null) continue;
+    if (value === true) el.setAttribute(key, '');
+    else el.setAttribute(key, String(value));
+  }
+
+  if (typeof node.props.text === 'string' && (!node.children || node.children.length === 0) && !isVoid) {
+    el.textContent = node.props.text;
+  }
+
+  if (node.bindings && node.bindings.text) {
+    el.textContent = `{{ ${node.bindings.text.expr || `${node.bindings.text.ref}()`} }}`;
+  }
+
+  if (!isVoid && node.children && node.children.length > 0) {
+    el.textContent = '';
+    for (const child of node.children) {
+      const childEl = renderNodeToElement(doc, child, palette);
+      el.appendChild(childEl);
+    }
+  }
+
+  return el;
+}
+
+export function renderEmptyPlaceholder(doc, message) {
+  const el = doc.createElement('div');
+  el.className = 'bn-builder__empty';
+  el.setAttribute('role', 'note');
+  el.innerHTML = `<p>${escapeHtml(message)}</p>`;
+  return el;
+}

--- a/packages/builder/src/escape.js
+++ b/packages/builder/src/escape.js
@@ -1,0 +1,19 @@
+export function escapeHtml(value) {
+  const s = value == null ? '' : String(value);
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function escapeAttr(value) {
+  return escapeHtml(value);
+}
+
+const JS_IDENT = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+export function isValidIdentifier(name) {
+  return typeof name === 'string' && JS_IDENT.test(name);
+}

--- a/packages/builder/src/escape.test.js
+++ b/packages/builder/src/escape.test.js
@@ -1,0 +1,37 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { escapeHtml, isValidIdentifier } from './escape.js';
+
+describe('escapeHtml', () => {
+  test('escapes <, >, &, ", \'', () => {
+    assert.equal(escapeHtml('<a href="x">y\'s</a>'), '&lt;a href=&quot;x&quot;&gt;y&#39;s&lt;/a&gt;');
+  });
+
+  test('handles null and undefined as empty string', () => {
+    assert.equal(escapeHtml(null), '');
+    assert.equal(escapeHtml(undefined), '');
+  });
+
+  test('coerces numbers and booleans', () => {
+    assert.equal(escapeHtml(42), '42');
+    assert.equal(escapeHtml(true), 'true');
+  });
+});
+
+describe('isValidIdentifier', () => {
+  test('accepts valid JS identifiers', () => {
+    assert.equal(isValidIdentifier('foo'), true);
+    assert.equal(isValidIdentifier('_foo'), true);
+    assert.equal(isValidIdentifier('$foo'), true);
+    assert.equal(isValidIdentifier('foo123'), true);
+  });
+
+  test('rejects invalid identifiers', () => {
+    assert.equal(isValidIdentifier(''), false);
+    assert.equal(isValidIdentifier('1foo'), false);
+    assert.equal(isValidIdentifier('foo bar'), false);
+    assert.equal(isValidIdentifier('foo-bar'), false);
+    assert.equal(isValidIdentifier(null), false);
+    assert.equal(isValidIdentifier(undefined), false);
+  });
+});

--- a/packages/builder/src/index.js
+++ b/packages/builder/src/index.js
@@ -1,0 +1,13 @@
+export { createBuilderState } from './state.js';
+export { createPalette, defaultPalette } from './palette.js';
+export { generateBaseNative } from './codegen.js';
+export { renderTreeView } from './tree-view.js';
+export { renderInspector } from './inspector.js';
+export { renderPaletteHTML } from './palette-element.js';
+export { escapeHtml, escapeAttr, isValidIdentifier } from './escape.js';
+export { renderNodeToElement } from './dom-render.js';
+export { BnBuilder } from './builder-element.js';
+export { BnBuilderCanvas } from './canvas-element.js';
+export { BnBuilderPalette } from './palette-element.js';
+export { BnBuilderTree } from './tree-element.js';
+export { BnBuilderInspector } from './inspector-element.js';

--- a/packages/builder/src/inspector-element.js
+++ b/packages/builder/src/inspector-element.js
@@ -1,0 +1,106 @@
+import { effect } from '@basenative/runtime';
+import { renderInspector } from './inspector.js';
+
+const TAG = 'bn-builder-inspector';
+
+function coerce(prop, raw) {
+  if (prop.kind === 'number') {
+    if (raw === '' || raw == null) return undefined;
+    const n = Number(raw);
+    return Number.isNaN(n) ? undefined : n;
+  }
+  if (prop.kind === 'boolean') {
+    return Boolean(raw);
+  }
+  return raw === '' ? undefined : raw;
+}
+
+export class BnBuilderInspector extends HTMLElement {
+  constructor() {
+    super();
+    this.state = null;
+    this.palette = null;
+    this._effect = null;
+  }
+
+  connectedCallback() {
+    this.style.display = 'contents';
+    this._wire();
+    this._render();
+    if (this.state && !this._effect) {
+      this._bindEffect();
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._effect) {
+      this._effect.dispose();
+      this._effect = null;
+    }
+  }
+
+  attach(state, palette) {
+    this.state = state;
+    this.palette = palette;
+    if (this.isConnected) {
+      if (this._effect) this._effect.dispose();
+      this._bindEffect();
+    }
+  }
+
+  _bindEffect() {
+    this._effect = effect(() => {
+      this.state.tree();
+      this.state.selection();
+      this._render();
+    });
+  }
+
+  _render() {
+    if (!this.state || !this.palette) {
+      this.innerHTML = '';
+      return;
+    }
+    this.innerHTML = renderInspector(this.state, this.palette);
+  }
+
+  _wire() {
+    this.addEventListener('input', (e) => this._handleChange(e));
+    this.addEventListener('change', (e) => this._handleChange(e));
+    this.addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-bn-action]');
+      if (!btn || !this.state) return;
+      const action = btn.dataset.bnAction;
+      const id = btn.dataset.bnNode;
+      if (action === 'remove') this.state.removeNode(id);
+      else if (action === 'duplicate') this.state.duplicateNode(id);
+    });
+  }
+
+  _handleChange(e) {
+    const target = e.target.closest('[data-bn-prop]');
+    if (!target || !this.state || !this.palette) return;
+    const propName = target.dataset.bnProp;
+    const nodeId = target.dataset.bnNode;
+    const node = this.state.getNode(nodeId);
+    if (!node) return;
+    const def = this.palette.get(node.type);
+    if (!def) return;
+    const prop = def.props.find((p) => p.name === propName);
+    if (!prop) return;
+
+    if (target.dataset.bnBinding === 'true') {
+      const ref = target.value.trim();
+      this.state.setBinding(nodeId, propName, ref ? { ref } : null);
+      return;
+    }
+
+    const raw = target.type === 'checkbox' ? target.checked : target.value;
+    const value = coerce(prop, raw);
+    this.state.updateProps(nodeId, { [propName]: value });
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get(TAG)) {
+  customElements.define(TAG, BnBuilderInspector);
+}

--- a/packages/builder/src/inspector.js
+++ b/packages/builder/src/inspector.js
@@ -1,0 +1,90 @@
+import { escapeHtml } from './escape.js';
+
+function renderField(nodeId, prop, value, binding) {
+  const id = `bn-prop-${nodeId}-${prop.name}`;
+  const label = escapeHtml(prop.label || prop.name);
+  const dataAttrs = `data-bn-prop="${escapeHtml(prop.name)}" data-bn-node="${escapeHtml(nodeId)}"`;
+
+  if (prop.kind === 'signal') {
+    const ref = binding ? binding.ref : '';
+    return `<label class="bn-inspector__field" for="${id}">`
+      + `<span class="bn-inspector__label">${label} <small>(signal)</small></span>`
+      + `<input id="${id}" type="text" ${dataAttrs} data-bn-binding="true" placeholder="signalName" value="${escapeHtml(ref)}" class="bn-inspector__input">`
+      + `</label>`;
+  }
+
+  if (prop.kind === 'enum' && Array.isArray(prop.options)) {
+    const options = prop.options.map((o) =>
+      `<option value="${escapeHtml(o)}"${value === o ? ' selected' : ''}>${escapeHtml(o || '—')}</option>`
+    ).join('');
+    return `<label class="bn-inspector__field" for="${id}">`
+      + `<span class="bn-inspector__label">${label}</span>`
+      + `<select id="${id}" ${dataAttrs} class="bn-inspector__input">${options}</select>`
+      + `</label>`;
+  }
+
+  if (prop.kind === 'boolean') {
+    const checked = value ? ' checked' : '';
+    return `<label class="bn-inspector__field bn-inspector__field--inline" for="${id}">`
+      + `<input id="${id}" type="checkbox" ${dataAttrs}${checked} class="bn-inspector__checkbox">`
+      + `<span class="bn-inspector__label">${label}</span>`
+      + `</label>`;
+  }
+
+  if (prop.kind === 'number') {
+    const v = value == null ? '' : escapeHtml(value);
+    return `<label class="bn-inspector__field" for="${id}">`
+      + `<span class="bn-inspector__label">${label}</span>`
+      + `<input id="${id}" type="number" ${dataAttrs} value="${v}" class="bn-inspector__input">`
+      + `</label>`;
+  }
+
+  const v = value == null ? '' : escapeHtml(value);
+  return `<label class="bn-inspector__field" for="${id}">`
+    + `<span class="bn-inspector__label">${label}</span>`
+    + `<input id="${id}" type="text" ${dataAttrs} value="${v}" class="bn-inspector__input">`
+    + `</label>`;
+}
+
+export function renderInspector(state, palette) {
+  const selectedId = state.selection.peek ? state.selection.peek() : state.selection();
+
+  if (!selectedId) {
+    return '<aside class="bn-inspector" aria-label="Property inspector">'
+      + '<p class="bn-inspector__empty">Select a component to edit its properties.</p>'
+      + '</aside>';
+  }
+
+  const node = state.getNode(selectedId);
+  if (!node) {
+    return '<aside class="bn-inspector" aria-label="Property inspector">'
+      + '<p class="bn-inspector__empty">Component not found.</p>'
+      + '</aside>';
+  }
+
+  const def = palette.get(node.type);
+  const heading = `<header class="bn-inspector__header">`
+    + `<h3 class="bn-inspector__title">${escapeHtml(def?.label || node.type)}</h3>`
+    + `<p class="bn-inspector__id">${escapeHtml(node.id)}</p>`
+    + `</header>`;
+
+  if (!def || !def.props.length) {
+    return `<aside class="bn-inspector" aria-label="Property inspector">${heading}`
+      + '<p class="bn-inspector__empty">No editable properties.</p>'
+      + '</aside>';
+  }
+
+  const fields = def.props
+    .map((prop) => renderField(node.id, prop, node.props[prop.name], node.bindings[prop.name]))
+    .join('\n');
+
+  const actions = `<footer class="bn-inspector__actions">`
+    + `<button type="button" data-bn-action="duplicate" data-bn-node="${escapeHtml(node.id)}" class="bn-inspector__btn">Duplicate</button>`
+    + `<button type="button" data-bn-action="remove" data-bn-node="${escapeHtml(node.id)}" class="bn-inspector__btn bn-inspector__btn--danger">Remove</button>`
+    + `</footer>`;
+
+  return `<aside class="bn-inspector" aria-label="Property inspector">${heading}`
+    + `<form class="bn-inspector__form" data-bn-inspector-form="${escapeHtml(node.id)}">${fields}</form>`
+    + actions
+    + `</aside>`;
+}

--- a/packages/builder/src/inspector.test.js
+++ b/packages/builder/src/inspector.test.js
@@ -1,0 +1,79 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createBuilderState } from './state.js';
+import { defaultPalette } from './palette.js';
+import { renderInspector } from './inspector.js';
+
+describe('renderInspector', () => {
+  test('shows empty state with no selection', () => {
+    const s = createBuilderState();
+    const html = renderInspector(s, defaultPalette());
+    assert.ok(html.includes('Select a component'));
+  });
+
+  test('renders fields for selected node', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    const node = s.addNode(null, { type: 'button', props: { text: 'Hi', variant: 'primary' } });
+    s.select(node.id);
+    const html = renderInspector(s, palette);
+    assert.ok(html.includes('Button'));
+    assert.ok(html.includes('value="Hi"'));
+    assert.ok(html.includes('Variant'));
+    assert.ok(html.includes('option value="primary" selected'));
+  });
+
+  test('renders signal-kind fields with placeholder', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    const node = s.addNode(null, { type: 'input' });
+    s.select(node.id);
+    const html = renderInspector(s, palette);
+    assert.ok(html.includes('placeholder="signalName"'));
+    assert.ok(html.includes('data-bn-binding="true"'));
+  });
+
+  test('shows existing binding ref as input value', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    const node = s.addNode(null, { type: 'input' });
+    s.setBinding(node.id, 'value', { ref: 'username' });
+    s.select(node.id);
+    const html = renderInspector(s, palette);
+    assert.ok(html.includes('value="username"'));
+  });
+
+  test('renders boolean as checkbox', () => {
+    const s = createBuilderState();
+    const palette = defaultPalette();
+    const node = s.addNode(null, { type: 'button', props: { disabled: true } });
+    s.select(node.id);
+    const html = renderInspector(s, palette);
+    assert.ok(html.includes('type="checkbox"'));
+    assert.ok(html.includes('checked'));
+  });
+
+  test('renders duplicate and remove actions', () => {
+    const s = createBuilderState();
+    const node = s.addNode(null, { type: 'button' });
+    s.select(node.id);
+    const html = renderInspector(s, defaultPalette());
+    assert.ok(html.includes('data-bn-action="duplicate"'));
+    assert.ok(html.includes('data-bn-action="remove"'));
+  });
+
+  test('shows component-not-found when selected id is invalid', () => {
+    const s = createBuilderState();
+    s.select('ghost');
+    const html = renderInspector(s, defaultPalette());
+    assert.ok(html.includes('not found'));
+  });
+
+  test('handles unknown component type', () => {
+    const s = createBuilderState();
+    const node = s.addNode(null, { type: 'mystery' });
+    s.select(node.id);
+    const html = renderInspector(s, defaultPalette());
+    assert.ok(html.includes('No editable properties') || html.includes('not found'));
+  });
+});

--- a/packages/builder/src/palette-element.js
+++ b/packages/builder/src/palette-element.js
@@ -1,0 +1,64 @@
+import { escapeHtml } from './escape.js';
+
+const TAG = 'bn-builder-palette';
+
+function renderPaletteHTML(palette) {
+  const categories = palette.categories();
+  if (!categories.length) {
+    return '<p class="bn-palette__empty">No components registered.</p>';
+  }
+  return categories.map((cat) => {
+    const items = palette.byCategory(cat).map((def) =>
+      `<li class="bn-palette__item">`
+        + `<button type="button" draggable="true" data-bn-palette-type="${escapeHtml(def.type)}" class="bn-palette__btn">`
+        + `<span class="bn-palette__label">${escapeHtml(def.label)}</span>`
+        + `<span class="bn-palette__type">${escapeHtml(def.type)}</span>`
+        + `</button>`
+        + `</li>`
+    ).join('');
+    return `<section class="bn-palette__group" aria-label="${escapeHtml(cat)} components">`
+      + `<h3 class="bn-palette__heading">${escapeHtml(cat)}</h3>`
+      + `<ul class="bn-palette__list" role="list">${items}</ul>`
+      + `</section>`;
+  }).join('');
+}
+
+export class BnBuilderPalette extends HTMLElement {
+  constructor() {
+    super();
+    this.palette = null;
+  }
+
+  connectedCallback() {
+    this.style.display = 'contents';
+    this.setAttribute('role', 'toolbar');
+    this.setAttribute('aria-label', 'Component palette');
+    this._render();
+    this._wire();
+  }
+
+  attach(palette) {
+    this.palette = palette;
+    if (this.isConnected) this._render();
+  }
+
+  _render() {
+    if (!this.palette) return;
+    this.innerHTML = `<div class="bn-palette">${renderPaletteHTML(this.palette)}</div>`;
+  }
+
+  _wire() {
+    this.addEventListener('dragstart', (e) => {
+      const btn = e.target.closest('[data-bn-palette-type]');
+      if (!btn) return;
+      e.dataTransfer.setData('application/x-bn-component-type', btn.dataset.bnPaletteType);
+      e.dataTransfer.effectAllowed = 'copy';
+    });
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get(TAG)) {
+  customElements.define(TAG, BnBuilderPalette);
+}
+
+export { renderPaletteHTML };

--- a/packages/builder/src/palette.js
+++ b/packages/builder/src/palette.js
@@ -1,0 +1,256 @@
+export function createPalette() {
+  const map = new Map();
+
+  function register(spec) {
+    if (!spec || !spec.type) {
+      throw new Error('Component definition requires a "type"');
+    }
+    const def = {
+      type: spec.type,
+      label: spec.label || spec.type,
+      category: spec.category || 'general',
+      tag: spec.tag || spec.type,
+      container: Boolean(spec.container),
+      props: Array.isArray(spec.props) ? spec.props.slice() : [],
+      defaults: spec.defaults ? { ...spec.defaults } : {},
+      defaultContent: spec.defaultContent,
+      role: spec.role,
+    };
+    map.set(def.type, def);
+    return def;
+  }
+
+  function unregister(type) {
+    return map.delete(type);
+  }
+
+  function get(type) {
+    return map.get(type) || null;
+  }
+
+  function list() {
+    return Array.from(map.values());
+  }
+
+  function byCategory(category) {
+    return list().filter((d) => d.category === category);
+  }
+
+  function categories() {
+    const set = new Set();
+    for (const def of map.values()) set.add(def.category);
+    return Array.from(set);
+  }
+
+  function search(query) {
+    const q = String(query || '').toLowerCase().trim();
+    if (!q) return list();
+    return list().filter((d) =>
+      d.type.toLowerCase().includes(q)
+      || d.label.toLowerCase().includes(q)
+      || d.category.toLowerCase().includes(q)
+    );
+  }
+
+  return { register, unregister, get, list, byCategory, categories, search };
+}
+
+export function defaultPalette() {
+  const palette = createPalette();
+
+  palette.register({
+    type: 'section',
+    label: 'Section',
+    category: 'layout',
+    tag: 'section',
+    container: true,
+    role: 'region',
+    props: [
+      { name: 'aria-label', kind: 'string', label: 'Label' },
+      { name: 'class', kind: 'string', label: 'Class' },
+    ],
+    defaults: { class: 'bn-section' },
+  });
+
+  palette.register({
+    type: 'stack',
+    label: 'Stack',
+    category: 'layout',
+    tag: 'div',
+    container: true,
+    props: [
+      { name: 'direction', kind: 'enum', options: ['row', 'column'], default: 'column', label: 'Direction' },
+      { name: 'gap', kind: 'string', default: '1rem', label: 'Gap' },
+      { name: 'class', kind: 'string', label: 'Class' },
+    ],
+    defaults: { direction: 'column', gap: '1rem', class: 'bn-stack' },
+  });
+
+  palette.register({
+    type: 'grid',
+    label: 'Grid',
+    category: 'layout',
+    tag: 'div',
+    container: true,
+    props: [
+      { name: 'columns', kind: 'number', default: 12, label: 'Columns' },
+      { name: 'gap', kind: 'string', default: '1rem', label: 'Gap' },
+      { name: 'class', kind: 'string', label: 'Class' },
+    ],
+    defaults: { columns: 12, gap: '1rem', class: 'bn-grid' },
+  });
+
+  palette.register({
+    type: 'heading',
+    label: 'Heading',
+    category: 'text',
+    tag: 'h2',
+    container: false,
+    props: [
+      { name: 'level', kind: 'enum', options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'], default: 'h2', label: 'Level' },
+      { name: 'text', kind: 'string', label: 'Text' },
+    ],
+    defaults: { level: 'h2', text: 'Heading' },
+  });
+
+  palette.register({
+    type: 'text',
+    label: 'Text',
+    category: 'text',
+    tag: 'p',
+    container: false,
+    props: [
+      { name: 'text', kind: 'string', label: 'Text' },
+    ],
+    defaults: { text: 'Lorem ipsum.' },
+  });
+
+  palette.register({
+    type: 'button',
+    label: 'Button',
+    category: 'inputs',
+    tag: 'button',
+    container: false,
+    props: [
+      { name: 'text', kind: 'string', label: 'Label' },
+      { name: 'variant', kind: 'enum', options: ['primary', 'secondary', 'ghost', 'destructive'], default: 'primary', label: 'Variant' },
+      { name: 'type', kind: 'enum', options: ['button', 'submit', 'reset'], default: 'button', label: 'Type' },
+      { name: 'disabled', kind: 'boolean', default: false, label: 'Disabled' },
+    ],
+    defaults: { text: 'Click me', variant: 'primary', type: 'button' },
+  });
+
+  palette.register({
+    type: 'input',
+    label: 'Input',
+    category: 'inputs',
+    tag: 'input',
+    container: false,
+    props: [
+      { name: 'type', kind: 'enum', options: ['text', 'email', 'password', 'number', 'search', 'tel', 'url'], default: 'text', label: 'Type' },
+      { name: 'name', kind: 'string', label: 'Name' },
+      { name: 'placeholder', kind: 'string', label: 'Placeholder' },
+      { name: 'value', kind: 'signal', label: 'Bound value' },
+      { name: 'required', kind: 'boolean', default: false, label: 'Required' },
+    ],
+    defaults: { type: 'text' },
+  });
+
+  palette.register({
+    type: 'textarea',
+    label: 'Textarea',
+    category: 'inputs',
+    tag: 'textarea',
+    container: false,
+    props: [
+      { name: 'name', kind: 'string', label: 'Name' },
+      { name: 'placeholder', kind: 'string', label: 'Placeholder' },
+      { name: 'rows', kind: 'number', default: 4, label: 'Rows' },
+      { name: 'value', kind: 'signal', label: 'Bound value' },
+    ],
+    defaults: { rows: 4 },
+  });
+
+  palette.register({
+    type: 'checkbox',
+    label: 'Checkbox',
+    category: 'inputs',
+    tag: 'input',
+    container: false,
+    props: [
+      { name: 'name', kind: 'string', label: 'Name' },
+      { name: 'label', kind: 'string', label: 'Label' },
+      { name: 'checked', kind: 'signal', label: 'Bound state' },
+    ],
+    defaults: { type: 'checkbox' },
+  });
+
+  palette.register({
+    type: 'label',
+    label: 'Label',
+    category: 'inputs',
+    tag: 'label',
+    container: true,
+    props: [
+      { name: 'for', kind: 'string', label: 'For' },
+      { name: 'text', kind: 'string', label: 'Text' },
+    ],
+    defaults: { text: 'Label' },
+  });
+
+  palette.register({
+    type: 'form',
+    label: 'Form',
+    category: 'inputs',
+    tag: 'form',
+    container: true,
+    props: [
+      { name: 'action', kind: 'string', label: 'Action' },
+      { name: 'method', kind: 'enum', options: ['get', 'post'], default: 'post', label: 'Method' },
+    ],
+    defaults: { method: 'post' },
+  });
+
+  palette.register({
+    type: 'link',
+    label: 'Link',
+    category: 'navigation',
+    tag: 'a',
+    container: false,
+    props: [
+      { name: 'href', kind: 'string', label: 'URL' },
+      { name: 'text', kind: 'string', label: 'Text' },
+      { name: 'target', kind: 'enum', options: ['', '_blank', '_self'], default: '', label: 'Target' },
+    ],
+    defaults: { href: '#', text: 'Link' },
+  });
+
+  palette.register({
+    type: 'image',
+    label: 'Image',
+    category: 'media',
+    tag: 'img',
+    container: false,
+    props: [
+      { name: 'src', kind: 'string', label: 'Source' },
+      { name: 'alt', kind: 'string', label: 'Alt text' },
+      { name: 'width', kind: 'number', label: 'Width' },
+      { name: 'height', kind: 'number', label: 'Height' },
+    ],
+    defaults: { src: '', alt: '' },
+  });
+
+  palette.register({
+    type: 'signal-text',
+    label: 'Signal Text',
+    category: 'reactive',
+    tag: 'span',
+    container: false,
+    props: [
+      { name: 'value', kind: 'signal', label: 'Bound expression' },
+    ],
+    defaults: {},
+  });
+
+  return palette;
+}

--- a/packages/builder/src/palette.test.js
+++ b/packages/builder/src/palette.test.js
@@ -1,0 +1,73 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createPalette, defaultPalette } from './palette.js';
+
+describe('createPalette', () => {
+  test('register requires a type', () => {
+    const p = createPalette();
+    assert.throws(() => p.register({}));
+  });
+
+  test('register fills defaults', () => {
+    const p = createPalette();
+    const def = p.register({ type: 'foo' });
+    assert.equal(def.type, 'foo');
+    assert.equal(def.label, 'foo');
+    assert.equal(def.category, 'general');
+    assert.equal(def.tag, 'foo');
+    assert.equal(def.container, false);
+    assert.deepEqual(def.props, []);
+  });
+
+  test('list, get, byCategory, categories, search', () => {
+    const p = createPalette();
+    p.register({ type: 'a', category: 'x', label: 'Alpha' });
+    p.register({ type: 'b', category: 'x', label: 'Bravo' });
+    p.register({ type: 'c', category: 'y', label: 'Cee' });
+
+    assert.equal(p.list().length, 3);
+    assert.equal(p.get('a').label, 'Alpha');
+    assert.equal(p.get('missing'), null);
+    assert.equal(p.byCategory('x').length, 2);
+    assert.deepEqual(new Set(p.categories()), new Set(['x', 'y']));
+    assert.equal(p.search('alpha').length, 1);
+    assert.equal(p.search('').length, 3);
+    assert.equal(p.search('zzz').length, 0);
+  });
+
+  test('unregister removes a definition', () => {
+    const p = createPalette();
+    p.register({ type: 'a' });
+    assert.equal(p.unregister('a'), true);
+    assert.equal(p.get('a'), null);
+    assert.equal(p.unregister('missing'), false);
+  });
+});
+
+describe('defaultPalette', () => {
+  test('registers core components', () => {
+    const p = defaultPalette();
+    assert.ok(p.get('section'));
+    assert.ok(p.get('button'));
+    assert.ok(p.get('input'));
+    assert.ok(p.get('text'));
+    assert.ok(p.get('signal-text'));
+  });
+
+  test('button is non-container', () => {
+    const p = defaultPalette();
+    assert.equal(p.get('button').container, false);
+  });
+
+  test('section is a container', () => {
+    const p = defaultPalette();
+    assert.equal(p.get('section').container, true);
+  });
+
+  test('input has signal-kind value prop', () => {
+    const p = defaultPalette();
+    const input = p.get('input');
+    const valueProp = input.props.find((x) => x.name === 'value');
+    assert.equal(valueProp.kind, 'signal');
+  });
+});

--- a/packages/builder/src/state.js
+++ b/packages/builder/src/state.js
@@ -1,0 +1,341 @@
+import { signal, computed, batch } from '@basenative/runtime';
+
+let idCounter = 0;
+function nextId() {
+  idCounter += 1;
+  return `n${idCounter.toString(36)}${Date.now().toString(36).slice(-4)}`;
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function normalizeNode(spec) {
+  if (!spec || !spec.type) {
+    throw new Error('Builder node requires a "type" field');
+  }
+  return {
+    id: spec.id || nextId(),
+    type: spec.type,
+    props: spec.props ? { ...spec.props } : {},
+    bindings: spec.bindings ? { ...spec.bindings } : {},
+    children: Array.isArray(spec.children) ? spec.children.map(normalizeNode) : [],
+  };
+}
+
+function normalizeRoots(initial) {
+  if (!initial) return [];
+  if (Array.isArray(initial)) return initial.map(normalizeNode);
+  return [normalizeNode(initial)];
+}
+
+function findNode(roots, id) {
+  for (const root of roots) {
+    if (root.id === id)
+      return { node: root, parent: null, siblings: roots, index: roots.indexOf(root) };
+    const stack = [root];
+    while (stack.length) {
+      const node = stack.pop();
+      for (let i = 0; i < node.children.length; i++) {
+        const child = node.children[i];
+        if (child.id === id) {
+          return { node: child, parent: node, siblings: node.children, index: i };
+        }
+        stack.push(child);
+      }
+    }
+  }
+  return null;
+}
+
+function findPath(roots, id, path = []) {
+  for (const root of roots) {
+    if (root.id === id) return [...path, root.id];
+    const sub = findPath(root.children, id, [...path, root.id]);
+    if (sub) return sub;
+  }
+  return null;
+}
+
+function isAncestor(roots, ancestorId, descendantId) {
+  const found = findNode(roots, ancestorId);
+  if (!found) return false;
+  const stack = [...found.node.children];
+  while (stack.length) {
+    const node = stack.pop();
+    if (node.id === descendantId) return true;
+    stack.push(...node.children);
+  }
+  return false;
+}
+
+function reassignIds(node) {
+  node.id = nextId();
+  for (const child of node.children) reassignIds(child);
+  return node;
+}
+
+export function createBuilderState(options = {}) {
+  const { initial, maxHistory = 100 } = options;
+
+  const tree = signal(normalizeRoots(initial));
+  const selection = signal(null);
+  const hover = signal(null);
+
+  const past = signal([]);
+  const future = signal([]);
+
+  const canUndo = computed(() => past().length > 0);
+  const canRedo = computed(() => future().length > 0);
+
+  const subscribers = new Set();
+  function emit(event) {
+    for (const cb of subscribers) cb(event);
+  }
+
+  function snapshot() {
+    return clone(tree.peek());
+  }
+
+  function commit(mutator, event) {
+    const before = snapshot();
+    const draft = clone(before);
+    const result = mutator(draft);
+    if (result === false) return false;
+    batch(() => {
+      past.set((p) => {
+        const next = [...p, before];
+        while (next.length > maxHistory) next.shift();
+        return next;
+      });
+      if (future.peek().length) future.set([]);
+      tree.set(draft);
+    });
+    if (event) emit(event);
+    return result == null ? true : result;
+  }
+
+  function getNode(id) {
+    const found = findNode(tree.peek(), id);
+    return found ? found.node : null;
+  }
+
+  function getParent(id) {
+    const found = findNode(tree.peek(), id);
+    return found ? found.parent : null;
+  }
+
+  function getPath(id) {
+    return findPath(tree.peek(), id) || [];
+  }
+
+  function addNode(parentId, spec, index) {
+    const node = normalizeNode(spec);
+    const ok = commit(
+      (draft) => {
+        if (parentId == null) {
+          if (typeof index === 'number') draft.splice(index, 0, node);
+          else draft.push(node);
+          return node;
+        }
+        const found = findNode(draft, parentId);
+        if (!found) return false;
+        if (typeof index === 'number') found.node.children.splice(index, 0, node);
+        else found.node.children.push(node);
+        return node;
+      },
+      { type: 'add', node, parentId: parentId ?? null },
+    );
+    return ok === false ? null : node;
+  }
+
+  function removeNode(id) {
+    return commit(
+      (draft) => {
+        const found = findNode(draft, id);
+        if (!found) return false;
+        found.siblings.splice(found.index, 1);
+        if (selection.peek() === id) selection.set(null);
+        if (hover.peek() === id) hover.set(null);
+        return true;
+      },
+      { type: 'remove', id },
+    );
+  }
+
+  function updateProps(id, patch) {
+    return commit(
+      (draft) => {
+        const found = findNode(draft, id);
+        if (!found) return false;
+        for (const key of Object.keys(patch)) {
+          const value = patch[key];
+          if (value === undefined) delete found.node.props[key];
+          else found.node.props[key] = value;
+        }
+        return true;
+      },
+      { type: 'update', id, patch: { ...patch } },
+    );
+  }
+
+  function setBinding(id, propKey, binding) {
+    return commit(
+      (draft) => {
+        const found = findNode(draft, id);
+        if (!found) return false;
+        if (binding == null) {
+          delete found.node.bindings[propKey];
+        } else {
+          if (!binding.ref || typeof binding.ref !== 'string') {
+            throw new Error('Signal binding requires a "ref" string');
+          }
+          found.node.bindings[propKey] = {
+            ref: binding.ref,
+            ...(binding.expr ? { expr: binding.expr } : {}),
+          };
+        }
+        return true;
+      },
+      { type: 'binding', id, propKey, binding: binding == null ? null : { ...binding } },
+    );
+  }
+
+  function moveNode(id, newParentId, index) {
+    if (id === newParentId) return false;
+    if (newParentId && isAncestor(tree.peek(), id, newParentId)) return false;
+    return commit(
+      (draft) => {
+        const found = findNode(draft, id);
+        if (!found) return false;
+        const [moved] = found.siblings.splice(found.index, 1);
+        if (newParentId == null) {
+          if (typeof index === 'number') draft.splice(index, 0, moved);
+          else draft.push(moved);
+        } else {
+          const target = findNode(draft, newParentId);
+          if (!target) return false;
+          if (typeof index === 'number') target.node.children.splice(index, 0, moved);
+          else target.node.children.push(moved);
+        }
+        return true;
+      },
+      {
+        type: 'move',
+        id,
+        parentId: newParentId ?? null,
+        index: typeof index === 'number' ? index : -1,
+      },
+    );
+  }
+
+  function duplicateNode(id) {
+    const original = getNode(id);
+    if (!original) return null;
+    const copy = reassignIds(clone(original));
+    const parent = getParent(id);
+    const parentId = parent ? parent.id : null;
+    const siblings = parent ? parent.children : tree.peek();
+    const index = siblings.findIndex((n) => n.id === id) + 1;
+    return addNode(parentId, copy, index);
+  }
+
+  function select(id) {
+    if (selection.peek() === id) return;
+    selection.set(id);
+    emit({ type: 'select', id });
+  }
+
+  function hoverNode(id) {
+    if (hover.peek() === id) return;
+    hover.set(id);
+    emit({ type: 'hover', id });
+  }
+
+  function undo() {
+    const stack = past.peek();
+    if (!stack.length) return false;
+    const previous = stack[stack.length - 1];
+    const current = snapshot();
+    batch(() => {
+      past.set(stack.slice(0, -1));
+      future.set([...future.peek(), current]);
+      tree.set(previous);
+    });
+    emit({ type: 'undo' });
+    return true;
+  }
+
+  function redo() {
+    const stack = future.peek();
+    if (!stack.length) return false;
+    const next = stack[stack.length - 1];
+    const current = snapshot();
+    batch(() => {
+      future.set(stack.slice(0, -1));
+      past.set([...past.peek(), current]);
+      tree.set(next);
+    });
+    emit({ type: 'redo' });
+    return true;
+  }
+
+  function clear() {
+    commit(
+      (draft) => {
+        draft.length = 0;
+        selection.set(null);
+        hover.set(null);
+        return true;
+      },
+      { type: 'clear' },
+    );
+  }
+
+  function toJSON() {
+    return JSON.stringify({ version: '0.1.0', tree: tree.peek() }, null, 2);
+  }
+
+  function fromJSON(json) {
+    const parsed = typeof json === 'string' ? JSON.parse(json) : json;
+    const roots = Array.isArray(parsed?.tree) ? parsed.tree.map(normalizeNode) : [];
+    batch(() => {
+      past.set([]);
+      future.set([]);
+      selection.set(null);
+      hover.set(null);
+      tree.set(roots);
+    });
+    emit({ type: 'load' });
+  }
+
+  function subscribe(callback) {
+    subscribers.add(callback);
+    return () => subscribers.delete(callback);
+  }
+
+  return {
+    tree,
+    selection,
+    hover,
+    canUndo,
+    canRedo,
+    getNode,
+    getParent,
+    getPath,
+    addNode,
+    removeNode,
+    updateProps,
+    setBinding,
+    moveNode,
+    duplicateNode,
+    select,
+    hoverNode,
+    undo,
+    redo,
+    clear,
+    toJSON,
+    fromJSON,
+    subscribe,
+  };
+}

--- a/packages/builder/src/state.test.js
+++ b/packages/builder/src/state.test.js
@@ -1,0 +1,321 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { effect } from '@basenative/runtime';
+import { createBuilderState } from './state.js';
+
+describe('createBuilderState — basics', () => {
+  test('starts empty by default', () => {
+    const s = createBuilderState();
+    assert.deepEqual(s.tree(), []);
+    assert.equal(s.selection(), null);
+    assert.equal(s.canUndo(), false);
+    assert.equal(s.canRedo(), false);
+  });
+
+  test('accepts initial roots', () => {
+    const s = createBuilderState({ initial: { type: 'section', children: [{ type: 'text' }] } });
+    const tree = s.tree();
+    assert.equal(tree.length, 1);
+    assert.equal(tree[0].type, 'section');
+    assert.equal(tree[0].children[0].type, 'text');
+  });
+
+  test('addNode requires a type', () => {
+    const s = createBuilderState();
+    assert.throws(() => s.addNode(null, {}));
+  });
+
+  test('addNode appends a root node', () => {
+    const s = createBuilderState();
+    const node = s.addNode(null, { type: 'button' });
+    assert.equal(s.tree().length, 1);
+    assert.equal(s.tree()[0].id, node.id);
+    assert.equal(s.tree()[0].type, 'button');
+  });
+
+  test('addNode adds to a parent', () => {
+    const s = createBuilderState();
+    const root = s.addNode(null, { type: 'section' });
+    s.addNode(root.id, { type: 'text' });
+    assert.equal(s.getNode(root.id).children.length, 1);
+    assert.equal(s.getNode(root.id).children[0].type, 'text');
+  });
+
+  test('addNode with index inserts at position', () => {
+    const s = createBuilderState();
+    s.addNode(null, { type: 'a' });
+    s.addNode(null, { type: 'b' });
+    s.addNode(null, { type: 'c' }, 1);
+    assert.deepEqual(s.tree().map((n) => n.type), ['a', 'c', 'b']);
+  });
+
+  test('addNode returns null for missing parent', () => {
+    const s = createBuilderState();
+    const node = s.addNode('nope', { type: 'x' });
+    assert.equal(node, null);
+  });
+
+  test('removeNode deletes a node and its descendants', () => {
+    const s = createBuilderState();
+    const root = s.addNode(null, { type: 'section' });
+    s.addNode(root.id, { type: 'text' });
+    s.removeNode(root.id);
+    assert.equal(s.tree().length, 0);
+  });
+
+  test('removeNode clears selection if removing selected', () => {
+    const s = createBuilderState();
+    const node = s.addNode(null, { type: 'button' });
+    s.select(node.id);
+    s.removeNode(node.id);
+    assert.equal(s.selection(), null);
+  });
+
+  test('updateProps merges patch', () => {
+    const s = createBuilderState();
+    const node = s.addNode(null, { type: 'button', props: { text: 'A' } });
+    s.updateProps(node.id, { text: 'B', variant: 'primary' });
+    assert.equal(s.getNode(node.id).props.text, 'B');
+    assert.equal(s.getNode(node.id).props.variant, 'primary');
+  });
+
+  test('updateProps with undefined removes a key', () => {
+    const s = createBuilderState();
+    const node = s.addNode(null, { type: 'button', props: { text: 'X' } });
+    s.updateProps(node.id, { text: undefined });
+    assert.equal('text' in s.getNode(node.id).props, false);
+  });
+});
+
+describe('signal bindings', () => {
+  test('setBinding stores ref and expr', () => {
+    const s = createBuilderState();
+    const n = s.addNode(null, { type: 'signal-text' });
+    s.setBinding(n.id, 'value', { ref: 'count' });
+    assert.deepEqual(s.getNode(n.id).bindings.value, { ref: 'count' });
+  });
+
+  test('setBinding rejects invalid refs', () => {
+    const s = createBuilderState();
+    const n = s.addNode(null, { type: 'input' });
+    assert.throws(() => s.setBinding(n.id, 'value', {}));
+  });
+
+  test('setBinding(null) removes binding', () => {
+    const s = createBuilderState();
+    const n = s.addNode(null, { type: 'input' });
+    s.setBinding(n.id, 'value', { ref: 'name' });
+    s.setBinding(n.id, 'value', null);
+    assert.equal('value' in s.getNode(n.id).bindings, false);
+  });
+});
+
+describe('moveNode', () => {
+  test('reparents a node', () => {
+    const s = createBuilderState();
+    const a = s.addNode(null, { type: 'section' });
+    const b = s.addNode(null, { type: 'section' });
+    const c = s.addNode(a.id, { type: 'text' });
+    s.moveNode(c.id, b.id);
+    assert.equal(s.getNode(a.id).children.length, 0);
+    assert.equal(s.getNode(b.id).children.length, 1);
+    assert.equal(s.getNode(b.id).children[0].id, c.id);
+  });
+
+  test('rejects moving a node into its own descendant', () => {
+    const s = createBuilderState();
+    const root = s.addNode(null, { type: 'section' });
+    const child = s.addNode(root.id, { type: 'section' });
+    const ok = s.moveNode(root.id, child.id);
+    assert.equal(ok, false);
+  });
+
+  test('reordering at root with index', () => {
+    const s = createBuilderState();
+    const a = s.addNode(null, { type: 'a' });
+    s.addNode(null, { type: 'b' });
+    s.addNode(null, { type: 'c' });
+    s.moveNode(a.id, null, 1);
+    assert.deepEqual(s.tree().map((n) => n.type), ['b', 'a', 'c']);
+  });
+
+  test('moving to end appends', () => {
+    const s = createBuilderState();
+    const a = s.addNode(null, { type: 'a' });
+    s.addNode(null, { type: 'b' });
+    s.moveNode(a.id, null);
+    assert.deepEqual(s.tree().map((n) => n.type), ['b', 'a']);
+  });
+});
+
+describe('duplicateNode', () => {
+  test('clones a node with new ids', () => {
+    const s = createBuilderState();
+    const root = s.addNode(null, { type: 'section' });
+    s.addNode(root.id, { type: 'text', props: { text: 'Hi' } });
+    const dup = s.duplicateNode(root.id);
+    assert.equal(s.tree().length, 2);
+    assert.notEqual(dup.id, root.id);
+    assert.notEqual(dup.children[0].id, s.getNode(root.id).children[0].id);
+    assert.equal(dup.children[0].props.text, 'Hi');
+  });
+
+  test('inserts duplicate after the original', () => {
+    const s = createBuilderState();
+    const a = s.addNode(null, { type: 'a' });
+    s.addNode(null, { type: 'b' });
+    s.duplicateNode(a.id);
+    assert.equal(s.tree()[1].type, 'a');
+    assert.equal(s.tree()[2].type, 'b');
+  });
+});
+
+describe('undo/redo', () => {
+  test('undoes addNode', () => {
+    const s = createBuilderState();
+    s.addNode(null, { type: 'button' });
+    assert.equal(s.tree().length, 1);
+    s.undo();
+    assert.equal(s.tree().length, 0);
+    assert.equal(s.canRedo(), true);
+  });
+
+  test('redoes addNode', () => {
+    const s = createBuilderState();
+    s.addNode(null, { type: 'button' });
+    s.undo();
+    s.redo();
+    assert.equal(s.tree().length, 1);
+  });
+
+  test('undoes removeNode', () => {
+    const s = createBuilderState();
+    const node = s.addNode(null, { type: 'button' });
+    s.removeNode(node.id);
+    s.undo();
+    assert.equal(s.tree().length, 1);
+  });
+
+  test('undoes updateProps', () => {
+    const s = createBuilderState();
+    const n = s.addNode(null, { type: 'button', props: { text: 'A' } });
+    s.updateProps(n.id, { text: 'B' });
+    s.undo();
+    assert.equal(s.getNode(n.id).props.text, 'A');
+  });
+
+  test('new action clears redo stack', () => {
+    const s = createBuilderState();
+    s.addNode(null, { type: 'a' });
+    s.undo();
+    assert.equal(s.canRedo(), true);
+    s.addNode(null, { type: 'b' });
+    assert.equal(s.canRedo(), false);
+  });
+
+  test('respects maxHistory', () => {
+    const s = createBuilderState({ maxHistory: 3 });
+    for (let i = 0; i < 5; i++) s.addNode(null, { type: `t${i}` });
+    let depth = 0;
+    while (s.undo()) depth++;
+    assert.equal(depth, 3);
+  });
+});
+
+describe('signal reactivity', () => {
+  test('tree() updates trigger effects', () => {
+    const s = createBuilderState();
+    let runs = 0;
+    let lastLen = -1;
+    const e = effect(() => {
+      runs += 1;
+      lastLen = s.tree().length;
+    });
+    assert.equal(runs, 1);
+    s.addNode(null, { type: 'a' });
+    assert.equal(runs, 2);
+    assert.equal(lastLen, 1);
+    s.addNode(null, { type: 'b' });
+    assert.equal(runs, 3);
+    assert.equal(lastLen, 2);
+    e.dispose();
+  });
+
+  test('selection() updates trigger effects', () => {
+    const s = createBuilderState();
+    const n = s.addNode(null, { type: 'a' });
+    let runs = 0;
+    const e = effect(() => {
+      s.selection();
+      runs += 1;
+    });
+    assert.equal(runs, 1);
+    s.select(n.id);
+    assert.equal(runs, 2);
+    s.select(n.id);
+    assert.equal(runs, 2, 'no-op select should not re-run');
+    e.dispose();
+  });
+});
+
+describe('subscribe', () => {
+  test('emits add/remove/select events', () => {
+    const s = createBuilderState();
+    const events = [];
+    s.subscribe((e) => events.push(e.type));
+    const n = s.addNode(null, { type: 'a' });
+    s.select(n.id);
+    s.removeNode(n.id);
+    assert.deepEqual(events, ['add', 'select', 'remove']);
+  });
+
+  test('unsubscribe stops events', () => {
+    const s = createBuilderState();
+    const events = [];
+    const off = s.subscribe((e) => events.push(e));
+    s.addNode(null, { type: 'a' });
+    off();
+    s.addNode(null, { type: 'b' });
+    assert.equal(events.length, 1);
+  });
+});
+
+describe('toJSON / fromJSON', () => {
+  test('round-trips a tree', () => {
+    const a = createBuilderState();
+    const root = a.addNode(null, { type: 'section', props: { class: 'hero' } });
+    a.addNode(root.id, { type: 'heading', props: { text: 'Hi', level: 'h1' } });
+    const json = a.toJSON();
+
+    const b = createBuilderState();
+    b.fromJSON(json);
+    assert.equal(b.tree().length, 1);
+    assert.equal(b.tree()[0].type, 'section');
+    assert.equal(b.tree()[0].children[0].props.text, 'Hi');
+  });
+
+  test('fromJSON resets history and selection', () => {
+    const s = createBuilderState();
+    s.addNode(null, { type: 'a' });
+    s.select(s.tree()[0].id);
+    s.fromJSON(JSON.stringify({ version: '0.1.0', tree: [] }));
+    assert.equal(s.tree().length, 0);
+    assert.equal(s.selection(), null);
+    assert.equal(s.canUndo(), false);
+  });
+});
+
+describe('getPath', () => {
+  test('returns path of ids from root to target', () => {
+    const s = createBuilderState();
+    const root = s.addNode(null, { type: 'section' });
+    const mid = s.addNode(root.id, { type: 'div' });
+    const leaf = s.addNode(mid.id, { type: 'text' });
+    assert.deepEqual(s.getPath(leaf.id), [root.id, mid.id, leaf.id]);
+  });
+
+  test('empty array for missing node', () => {
+    const s = createBuilderState();
+    assert.deepEqual(s.getPath('nope'), []);
+  });
+});

--- a/packages/builder/src/tree-element.js
+++ b/packages/builder/src/tree-element.js
@@ -1,0 +1,73 @@
+import { effect } from '@basenative/runtime';
+import { renderTreeView } from './tree-view.js';
+
+const TAG = 'bn-builder-tree';
+
+export class BnBuilderTree extends HTMLElement {
+  constructor() {
+    super();
+    this.state = null;
+    this._effect = null;
+  }
+
+  connectedCallback() {
+    this.style.display = 'contents';
+    this._wire();
+    this._render();
+    if (this.state && !this._effect) {
+      this._effect = effect(() => {
+        this.state.tree();
+        this.state.selection();
+        this.state.hover();
+        this._render();
+      });
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._effect) {
+      this._effect.dispose();
+      this._effect = null;
+    }
+  }
+
+  attach(state) {
+    this.state = state;
+    if (this.isConnected) {
+      if (this._effect) this._effect.dispose();
+      this._effect = effect(() => {
+        state.tree();
+        state.selection();
+        state.hover();
+        this._render();
+      });
+    }
+  }
+
+  _render() {
+    if (!this.state) {
+      this.innerHTML = '';
+      return;
+    }
+    this.innerHTML = renderTreeView(this.state);
+  }
+
+  _wire() {
+    this.addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-bn-tree-select]');
+      if (!btn || !this.state) return;
+      this.state.select(btn.dataset.bnTreeSelect);
+    });
+    this.addEventListener('mouseover', (e) => {
+      const item = e.target.closest('[data-bn-tree-id]');
+      if (item && this.state) this.state.hoverNode(item.dataset.bnTreeId);
+    });
+    this.addEventListener('mouseleave', () => {
+      if (this.state) this.state.hoverNode(null);
+    });
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get(TAG)) {
+  customElements.define(TAG, BnBuilderTree);
+}

--- a/packages/builder/src/tree-view.js
+++ b/packages/builder/src/tree-view.js
@@ -1,0 +1,47 @@
+import { escapeHtml } from './escape.js';
+
+function renderRow(node, depth, selectedId, hoverId) {
+  const selected = node.id === selectedId;
+  const hovered = node.id === hoverId;
+  const classes = ['bn-tree__row'];
+  if (selected) classes.push('bn-tree__row--selected');
+  if (hovered) classes.push('bn-tree__row--hover');
+
+  const indent = '  '.repeat(depth);
+  const summary = node.props && typeof node.props.text === 'string' ? ` — ${escapeHtml(node.props.text)}` : '';
+  const ariaSelected = selected ? ' aria-selected="true"' : '';
+  const expanded = node.children && node.children.length > 0 ? ' aria-expanded="true"' : '';
+
+  return `${indent}<li role="treeitem"${ariaSelected}${expanded} data-bn-tree-id="${escapeHtml(node.id)}" class="${classes.join(' ')}">`
+    + `<button type="button" data-bn-tree-select="${escapeHtml(node.id)}" class="bn-tree__label">`
+    + `<span class="bn-tree__type">${escapeHtml(node.type)}</span>`
+    + `<span class="bn-tree__summary">${summary}</span>`
+    + `</button>`;
+}
+
+function renderChildren(children, depth, selectedId, hoverId) {
+  if (!children || children.length === 0) return '';
+  const indent = '  '.repeat(depth);
+  const inner = children.map((c) => renderSubtree(c, depth + 1, selectedId, hoverId)).join('\n');
+  return `\n${indent}<ul role="group" class="bn-tree__children">\n${inner}\n${indent}</ul>`;
+}
+
+function renderSubtree(node, depth, selectedId, hoverId) {
+  const indent = '  '.repeat(depth);
+  return `${renderRow(node, depth, selectedId, hoverId)}${renderChildren(node.children, depth, selectedId, hoverId)}\n${indent}</li>`;
+}
+
+export function renderTreeView(state) {
+  const tree = state.tree.peek ? state.tree.peek() : state.tree();
+  const selectedId = state.selection.peek ? state.selection.peek() : state.selection();
+  const hoverId = state.hover.peek ? state.hover.peek() : state.hover();
+
+  if (!tree.length) {
+    return '<div class="bn-tree bn-tree--empty" role="tree" aria-label="Component tree">'
+      + '<p class="bn-tree__empty">No components yet. Drag from the palette.</p>'
+      + '</div>';
+  }
+
+  const items = tree.map((root) => renderSubtree(root, 1, selectedId, hoverId)).join('\n');
+  return `<ul role="tree" aria-label="Component tree" class="bn-tree">\n${items}\n</ul>`;
+}

--- a/packages/builder/src/tree-view.test.js
+++ b/packages/builder/src/tree-view.test.js
@@ -1,0 +1,48 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createBuilderState } from './state.js';
+import { renderTreeView } from './tree-view.js';
+
+describe('renderTreeView', () => {
+  test('shows empty state', () => {
+    const s = createBuilderState();
+    const html = renderTreeView(s);
+    assert.ok(html.includes('bn-tree--empty'));
+    assert.ok(html.includes('No components yet'));
+  });
+
+  test('renders a tree with role=tree and aria-label', () => {
+    const s = createBuilderState();
+    s.addNode(null, { type: 'button' });
+    const html = renderTreeView(s);
+    assert.ok(html.includes('role="tree"'));
+    assert.ok(html.includes('aria-label="Component tree"'));
+  });
+
+  test('renders nested children inside group', () => {
+    const s = createBuilderState();
+    const root = s.addNode(null, { type: 'section' });
+    s.addNode(root.id, { type: 'text' });
+    const html = renderTreeView(s);
+    assert.ok(html.includes('role="treeitem"'));
+    assert.ok(html.includes('role="group"'));
+    assert.ok(html.includes('aria-expanded="true"'));
+  });
+
+  test('marks selected node with aria-selected', () => {
+    const s = createBuilderState();
+    const node = s.addNode(null, { type: 'button' });
+    s.select(node.id);
+    const html = renderTreeView(s);
+    assert.ok(html.includes('aria-selected="true"'));
+    assert.ok(html.includes('bn-tree__row--selected'));
+  });
+
+  test('escapes node text in summary', () => {
+    const s = createBuilderState();
+    s.addNode(null, { type: 'text', props: { text: '<bad>' } });
+    const html = renderTreeView(s);
+    assert.ok(html.includes('&lt;bad&gt;'));
+    assert.ok(!html.includes('<bad>'));
+  });
+});

--- a/packages/builder/types/index.d.ts
+++ b/packages/builder/types/index.d.ts
@@ -1,0 +1,151 @@
+/**
+ * @basenative/builder — public types.
+ *
+ * The builder is a signal-based drag-and-drop composer for BaseNative
+ * components. State is a hierarchical tree of nodes; each node owns props,
+ * signal bindings, and ordered children.
+ */
+
+export interface SignalBinding {
+  /** Name of the signal in the user's scope (e.g. "count"). */
+  ref: string;
+  /** Optional expression body — defaults to `${ref}()`. */
+  expr?: string;
+}
+
+export interface BuilderNode {
+  id: string;
+  type: string;
+  props: Record<string, unknown>;
+  bindings: Record<string, SignalBinding>;
+  children: BuilderNode[];
+}
+
+export interface ComponentPropSchema {
+  name: string;
+  label?: string;
+  kind: 'string' | 'number' | 'boolean' | 'enum' | 'signal';
+  default?: unknown;
+  options?: string[];
+  description?: string;
+}
+
+export interface ComponentDefinition {
+  type: string;
+  label: string;
+  category: string;
+  /** Semantic HTML tag this component renders to. */
+  tag: string;
+  /** Whether this component accepts children (containers). */
+  container: boolean;
+  /** Props the inspector exposes for editing. */
+  props: ComponentPropSchema[];
+  /** Default prop values used when adding via the palette. */
+  defaults: Record<string, unknown>;
+  /** Default text content (for components like text/heading). */
+  defaultContent?: string;
+  /** Optional ARIA role assigned to the rendered element. */
+  role?: string;
+}
+
+export interface ComponentPalette {
+  register(def: Partial<ComponentDefinition> & { type: string }): ComponentDefinition;
+  unregister(type: string): boolean;
+  get(type: string): ComponentDefinition | null;
+  list(): ComponentDefinition[];
+  byCategory(category: string): ComponentDefinition[];
+  categories(): string[];
+  search(query: string): ComponentDefinition[];
+}
+
+export interface BuilderStateOptions {
+  initial?: BuilderNode | BuilderNode[];
+  /** Maximum history entries kept on the past stack. */
+  maxHistory?: number;
+}
+
+export interface BuilderState {
+  /** Root nodes signal — readable via `state.tree()`. */
+  tree: { (): BuilderNode[]; set(next: BuilderNode[] | ((v: BuilderNode[]) => BuilderNode[])): void; peek(): BuilderNode[] };
+  selection: { (): string | null; set(id: string | null): void; peek(): string | null };
+  hover: { (): string | null; set(id: string | null): void; peek(): string | null };
+  canUndo: { (): boolean; peek(): boolean };
+  canRedo: { (): boolean; peek(): boolean };
+
+  getNode(id: string): BuilderNode | null;
+  getParent(id: string): BuilderNode | null;
+  getPath(id: string): string[];
+
+  addNode(parentId: string | null, spec: Partial<BuilderNode> & { type: string }, index?: number): BuilderNode;
+  removeNode(id: string): boolean;
+  updateProps(id: string, patch: Record<string, unknown>): boolean;
+  setBinding(id: string, propKey: string, binding: SignalBinding | null): boolean;
+  moveNode(id: string, newParentId: string | null, index?: number): boolean;
+  duplicateNode(id: string): BuilderNode | null;
+
+  select(id: string | null): void;
+  hoverNode(id: string | null): void;
+
+  undo(): boolean;
+  redo(): boolean;
+  clear(): void;
+
+  toJSON(): string;
+  fromJSON(json: string): void;
+  subscribe(callback: (event: BuilderEvent) => void): () => void;
+}
+
+export type BuilderEvent =
+  | { type: 'add'; node: BuilderNode; parentId: string | null }
+  | { type: 'remove'; id: string }
+  | { type: 'update'; id: string; patch: Record<string, unknown> }
+  | { type: 'binding'; id: string; propKey: string; binding: SignalBinding | null }
+  | { type: 'move'; id: string; parentId: string | null; index: number }
+  | { type: 'select'; id: string | null }
+  | { type: 'hover'; id: string | null }
+  | { type: 'undo' }
+  | { type: 'redo' }
+  | { type: 'clear' }
+  | { type: 'load' };
+
+export interface CodegenOptions {
+  /** Indentation string per nesting level. Default: "  ". */
+  indent?: string;
+  /** Document mode wraps output in <!DOCTYPE> + html shell. Default: false. */
+  document?: boolean;
+  /** Title used in document mode. */
+  title?: string;
+  /** Names of signals to declare in the generated component scope. */
+  signals?: Record<string, unknown>;
+}
+
+export function createBuilderState(options?: BuilderStateOptions): BuilderState;
+export function createPalette(): ComponentPalette;
+export function defaultPalette(): ComponentPalette;
+export function generateBaseNative(state: BuilderState, options?: CodegenOptions): string;
+export function renderTreeView(state: BuilderState): string;
+export function renderInspector(state: BuilderState, palette: ComponentPalette): string;
+export function escapeHtml(value: unknown): string;
+
+export class BnBuilder extends HTMLElement {
+  state: BuilderState;
+  palette: ComponentPalette;
+}
+
+export class BnBuilderCanvas extends HTMLElement {
+  state: BuilderState;
+  palette: ComponentPalette;
+}
+
+export class BnBuilderPalette extends HTMLElement {
+  palette: ComponentPalette;
+}
+
+export class BnBuilderTree extends HTMLElement {
+  state: BuilderState;
+}
+
+export class BnBuilderInspector extends HTMLElement {
+  state: BuilderState;
+  palette: ComponentPalette;
+}

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -4,7 +4,8 @@
   "description": "Headless third-party integration wrappers for BaseNative apps",
   "type": "module",
   "exports": {
-    "./plaid": "./src/plaid.js"
+    "./plaid": "./src/plaid.js",
+    "./yield": "./src/yield.js"
   },
   "types": "./types/index.d.ts",
   "files": ["src", "types"],

--- a/packages/integrations/src/plaid.js
+++ b/packages/integrations/src/plaid.js
@@ -1,16 +1,14 @@
 /**
  * @basenative/integrations/plaid — headless Plaid Link wrapper.
  *
- * Client-side: loadPlaidLink() injects the Plaid Link script and
- * returns a handler for opening the Link flow.
- *
- * Server-side: createLinkToken() and exchangePublicToken() wrap the
- * Plaid API for Cloudflare Worker / Node.js environments.
+ * Client-side: createPlaidLink() wraps the Plaid Link initialization with signals.
+ * Server-side: createPlaidClient() provides account/balance/transfer APIs.
+ * Yield optimization: findBestYieldAccount() computes optimal float allocation.
  */
 
 const PLAID_LINK_CDN = 'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
 
-// ---------- Client-side ----------
+// ---------- Client-side: Signal-based Link initialization ----------
 
 /**
  * Load the Plaid Link drop-in script if not already present.
@@ -47,7 +45,55 @@ export function loadPlaidScript() {
 }
 
 /**
- * Open Plaid Link with the given link token.
+ * Create a signal-based Plaid Link handler.
+ * Returns signals for linkToken, linkStatus, and accounts.
+ *
+ * @param {object} config
+ * @param {string} config.token         Link token from createLinkToken()
+ * @param {function} config.onSuccess   Called with (publicToken, metadata)
+ * @param {function} [config.onExit]    Called when user exits Link
+ * @param {function} [config.onEvent]   Called on Link events
+ * @param {object} [config.signals]     Signals object with signal(), computed() functions
+ * @returns {Promise<{ linkToken: object, linkStatus: object, handler: object }>}
+ */
+export async function createPlaidLink(config) {
+  const { token, onSuccess, onExit, onEvent, signals } = config;
+
+  await loadPlaidScript();
+
+  if (!window.Plaid) {
+    throw new Error('@basenative/integrations/plaid: Plaid Link script failed to initialize');
+  }
+
+  // If signals are provided, create signal-based state
+  const linkTokenSignal = signals?.signal ? signals.signal(token) : null;
+  const linkStatusSignal = signals?.signal ? signals.signal('ready') : null;
+
+  const handler = window.Plaid.create({
+    token,
+    onSuccess: (publicToken, metadata) => {
+      if (linkStatusSignal) linkStatusSignal.set('success');
+      if (onSuccess) onSuccess(publicToken, metadata);
+    },
+    onExit: (err, metadata) => {
+      if (linkStatusSignal) linkStatusSignal.set('exit');
+      if (onExit) onExit(err, metadata);
+    },
+    onEvent: (eventName, metadata) => {
+      if (onEvent) onEvent(eventName, metadata);
+    },
+  });
+
+  return {
+    linkToken: linkTokenSignal,
+    linkStatus: linkStatusSignal,
+    open: () => handler.open(),
+    destroy: () => handler.destroy(),
+  };
+}
+
+/**
+ * Open Plaid Link with the given link token (legacy API).
  *
  * @param {object} options
  * @param {string} options.token         Link token from createLinkToken()
@@ -84,7 +130,7 @@ export async function openPlaidLink(options) {
   };
 }
 
-// ---------- Server-side ----------
+// ---------- Server-side: Plaid Client Factory ----------
 
 const PLAID_ENVS = {
   sandbox: 'https://sandbox.plaid.com',
@@ -126,6 +172,32 @@ async function plaidRequest(path, body, credentials) {
   }
 
   return data;
+}
+
+/**
+ * Create a Plaid API client factory with server methods.
+ * Works in Cloudflare Workers and Node.js environments.
+ *
+ * @param {object} config
+ * @param {string} config.clientId
+ * @param {string} config.secret
+ * @param {string} [config.environment='sandbox']
+ * @returns {object}
+ */
+export function createPlaidClient(config) {
+  const credentials = {
+    clientId: config.clientId,
+    secret: config.secret,
+    env: config.environment || 'sandbox',
+  };
+
+  return {
+    exchangePublicToken: (publicToken) => exchangePublicToken(publicToken, credentials),
+    getAccounts: (accessToken) => getAccounts(accessToken, credentials),
+    getBalance: (accessToken) => getBalance(accessToken, credentials),
+    createTransfer: (params) => createTransfer(params, credentials),
+    getTransferStatus: (transferId) => getTransferStatus(transferId, credentials),
+  };
 }
 
 /**
@@ -179,6 +251,28 @@ export async function exchangePublicToken(publicToken, credentials) {
 }
 
 /**
+ * Fetch linked accounts (without balance details).
+ *
+ * @param {string} accessToken  The access token from exchangePublicToken()
+ * @param {object} credentials
+ * @returns {Promise<{ accounts: Array<{ id: string, name: string, type: string, subtype: string }> }>}
+ */
+export async function getAccounts(accessToken, credentials) {
+  const data = await plaidRequest('/accounts/get', {
+    access_token: accessToken,
+  }, credentials);
+
+  return {
+    accounts: data.accounts.map(a => ({
+      id: a.account_id,
+      name: a.name,
+      type: a.type,
+      subtype: a.subtype,
+    })),
+  };
+}
+
+/**
  * Fetch account balances for a linked item.
  *
  * @param {string} accessToken  The access token from exchangePublicToken()
@@ -203,5 +297,107 @@ export async function getBalances(accessToken, credentials) {
         currency: a.balances.iso_currency_code,
       },
     })),
+  };
+}
+
+/**
+ * Alias for getBalances() for consistency.
+ *
+ * @param {string} accessToken
+ * @param {object} credentials
+ * @returns {Promise<object>}
+ */
+export async function getBalance(accessToken, credentials) {
+  return getBalances(accessToken, credentials);
+}
+
+/**
+ * Initiate a transfer via Plaid Transfer API.
+ * Supports FedNow instant transfers (network: "rtp") with graceful fallback to ACH.
+ *
+ * @param {object} params
+ * @param {string} params.accessToken        Access token for the source account
+ * @param {string} params.accountId          Account to transfer from
+ * @param {string} params.type               Transfer type ("debit" or "credit")
+ * @param {number} params.amount             Amount in cents
+ * @param {string} params.description        Transfer description
+ * @param {string} [params.network]          "rtp" (RTP/FedNow) or "ach" (default: auto-detect)
+ * @param {object} [params.user]             User info { name, email }
+ * @param {object} credentials
+ * @returns {Promise<{ transferId: string, status: string, network: string }>}
+ */
+export async function createTransfer(params, credentials) {
+  const {
+    accessToken,
+    accountId,
+    type,
+    amount,
+    description,
+    network,
+    user,
+  } = params;
+
+  const body = {
+    access_token: accessToken,
+    account_id: accountId,
+    type,
+    amount: amount / 100, // Convert cents to dollars
+    description: description || 'Transfer via PendingBusiness',
+  };
+
+  // If network is explicitly set to "rtp" (RTP/FedNow), use it
+  // Otherwise, let Plaid auto-detect or default to ACH
+  if (network === 'rtp') {
+    body.network = 'rtp';
+  }
+
+  if (user) {
+    body.user = {
+      name: user.name,
+      email_address: user.email,
+    };
+  }
+
+  try {
+    const data = await plaidRequest('/transfer/create', body, credentials);
+
+    return {
+      transferId: data.transfer_id,
+      status: data.status,
+      network: data.network || 'ach', // Default to ACH if not specified
+    };
+  } catch (err) {
+    // If FedNow fails, retry with ACH
+    if (network === 'rtp' && err.plaidError?.error_code === 'INVALID_REQUEST') {
+      const achBody = { ...body };
+      delete achBody.network;
+      const data = await plaidRequest('/transfer/create', achBody, credentials);
+      return {
+        transferId: data.transfer_id,
+        status: data.status,
+        network: 'ach', // Fell back to ACH
+      };
+    }
+    throw err;
+  }
+}
+
+/**
+ * Check the status of a transfer.
+ *
+ * @param {string} transferId   Transfer ID from createTransfer()
+ * @param {object} credentials
+ * @returns {Promise<{ transferId: string, status: string, amount: number, network: string }>}
+ */
+export async function getTransferStatus(transferId, credentials) {
+  const data = await plaidRequest('/transfer/get', {
+    transfer_id: transferId,
+  }, credentials);
+
+  return {
+    transferId: data.transfer_id,
+    status: data.status,
+    amount: data.amount,
+    network: data.network || 'ach',
   };
 }

--- a/packages/integrations/src/plaid.test.js
+++ b/packages/integrations/src/plaid.test.js
@@ -4,7 +4,17 @@ import assert from 'node:assert/strict';
 // Mock fetch for server-side API tests
 const originalFetch = globalThis.fetch;
 
-describe('plaid server-side', () => {
+describe('plaid client-side', () => {
+  it('loadPlaidScript rejects in Node.js', async () => {
+    const { loadPlaidScript } = await import('./plaid.js');
+    await assert.rejects(
+      () => loadPlaidScript(),
+      /requires a browser environment/
+    );
+  });
+});
+
+describe('plaid server-side — link token', () => {
   it('createLinkToken calls /link/token/create', async () => {
     globalThis.fetch = mock.fn(() => Promise.resolve({
       ok: true,
@@ -38,7 +48,9 @@ describe('plaid server-side', () => {
 
     globalThis.fetch = originalFetch;
   });
+});
 
+describe('plaid server-side — token exchange', () => {
   it('exchangePublicToken calls /item/public_token/exchange', async () => {
     globalThis.fetch = mock.fn(() => Promise.resolve({
       ok: true,
@@ -49,7 +61,6 @@ describe('plaid server-side', () => {
       }),
     }));
 
-    // Re-import to use fresh fetch mock
     const mod = await import('./plaid.js?v=2');
     const result = await mod.exchangePublicToken(
       'public-sandbox-token',
@@ -61,6 +72,37 @@ describe('plaid server-side', () => {
 
     const body = JSON.parse(globalThis.fetch.mock.calls[0].arguments[1].body);
     assert.equal(body.public_token, 'public-sandbox-token');
+
+    globalThis.fetch = originalFetch;
+  });
+});
+
+describe('plaid server-side — accounts & balances', () => {
+  it('getAccounts calls /accounts/get', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        accounts: [{
+          account_id: 'acc-1',
+          name: 'Checking',
+          type: 'depository',
+          subtype: 'checking',
+        }],
+      }),
+    }));
+
+    const mod = await import('./plaid.js?v=3a');
+    const result = await mod.getAccounts(
+      'access-token',
+      { clientId: 'cid', secret: 'sec', env: 'sandbox' }
+    );
+
+    assert.equal(result.accounts.length, 1);
+    assert.equal(result.accounts[0].id, 'acc-1');
+    assert.equal(result.accounts[0].name, 'Checking');
+
+    const [url] = globalThis.fetch.mock.calls[0].arguments;
+    assert.equal(url, 'https://sandbox.plaid.com/accounts/get');
 
     globalThis.fetch = originalFetch;
   });
@@ -84,7 +126,7 @@ describe('plaid server-side', () => {
       }),
     }));
 
-    const mod = await import('./plaid.js?v=3');
+    const mod = await import('./plaid.js?v=3b');
     const result = await mod.getBalances(
       'access-token',
       { clientId: 'cid', secret: 'sec', env: 'sandbox' }
@@ -92,13 +134,210 @@ describe('plaid server-side', () => {
 
     assert.equal(result.accounts.length, 1);
     assert.equal(result.accounts[0].id, 'acc-1');
-    assert.equal(result.accounts[0].name, 'Checking');
     assert.equal(result.accounts[0].balances.available, 1000);
     assert.equal(result.accounts[0].balances.currency, 'USD');
 
     globalThis.fetch = originalFetch;
   });
 
+  it('getBalance is an alias for getBalances', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        accounts: [{
+          account_id: 'acc-1',
+          name: 'Savings',
+          type: 'depository',
+          subtype: 'savings',
+          balances: {
+            available: 5000,
+            current: 5000,
+            limit: null,
+            iso_currency_code: 'USD',
+          },
+        }],
+      }),
+    }));
+
+    const mod = await import('./plaid.js?v=3c');
+    const result = await mod.getBalance(
+      'access-token',
+      { clientId: 'cid', secret: 'sec', env: 'sandbox' }
+    );
+
+    assert.equal(result.accounts[0].balances.available, 5000);
+
+    globalThis.fetch = originalFetch;
+  });
+});
+
+describe('plaid server-side — transfers', () => {
+  it('createTransfer initiates a transfer', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        transfer_id: 'xfer-001',
+        status: 'pending',
+        network: 'ach',
+      }),
+    }));
+
+    const mod = await import('./plaid.js?v=4a');
+    const result = await mod.createTransfer({
+      accessToken: 'access-token',
+      accountId: 'acc-1',
+      type: 'debit',
+      amount: 50000, // $500 in cents
+      description: 'Test transfer',
+    }, { clientId: 'cid', secret: 'sec', env: 'sandbox' });
+
+    assert.equal(result.transferId, 'xfer-001');
+    assert.equal(result.status, 'pending');
+    assert.equal(result.network, 'ach');
+
+    const [url, opts] = globalThis.fetch.mock.calls[0].arguments;
+    assert.equal(url, 'https://sandbox.plaid.com/transfer/create');
+
+    const body = JSON.parse(opts.body);
+    assert.equal(body.amount, 500); // Converted to dollars
+    assert.equal(body.type, 'debit');
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('createTransfer supports FedNow (RTP) network', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        transfer_id: 'xfer-fedNow',
+        status: 'pending',
+        network: 'rtp',
+      }),
+    }));
+
+    const mod = await import('./plaid.js?v=4b');
+    const result = await mod.createTransfer({
+      accessToken: 'access-token',
+      accountId: 'acc-1',
+      type: 'debit',
+      amount: 100000,
+      description: 'FedNow transfer',
+      network: 'rtp',
+    }, { clientId: 'cid', secret: 'sec', env: 'sandbox' });
+
+    assert.equal(result.transferId, 'xfer-fedNow');
+    assert.equal(result.network, 'rtp');
+
+    const body = JSON.parse(globalThis.fetch.mock.calls[0].arguments[1].body);
+    assert.equal(body.network, 'rtp');
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('createTransfer falls back from FedNow to ACH on error', async () => {
+    let callCount = 0;
+    globalThis.fetch = mock.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        // First call (RTP) fails
+        return Promise.resolve({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({
+            error_message: 'INVALID_REQUEST',
+            error_code: 'INVALID_REQUEST',
+            error_type: 'INVALID_INPUT',
+          }),
+        });
+      }
+      // Second call (ACH fallback) succeeds
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          transfer_id: 'xfer-ach-fallback',
+          status: 'pending',
+          network: 'ach',
+        }),
+      });
+    });
+
+    const mod = await import('./plaid.js?v=4c');
+    const result = await mod.createTransfer({
+      accessToken: 'access-token',
+      accountId: 'acc-1',
+      type: 'debit',
+      amount: 100000,
+      description: 'FedNow with fallback',
+      network: 'rtp',
+    }, { clientId: 'cid', secret: 'sec', env: 'sandbox' });
+
+    assert.equal(result.transferId, 'xfer-ach-fallback');
+    assert.equal(result.network, 'ach');
+    assert.equal(callCount, 2);
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('getTransferStatus checks transfer status', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        transfer_id: 'xfer-001',
+        status: 'posted',
+        amount: 500,
+        network: 'ach',
+      }),
+    }));
+
+    const mod = await import('./plaid.js?v=4d');
+    const result = await mod.getTransferStatus(
+      'xfer-001',
+      { clientId: 'cid', secret: 'sec', env: 'sandbox' }
+    );
+
+    assert.equal(result.transferId, 'xfer-001');
+    assert.equal(result.status, 'posted');
+    assert.equal(result.amount, 500);
+
+    const [url] = globalThis.fetch.mock.calls[0].arguments;
+    assert.equal(url, 'https://sandbox.plaid.com/transfer/get');
+
+    globalThis.fetch = originalFetch;
+  });
+});
+
+describe('plaid server-side — factory client', () => {
+  it('createPlaidClient returns an API client', async () => {
+    globalThis.fetch = mock.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        access_token: 'access-xyz',
+        item_id: 'item-001',
+        request_id: 'req-123',
+      }),
+    }));
+
+    const { createPlaidClient } = await import('./plaid.js?v=5');
+    const client = createPlaidClient({
+      clientId: 'test-id',
+      secret: 'test-secret',
+      environment: 'sandbox',
+    });
+
+    assert.ok(client.exchangePublicToken);
+    assert.ok(client.getAccounts);
+    assert.ok(client.getBalance);
+    assert.ok(client.createTransfer);
+    assert.ok(client.getTransferStatus);
+
+    const result = await client.exchangePublicToken('pub-token');
+    assert.equal(result.accessToken, 'access-xyz');
+
+    globalThis.fetch = originalFetch;
+  });
+});
+
+describe('plaid server-side — error handling', () => {
   it('throws on Plaid API error', async () => {
     globalThis.fetch = mock.fn(() => Promise.resolve({
       ok: false,
@@ -109,7 +348,7 @@ describe('plaid server-side', () => {
       }),
     }));
 
-    const mod = await import('./plaid.js?v=4');
+    const mod = await import('./plaid.js?v=6');
     await assert.rejects(
       () => mod.createLinkToken({ userId: 'u1' }, { clientId: 'bad', secret: 'bad', env: 'sandbox' }),
       (err) => {
@@ -123,18 +362,10 @@ describe('plaid server-side', () => {
   });
 
   it('rejects unknown env', async () => {
-    const mod = await import('./plaid.js?v=5');
+    const mod = await import('./plaid.js?v=7');
     await assert.rejects(
       () => mod.createLinkToken({ userId: 'u1' }, { clientId: 'c', secret: 's', env: 'invalid' }),
       /unknown env/
-    );
-  });
-
-  it('loadPlaidScript rejects in Node.js', async () => {
-    const mod = await import('./plaid.js?v=6');
-    await assert.rejects(
-      () => mod.loadPlaidScript(),
-      /requires a browser environment/
     );
   });
 });

--- a/packages/integrations/src/yield.js
+++ b/packages/integrations/src/yield.js
@@ -1,0 +1,170 @@
+/**
+ * Yield optimization for idle float management in PendingBusiness.
+ *
+ * Pure functions for determining optimal account allocation and transfer timing.
+ * No external API calls — just the math for float yield maximization.
+ */
+
+/**
+ * Find the best yield account from a list of linked accounts with balances and APYs.
+ *
+ * @param {Array<{ id: string, name: string, balance: number, apy: number }>} accounts
+ * @returns {{ accountId: string, accountName: string, apy: number, expectedMonthlyYield: number }}
+ */
+export function findBestYieldAccount(accounts) {
+  if (!accounts || accounts.length === 0) {
+    throw new Error('No accounts provided for yield calculation');
+  }
+
+  let best = accounts[0];
+  for (let i = 1; i < accounts.length; i++) {
+    if (accounts[i].apy > best.apy) {
+      best = accounts[i];
+    }
+  }
+
+  // Calculate expected monthly yield on the account's current balance
+  const monthlyRate = best.apy / 12;
+  const expectedMonthlyYield = best.balance * monthlyRate;
+
+  return {
+    accountId: best.id,
+    accountName: best.name,
+    apy: best.apy,
+    expectedMonthlyYield,
+  };
+}
+
+/**
+ * Determine optimal float allocation across multiple accounts.
+ *
+ * Allocates funds to maximize total yield while respecting account limits.
+ *
+ * @param {Array<{ id: string, name: string, balance: number, apy: number, maxBalance?: number }>} accounts
+ * @param {number} totalFloat     Total float to allocate across accounts
+ * @returns {Array<{ accountId: string, accountName: string, allocation: number, expectedYield: number }>}
+ */
+export function optimizeFloatAllocation(accounts, totalFloat) {
+  if (!accounts || accounts.length === 0) {
+    throw new Error('No accounts provided for allocation');
+  }
+
+  if (totalFloat < 0) {
+    throw new Error('Total float must be non-negative');
+  }
+
+  // Sort accounts by APY descending
+  const sorted = [...accounts].sort((a, b) => b.apy - a.apy);
+
+  const allocation = [];
+  let remaining = totalFloat;
+
+  for (const account of sorted) {
+    const max = account.maxBalance || Infinity;
+    const allocate = Math.min(remaining, max - (account.balance || 0));
+
+    if (allocate > 0) {
+      const monthlyRate = account.apy / 12;
+      const expectedYield = allocate * monthlyRate;
+
+      allocation.push({
+        accountId: account.id,
+        accountName: account.name,
+        allocation: allocate,
+        expectedYield,
+      });
+
+      remaining -= allocate;
+    }
+
+    if (remaining === 0) break;
+  }
+
+  return allocation;
+}
+
+/**
+ * Calculate optimal timing for float transfers based on liability due dates and yield.
+ *
+ * Returns a transfer schedule that keeps idle float in high-yield accounts
+ * until it's needed to cover liabilities.
+ *
+ * @param {Array<{ dueDate: Date, amount: number, description?: string }>} liabilities
+ * @param {Array<{ id: string, name: string, currentBalance: number, apy: number }>} accounts
+ * @returns {Array<{ transferDate: Date, fromAccountId: string, amount: number, reason: string }>}
+ */
+export function calculateOptimalTransferTiming(liabilities, accounts) {
+  if (!liabilities || liabilities.length === 0) {
+    return [];
+  }
+
+  if (!accounts || accounts.length === 0) {
+    throw new Error('No accounts available for float management');
+  }
+
+  // Find the best yield account
+  const best = findBestYieldAccount(accounts);
+
+  // Sort liabilities by due date
+  const sorted = [...liabilities].sort((a, b) => a.dueDate - b.dueDate);
+
+  const schedule = [];
+  const transferBuffer = 2; // days before due date to transfer
+
+  for (const liability of sorted) {
+    const transferDate = new Date(liability.dueDate);
+    transferDate.setDate(transferDate.getDate() - transferBuffer);
+
+    schedule.push({
+      transferDate,
+      fromAccountId: best.accountId,
+      amount: liability.amount,
+      reason: liability.description || 'Scheduled liability payment',
+    });
+  }
+
+  return schedule;
+}
+
+/**
+ * Calculate the break-even point for a transfer based on yield difference.
+ *
+ * Determines if it's worth transferring money from one account to another
+ * based on the yield difference and transfer cost.
+ *
+ * @param {number} amount             Amount to transfer (in cents)
+ * @param {number} fromApy            APY of source account
+ * @param {number} toApy              APY of destination account
+ * @param {number} [transferCostCents=0] Fixed transfer cost (usually 0 for ACH)
+ * @param {number} [daysFloat=30]     Number of days the money will be in destination
+ * @returns {{ profitable: boolean, yieldGain: number, breakEvenDays: number }}
+ */
+export function calculateBreakEven(amount, fromApy, toApy, transferCostCents = 0, daysFloat = 30) {
+  if (toApy <= fromApy) {
+    return {
+      profitable: false,
+      yieldGain: 0,
+      breakEvenDays: Infinity,
+    };
+  }
+
+  const amountDollars = amount / 100;
+  const costDollars = transferCostCents / 100;
+
+  // Daily yield difference
+  const yieldDiff = toApy - fromApy;
+  const dailyYieldGain = amountDollars * (yieldDiff / 365);
+
+  // Break-even point (how many days to recoup transfer cost)
+  const breakEvenDays = dailyYieldGain > 0 ? costDollars / dailyYieldGain : Infinity;
+
+  // Total yield gain over daysFloat
+  const totalYieldGain = dailyYieldGain * daysFloat;
+  const netGain = totalYieldGain - costDollars;
+
+  return {
+    profitable: netGain > 0,
+    yieldGain: netGain,
+    breakEvenDays,
+  };
+}

--- a/packages/integrations/src/yield.test.js
+++ b/packages/integrations/src/yield.test.js
@@ -1,0 +1,263 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  findBestYieldAccount,
+  optimizeFloatAllocation,
+  calculateOptimalTransferTiming,
+  calculateBreakEven,
+} from './yield.js';
+
+describe('yield optimization', () => {
+  describe('findBestYieldAccount', () => {
+    it('returns the account with highest APY', () => {
+      const accounts = [
+        { id: 'acc-1', name: 'Checking', balance: 1000, apy: 0.01 },
+        { id: 'acc-2', name: 'Money Market', balance: 5000, apy: 0.045 },
+        { id: 'acc-3', name: 'Savings', balance: 2000, apy: 0.035 },
+      ];
+
+      const result = findBestYieldAccount(accounts);
+
+      assert.equal(result.accountId, 'acc-2');
+      assert.equal(result.accountName, 'Money Market');
+      assert.equal(result.apy, 0.045);
+    });
+
+    it('calculates expected monthly yield correctly', () => {
+      const accounts = [
+        { id: 'acc-1', name: 'Test', balance: 12000, apy: 0.12 }, // 12% APY = 1% per month
+      ];
+
+      const result = findBestYieldAccount(accounts);
+
+      // 12000 * (0.12 / 12) = 120
+      assert.equal(result.expectedMonthlyYield, 120);
+    });
+
+    it('throws on empty accounts', () => {
+      assert.throws(
+        () => findBestYieldAccount([]),
+        /No accounts provided/
+      );
+    });
+
+    it('throws on null accounts', () => {
+      assert.throws(
+        () => findBestYieldAccount(null),
+        /No accounts provided/
+      );
+    });
+
+    it('handles single account', () => {
+      const accounts = [
+        { id: 'only', name: 'Single', balance: 5000, apy: 0.05 },
+      ];
+
+      const result = findBestYieldAccount(accounts);
+
+      assert.equal(result.accountId, 'only');
+      assert.equal(result.apy, 0.05);
+    });
+  });
+
+  describe('optimizeFloatAllocation', () => {
+    it('allocates float to highest-yield accounts first', () => {
+      const accounts = [
+        { id: 'low', name: 'Low Yield', balance: 1000, apy: 0.01, maxBalance: Infinity },
+        { id: 'high', name: 'High Yield', balance: 2000, apy: 0.05, maxBalance: Infinity },
+        { id: 'mid', name: 'Mid Yield', balance: 1500, apy: 0.03, maxBalance: Infinity },
+      ];
+
+      const result = optimizeFloatAllocation(accounts, 10000);
+
+      assert.equal(result.length, 1);
+      assert.equal(result[0].accountId, 'high'); // Highest APY first
+      assert.equal(result[0].allocation, 10000); // All goes to high
+    });
+
+    it('respects max balance limits', () => {
+      const accounts = [
+        { id: 'acc-1', name: 'Limited', balance: 2000, apy: 0.10, maxBalance: 5000 },
+        { id: 'acc-2', name: 'Unlimited', balance: 1000, apy: 0.08 },
+      ];
+
+      const result = optimizeFloatAllocation(accounts, 5000);
+
+      const acc1 = result.find(r => r.accountId === 'acc-1');
+      const acc2 = result.find(r => r.accountId === 'acc-2');
+
+      assert.equal(acc1.allocation, 3000); // Limited to 5000 - 2000
+      assert.equal(acc2.allocation, 2000); // Remainder
+    });
+
+    it('calculates expected yield for each allocation', () => {
+      const accounts = [
+        { id: 'acc-1', name: 'Test', balance: 0, apy: 0.12 },
+      ];
+
+      const result = optimizeFloatAllocation(accounts, 10000);
+
+      // 10000 * (0.12 / 12) = 100
+      assert.equal(result[0].expectedYield, 100);
+    });
+
+    it('handles zero float', () => {
+      const accounts = [
+        { id: 'acc-1', name: 'Test', balance: 1000, apy: 0.05 },
+      ];
+
+      const result = optimizeFloatAllocation(accounts, 0);
+
+      assert.equal(result.length, 0);
+    });
+
+    it('throws on negative float', () => {
+      const accounts = [
+        { id: 'acc-1', name: 'Test', balance: 1000, apy: 0.05 },
+      ];
+
+      assert.throws(
+        () => optimizeFloatAllocation(accounts, -1000),
+        /non-negative/
+      );
+    });
+
+    it('throws on empty accounts', () => {
+      assert.throws(
+        () => optimizeFloatAllocation([], 10000),
+        /No accounts provided/
+      );
+    });
+  });
+
+  describe('calculateOptimalTransferTiming', () => {
+    it('creates transfer schedule for liabilities', () => {
+      const liabilities = [
+        { dueDate: new Date('2025-05-15'), amount: 5000, description: 'Payroll' },
+        { dueDate: new Date('2025-06-01'), amount: 3000, description: 'Rent' },
+      ];
+
+      const accounts = [
+        { id: 'acc-1', name: 'Money Market', balance: 10000, apy: 0.05 },
+      ];
+
+      const schedule = calculateOptimalTransferTiming(liabilities, accounts);
+
+      assert.equal(schedule.length, 2);
+      assert.equal(schedule[0].amount, 5000);
+      assert.equal(schedule[1].amount, 3000);
+    });
+
+    it('schedules transfers 2 days before due date', () => {
+      const dueDate = new Date('2025-05-15');
+      const liabilities = [{ dueDate, amount: 1000 }];
+
+      const accounts = [
+        { id: 'acc-1', name: 'Test', balance: 5000, apy: 0.05 },
+      ];
+
+      const schedule = calculateOptimalTransferTiming(liabilities, accounts);
+
+      const expectedDate = new Date(dueDate);
+      expectedDate.setDate(expectedDate.getDate() - 2);
+
+      assert.equal(schedule[0].transferDate.toISOString(), expectedDate.toISOString());
+    });
+
+    it('sorts schedule by due date', () => {
+      const liabilities = [
+        { dueDate: new Date('2025-06-01'), amount: 1000 },
+        { dueDate: new Date('2025-05-01'), amount: 2000 },
+        { dueDate: new Date('2025-05-15'), amount: 1500 },
+      ];
+
+      const accounts = [
+        { id: 'acc-1', name: 'Test', balance: 10000, apy: 0.05 },
+      ];
+
+      const schedule = calculateOptimalTransferTiming(liabilities, accounts);
+
+      assert.equal(schedule[0].amount, 2000); // May 1
+      assert.equal(schedule[1].amount, 1500); // May 15
+      assert.equal(schedule[2].amount, 1000); // June 1
+    });
+
+    it('throws on empty liabilities', () => {
+      const accounts = [
+        { id: 'acc-1', name: 'Test', balance: 5000, apy: 0.05 },
+      ];
+
+      const result = calculateOptimalTransferTiming([], accounts);
+      assert.equal(result.length, 0);
+    });
+
+    it('throws on empty accounts', () => {
+      const liabilities = [
+        { dueDate: new Date('2025-05-15'), amount: 1000 },
+      ];
+
+      assert.throws(
+        () => calculateOptimalTransferTiming(liabilities, []),
+        /No accounts available/
+      );
+    });
+  });
+
+  describe('calculateBreakEven', () => {
+    it('determines profitability of a transfer', () => {
+      // 5% source, 10% destination, $1000, 30 days
+      // Yield diff = 5% / year = 0.05 / 365 * 1000 * 30 = $4.11
+      // No transfer cost, so profitable
+      const result = calculateBreakEven(100000, 0.05, 0.10, 0, 30);
+
+      assert.equal(result.profitable, true);
+      assert.ok(result.yieldGain > 0);
+    });
+
+    it('calculates break-even days correctly', () => {
+      // $1000, 5% difference, $1 transfer cost
+      // Daily yield = 1000 * (0.05 / 365) = $0.137
+      // Break-even = 1 / 0.137 ≈ 7.3 days
+      const result = calculateBreakEven(100000, 0.05, 0.10, 100);
+
+      assert.ok(result.breakEvenDays > 0);
+      assert.ok(result.breakEvenDays < 100);
+    });
+
+    it('returns false when destination APY is lower', () => {
+      const result = calculateBreakEven(100000, 0.10, 0.05, 0, 30);
+
+      assert.equal(result.profitable, false);
+      assert.equal(result.yieldGain, 0);
+      assert.equal(result.breakEvenDays, Infinity);
+    });
+
+    it('returns false when destination APY equals source APY', () => {
+      const result = calculateBreakEven(100000, 0.05, 0.05, 0, 30);
+
+      assert.equal(result.profitable, false);
+    });
+
+    it('accounts for transfer costs', () => {
+      // Small amount, high cost relative to gain
+      const result = calculateBreakEven(10000, 0.05, 0.10, 10000, 1); // $100 transfer cost
+
+      assert.equal(result.profitable, false); // Cost exceeds 1-day gain
+    });
+
+    it('uses defaults for optional parameters', () => {
+      const result = calculateBreakEven(100000, 0.05, 0.10);
+
+      assert.equal(result.profitable, true);
+      assert.ok(result.yieldGain > 0);
+    });
+
+    it('handles zero transfer cost', () => {
+      const result = calculateBreakEven(100000, 0.05, 0.10, 0, 30);
+
+      assert.equal(result.profitable, true);
+      assert.ok(result.yieldGain > 0);
+      assert.ok(result.breakEvenDays < 1); // Should be immediate with no cost
+    });
+  });
+});

--- a/packages/integrations/types/index.d.ts
+++ b/packages/integrations/types/index.d.ts
@@ -57,8 +57,75 @@ export interface OpenPlaidLinkOptions {
   onEvent?: (eventName: string, metadata: unknown) => void;
 }
 
+// Client-side Link API
 export function loadPlaidScript(): Promise<void>;
 export function openPlaidLink(options: OpenPlaidLinkOptions): Promise<PlaidLinkHandler>;
+export function createPlaidLink(config: any): Promise<any>;
+
+// Server-side API
+export interface PlaidClient {
+  exchangePublicToken(publicToken: string): Promise<ExchangeResult>;
+  getAccounts(accessToken: string): Promise<any>;
+  getBalance(accessToken: string): Promise<BalancesResult>;
+  createTransfer(params: any): Promise<any>;
+  getTransferStatus(transferId: string): Promise<any>;
+}
+
+export function createPlaidClient(config: { clientId: string; secret: string; environment?: string }): PlaidClient;
 export function createLinkToken(options: LinkTokenOptions, credentials: PlaidCredentials): Promise<LinkTokenResult>;
 export function exchangePublicToken(publicToken: string, credentials: PlaidCredentials): Promise<ExchangeResult>;
+export function getAccounts(accessToken: string, credentials: PlaidCredentials): Promise<any>;
 export function getBalances(accessToken: string, credentials: PlaidCredentials): Promise<BalancesResult>;
+export function getBalance(accessToken: string, credentials: PlaidCredentials): Promise<BalancesResult>;
+export function createTransfer(params: any, credentials: PlaidCredentials): Promise<any>;
+export function getTransferStatus(transferId: string, credentials: PlaidCredentials): Promise<any>;
+
+// Yield optimization API
+export interface YieldAccount {
+  id: string;
+  name: string;
+  balance: number;
+  apy: number;
+  maxBalance?: number;
+}
+
+export interface BestYieldResult {
+  accountId: string;
+  accountName: string;
+  apy: number;
+  expectedMonthlyYield: number;
+}
+
+export interface FloatAllocation {
+  accountId: string;
+  accountName: string;
+  allocation: number;
+  expectedYield: number;
+}
+
+export interface TransferSchedule {
+  transferDate: Date;
+  fromAccountId: string;
+  amount: number;
+  reason: string;
+}
+
+export interface BreakEvenResult {
+  profitable: boolean;
+  yieldGain: number;
+  breakEvenDays: number;
+}
+
+export function findBestYieldAccount(accounts: YieldAccount[]): BestYieldResult;
+export function optimizeFloatAllocation(accounts: YieldAccount[], totalFloat: number): FloatAllocation[];
+export function calculateOptimalTransferTiming(
+  liabilities: Array<{ dueDate: Date; amount: number; description?: string }>,
+  accounts: YieldAccount[]
+): TransferSchedule[];
+export function calculateBreakEven(
+  amount: number,
+  fromApy: number,
+  toApy: number,
+  transferCostCents?: number,
+  daysFloat?: number
+): BreakEvenResult;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,12 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
 
+  packages/builder:
+    dependencies:
+      '@basenative/runtime':
+        specifier: workspace:*
+        version: link:../runtime
+
   packages/claude-config: {}
 
   packages/cli: {}
@@ -348,6 +354,8 @@ importers:
       '@basenative/og-image':
         specifier: workspace:*
         version: link:../og-image
+
+  packages/station: {}
 
   packages/tenant: {}
 


### PR DESCRIPTION
## Summary
- Adds **`@basenative/builder`** — a zero-dependency, signal-based drag-and-drop component composer that dogfoods every BaseNative primitive (`signal`, `computed`, `effect`, `batch`).
- Five web components (`<bn-builder>` + canvas/palette/tree/inspector) with native HTML5 DnD, full ARIA semantics, and `display: contents` on every host.
- Clean BaseNative codegen with `@bind` directives and `{{ expr }}` interpolation, plus optional document-mode shell + scaffolded signal declarations.

## What's in the package

**Core (`src/`)**
- `state.js` — `createBuilderState()`: signal-backed tree, snapshot-based undo/redo, signal bindings, JSON persistence, event subscribe.
- `palette.js` — `createPalette()` + `defaultPalette()` (14 components: layout / text / inputs / navigation / media / reactive).
- `codegen.js` — `generateBaseNative()`: semantic HTML, void-element handling, `@bind`, identifier-validated signal refs, optional doc-shell.
- `tree-view.js` + `inspector.js` — pure HTML rendering helpers (role=tree, aria-selected, signal-kind binding fields).
- `dom-render.js` + `escape.js` — shared DOM rendering + HTML/identifier escaping.

**Web components**
- `<bn-builder>` — orchestrating shell with toolbar (undo/redo/clear/export).
- `<bn-builder-canvas>` — drop target + live preview, HTML5 DnD, keyboard shortcuts (Delete, Cmd+Z, Cmd+Shift+Z).
- `<bn-builder-palette>` — drag source.
- `<bn-builder-tree>` — outline view.
- `<bn-builder-inspector>` — reactive prop + signal-binding form.

**Constitution audit**
- Zero deps beyond `@basenative/runtime`.
- ESM-only, no build step.
- `display: contents` on every host (axiom 3).
- Semantic HTML in generated output (axiom 1).
- No `eval` / `new Function` in codegen (CSP-safe).

## Test plan
- [x] 74 `node:test` cases pass — state mutations, undo/redo, signal reactivity, JSON round-trip, palette registration, codegen output shapes, tree-view + inspector HTML escaping.
- [x] ESLint clean on `packages/builder/src/`.
- [x] `@basenative/runtime` and `@basenative/visual-builder` test suites still green (383 + 40).
- [ ] Reviewer sanity-check: open `<bn-builder>` in a downstream example app and confirm DnD, undo/redo, and code export behave as documented.

## Notes for review
- This branch (`claude/funny-agnesi-b4c22f`) also includes one pre-existing commit from Epic 1C (`5fbb027 — feat(integrations): expand plaid wrapper`) that was already on the worktree. The Epic 4 work is isolated to commit `6cd8b70`.
- The original Epic 4 backlog (Tasks A/B/C) is split: `bn-canvas` lives in `@basenative/visual-builder` for absolute-position canvases; this new package handles structural composition + codegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)