### PR TITLE
fix: make @basenative/runtime, @basenative/server, @basenative/router publishable

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@basenative/router",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "SSR-aware path routing with named params, wildcards, and history API integration",
   "type": "module",
   "exports": {
-    ".": "./src/index.js"
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./src/index.js"
+    }
   },
   "types": "./types/index.d.ts",
   "dependencies": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basenative/runtime",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Signal-based web runtime over native HTML — zero build step, zero production dependencies",
   "type": "module",
   "exports": {

--- a/packages/runtime/src/evaluate.js
+++ b/packages/runtime/src/evaluate.js
@@ -1,4 +1,4 @@
-import { evaluateExpression } from '../../../src/shared/expression.js';
+import { evaluateExpression } from './expression.js';
 
 export function evaluate(expr, ctx, options) {
   return evaluateExpression(expr, ctx, options);

--- a/packages/runtime/src/evaluate.test.js
+++ b/packages/runtime/src/evaluate.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { evaluate, interpolate } from './evaluate.js';
-import { clearExpressionCache } from '../../../src/shared/expression.js';
+import { clearExpressionCache } from './expression.js';
 
 describe('evaluate', () => {
   it('supports a safe expression subset without eval-like APIs', () => {

--- a/packages/runtime/src/expression.fuzz.test.js
+++ b/packages/runtime/src/expression.fuzz.test.js
@@ -7,7 +7,7 @@
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { evaluateExpression, clearExpressionCache } from '../../../src/shared/expression.js';
+import { evaluateExpression, clearExpressionCache } from './expression.js';
 
 function noThrow(expr, ctx = {}) {
   let threw = false;

--- a/packages/runtime/src/expression.js
+++ b/packages/runtime/src/expression.js
@@ -1,0 +1,694 @@
+export const SCOPE_SLOT = Symbol.for('basenative.scopeSlot');
+
+const EXPRESSION_CACHE = new Map();
+const UNSAFE_PROPERTIES = new Set(['__proto__', 'prototype', 'constructor']);
+
+function createExpressionError(code, message, source, index = 0) {
+  const error = new SyntaxError(message);
+  error.code = code;
+  error.source = source;
+  error.index = index;
+  return error;
+}
+
+function reportDiagnostic(options, diagnostic) {
+  if (typeof options?.onDiagnostic === 'function') {
+    options.onDiagnostic(diagnostic);
+  }
+}
+
+function tokenize(source) {
+  const tokens = [];
+  let index = 0;
+
+  while (index < source.length) {
+    const char = source[index];
+
+    if (/\s/.test(char)) {
+      index++;
+      continue;
+    }
+
+    const tri = source.slice(index, index + 3);
+    const duo = source.slice(index, index + 2);
+    if (tri === '===' || tri === '!==') {
+      tokens.push({ type: 'operator', value: tri, index });
+      index += 3;
+      continue;
+    }
+    if (
+      duo === '&&' || duo === '||' || duo === '==' || duo === '!=' ||
+      duo === '<=' || duo === '>='
+    ) {
+      tokens.push({ type: 'operator', value: duo, index });
+      index += 2;
+      continue;
+    }
+
+    if ('()[]{}.,:;?'.includes(char)) {
+      tokens.push({ type: 'punct', value: char, index });
+      index++;
+      continue;
+    }
+
+    if ('+-*/%!<>'.includes(char)) {
+      tokens.push({ type: 'operator', value: char, index });
+      index++;
+      continue;
+    }
+
+    if (char === '"' || char === '\'') {
+      const quote = char;
+      const start = index;
+      index++;
+      let value = '';
+
+      while (index < source.length) {
+        const current = source[index];
+        if (current === '\\') {
+          const next = source[index + 1];
+          if (next == null) break;
+          const escapeMap = {
+            '"': '"',
+            '\'': '\'',
+            '\\': '\\',
+            n: '\n',
+            r: '\r',
+            t: '\t',
+          };
+          value += escapeMap[next] ?? next;
+          index += 2;
+          continue;
+        }
+
+        if (current === quote) {
+          index++;
+          tokens.push({ type: 'string', value, index: start });
+          value = null;
+          break;
+        }
+
+        value += current;
+        index++;
+      }
+
+      if (value !== null) {
+        throw createExpressionError(
+          'BN_EXPR_UNTERMINATED_STRING',
+          'Unterminated string literal',
+          source,
+          start
+        );
+      }
+
+      continue;
+    }
+
+    if (/[0-9]/.test(char)) {
+      const start = index;
+      let raw = char;
+      index++;
+      while (index < source.length && /[0-9.]/.test(source[index])) {
+        raw += source[index];
+        index++;
+      }
+      if (!/^(\d+|\d+\.\d+)$/.test(raw)) {
+        throw createExpressionError(
+          'BN_EXPR_INVALID_NUMBER',
+          `Invalid numeric literal "${raw}"`,
+          source,
+          start
+        );
+      }
+      tokens.push({ type: 'number', value: Number(raw), index: start });
+      continue;
+    }
+
+    if (/[A-Za-z_$]/.test(char)) {
+      const start = index;
+      let value = char;
+      index++;
+      while (index < source.length && /[A-Za-z0-9_$]/.test(source[index])) {
+        value += source[index];
+        index++;
+      }
+      tokens.push({ type: 'identifier', value, index: start });
+      continue;
+    }
+
+    throw createExpressionError(
+      'BN_EXPR_INVALID_TOKEN',
+      `Unsupported token "${char}"`,
+      source,
+      index
+    );
+  }
+
+  tokens.push({ type: 'eof', value: '', index: source.length });
+  return tokens;
+}
+
+class Parser {
+  constructor(tokens, source) {
+    this.tokens = tokens;
+    this.source = source;
+    this.index = 0;
+  }
+
+  current() {
+    return this.tokens[this.index];
+  }
+
+  advance() {
+    const token = this.current();
+    this.index++;
+    return token;
+  }
+
+  match(type, value) {
+    const token = this.current();
+    if (!token || token.type !== type) return false;
+    if (value != null && token.value !== value) return false;
+    this.index++;
+    return true;
+  }
+
+  expect(type, value, message) {
+    const token = this.current();
+    if (token?.type === type && (value == null || token.value === value)) {
+      this.index++;
+      return token;
+    }
+    throw createExpressionError(
+      'BN_EXPR_UNEXPECTED_TOKEN',
+      message ?? `Unexpected token "${token?.value ?? 'EOF'}"`,
+      this.source,
+      token?.index ?? this.source.length
+    );
+  }
+
+  parseProgram() {
+    const body = [];
+    while (this.current().type !== 'eof') {
+      if (this.match('punct', ';')) continue;
+      body.push(this.parseExpression());
+      this.match('punct', ';');
+    }
+    return { type: 'Program', body };
+  }
+
+  parseExpression() {
+    return this.parseConditional();
+  }
+
+  parseConditional() {
+    const test = this.parseLogicalOr();
+    if (!this.match('punct', '?')) return test;
+    const consequent = this.parseExpression();
+    this.expect('punct', ':', 'Expected ":" in conditional expression');
+    const alternate = this.parseExpression();
+    return { type: 'ConditionalExpression', test, consequent, alternate };
+  }
+
+  parseLogicalOr() {
+    let node = this.parseLogicalAnd();
+    while (this.match('operator', '||')) {
+      node = {
+        type: 'LogicalExpression',
+        operator: '||',
+        left: node,
+        right: this.parseLogicalAnd(),
+      };
+    }
+    return node;
+  }
+
+  parseLogicalAnd() {
+    let node = this.parseEquality();
+    while (this.match('operator', '&&')) {
+      node = {
+        type: 'LogicalExpression',
+        operator: '&&',
+        left: node,
+        right: this.parseEquality(),
+      };
+    }
+    return node;
+  }
+
+  parseEquality() {
+    let node = this.parseRelational();
+    while (true) {
+      if (this.match('operator', '===')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '===',
+          left: node,
+          right: this.parseRelational(),
+        };
+        continue;
+      }
+      if (this.match('operator', '!==')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '!==',
+          left: node,
+          right: this.parseRelational(),
+        };
+        continue;
+      }
+      if (this.match('operator', '==')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '==',
+          left: node,
+          right: this.parseRelational(),
+        };
+        continue;
+      }
+      if (this.match('operator', '!=')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '!=',
+          left: node,
+          right: this.parseRelational(),
+        };
+        continue;
+      }
+      return node;
+    }
+  }
+
+  parseRelational() {
+    let node = this.parseAdditive();
+    while (true) {
+      if (this.match('operator', '<=')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '<=',
+          left: node,
+          right: this.parseAdditive(),
+        };
+        continue;
+      }
+      if (this.match('operator', '>=')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '>=',
+          left: node,
+          right: this.parseAdditive(),
+        };
+        continue;
+      }
+      if (this.match('operator', '<')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '<',
+          left: node,
+          right: this.parseAdditive(),
+        };
+        continue;
+      }
+      if (this.match('operator', '>')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '>',
+          left: node,
+          right: this.parseAdditive(),
+        };
+        continue;
+      }
+      return node;
+    }
+  }
+
+  parseAdditive() {
+    let node = this.parseMultiplicative();
+    while (true) {
+      if (this.match('operator', '+')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '+',
+          left: node,
+          right: this.parseMultiplicative(),
+        };
+        continue;
+      }
+      if (this.match('operator', '-')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '-',
+          left: node,
+          right: this.parseMultiplicative(),
+        };
+        continue;
+      }
+      return node;
+    }
+  }
+
+  parseMultiplicative() {
+    let node = this.parseUnary();
+    while (true) {
+      if (this.match('operator', '*')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '*',
+          left: node,
+          right: this.parseUnary(),
+        };
+        continue;
+      }
+      if (this.match('operator', '/')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '/',
+          left: node,
+          right: this.parseUnary(),
+        };
+        continue;
+      }
+      if (this.match('operator', '%')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '%',
+          left: node,
+          right: this.parseUnary(),
+        };
+        continue;
+      }
+      return node;
+    }
+  }
+
+  parseUnary() {
+    if (this.match('operator', '!')) {
+      return { type: 'UnaryExpression', operator: '!', argument: this.parseUnary() };
+    }
+    if (this.match('operator', '+')) {
+      return { type: 'UnaryExpression', operator: '+', argument: this.parseUnary() };
+    }
+    if (this.match('operator', '-')) {
+      return { type: 'UnaryExpression', operator: '-', argument: this.parseUnary() };
+    }
+    return this.parsePostfix();
+  }
+
+  parsePostfix() {
+    let node = this.parsePrimary();
+
+    while (true) {
+      if (this.match('punct', '.')) {
+        const property = this.expect(
+          'identifier',
+          null,
+          'Expected a property name after "."'
+        );
+        node = {
+          type: 'MemberExpression',
+          object: node,
+          property: { type: 'Identifier', name: property.value },
+          computed: false,
+        };
+        continue;
+      }
+
+      if (this.match('punct', '[')) {
+        const property = this.parseExpression();
+        this.expect('punct', ']', 'Expected "]" after computed property');
+        node = {
+          type: 'MemberExpression',
+          object: node,
+          property,
+          computed: true,
+        };
+        continue;
+      }
+
+      if (this.match('punct', '(')) {
+        const args = [];
+        if (!this.match('punct', ')')) {
+          do {
+            args.push(this.parseExpression());
+          } while (this.match('punct', ','));
+          this.expect('punct', ')', 'Expected ")" after function arguments');
+        }
+        node = { type: 'CallExpression', callee: node, arguments: args };
+        continue;
+      }
+
+      return node;
+    }
+  }
+
+  parsePrimary() {
+    const token = this.current();
+
+    if (token.type === 'number') {
+      this.advance();
+      return { type: 'Literal', value: token.value };
+    }
+
+    if (token.type === 'string') {
+      this.advance();
+      return { type: 'Literal', value: token.value };
+    }
+
+    if (token.type === 'identifier') {
+      this.advance();
+      if (token.value === 'true') return { type: 'Literal', value: true };
+      if (token.value === 'false') return { type: 'Literal', value: false };
+      if (token.value === 'null') return { type: 'Literal', value: null };
+      if (token.value === 'undefined') return { type: 'Literal', value: undefined };
+      return { type: 'Identifier', name: token.value };
+    }
+
+    if (this.match('punct', '(')) {
+      const node = this.parseExpression();
+      this.expect('punct', ')', 'Expected ")" after grouped expression');
+      return node;
+    }
+
+    if (this.match('punct', '[')) {
+      const elements = [];
+      if (!this.match('punct', ']')) {
+        do {
+          elements.push(this.parseExpression());
+        } while (this.match('punct', ','));
+        this.expect('punct', ']', 'Expected "]" after array literal');
+      }
+      return { type: 'ArrayExpression', elements };
+    }
+
+    if (this.match('punct', '{')) {
+      const properties = [];
+      if (!this.match('punct', '}')) {
+        do {
+          const keyToken = this.current();
+          let key;
+          if (keyToken.type === 'identifier') {
+            this.advance();
+            key = keyToken.value;
+          } else if (keyToken.type === 'string' || keyToken.type === 'number') {
+            this.advance();
+            key = String(keyToken.value);
+          } else {
+            throw createExpressionError(
+              'BN_EXPR_INVALID_OBJECT_KEY',
+              'Expected an object property name',
+              this.source,
+              keyToken.index
+            );
+          }
+
+          let value;
+          if (this.match('punct', ':')) {
+            value = this.parseExpression();
+          } else {
+            value = { type: 'Identifier', name: key };
+          }
+          properties.push({ key, value });
+        } while (this.match('punct', ','));
+        this.expect('punct', '}', 'Expected "}" after object literal');
+      }
+      return { type: 'ObjectExpression', properties };
+    }
+
+    throw createExpressionError(
+      'BN_EXPR_UNEXPECTED_TOKEN',
+      `Unexpected token "${token.value}"`,
+      this.source,
+      token.index
+    );
+  }
+}
+
+export function isScopeSlot(value) {
+  return Boolean(value) && value[SCOPE_SLOT] === true && typeof value.get === 'function';
+}
+
+function resolveValue(value) {
+  return isScopeSlot(value) ? value.get() : value;
+}
+
+function lookupIdentifier(ctx, name) {
+  if (ctx == null) return undefined;
+  return resolveValue(ctx[name]);
+}
+
+function safeMemberRead(object, property, source) {
+  if (typeof property === 'string' && UNSAFE_PROPERTIES.has(property)) {
+    throw createExpressionError(
+      'BN_EXPR_UNSAFE_MEMBER',
+      `Access to "${property}" is not allowed in BaseNative expressions`,
+      source
+    );
+  }
+  return object[property];
+}
+
+function evaluateNode(node, ctx, source) {
+  switch (node.type) {
+    case 'Program': {
+      let result;
+      for (const statement of node.body) result = evaluateNode(statement, ctx, source);
+      return result;
+    }
+
+    case 'Literal':
+      return node.value;
+
+    case 'Identifier':
+      return lookupIdentifier(ctx, node.name);
+
+    case 'UnaryExpression': {
+      const value = evaluateNode(node.argument, ctx, source);
+      if (node.operator === '!') return !value;
+      if (node.operator === '+') return +value;
+      if (node.operator === '-') return -value;
+      return undefined;
+    }
+
+    case 'BinaryExpression': {
+      const left = evaluateNode(node.left, ctx, source);
+      const right = evaluateNode(node.right, ctx, source);
+      switch (node.operator) {
+        case '+': return left + right;
+        case '-': return left - right;
+        case '*': return left * right;
+        case '/': return left / right;
+        case '%': return left % right;
+        case '<': return left < right;
+        case '<=': return left <= right;
+        case '>': return left > right;
+        case '>=': return left >= right;
+        case '==': return left == right;
+        case '!=': return left != right;
+        case '===': return left === right;
+        case '!==': return left !== right;
+        default: return undefined;
+      }
+    }
+
+    case 'LogicalExpression':
+      return node.operator === '&&'
+        ? (evaluateNode(node.left, ctx, source) && evaluateNode(node.right, ctx, source))
+        : (evaluateNode(node.left, ctx, source) || evaluateNode(node.right, ctx, source));
+
+    case 'ConditionalExpression':
+      return evaluateNode(node.test, ctx, source)
+        ? evaluateNode(node.consequent, ctx, source)
+        : evaluateNode(node.alternate, ctx, source);
+
+    case 'ArrayExpression':
+      return node.elements.map(element => evaluateNode(element, ctx, source));
+
+    case 'ObjectExpression': {
+      const result = {};
+      for (const property of node.properties) {
+        result[property.key] = evaluateNode(property.value, ctx, source);
+      }
+      return result;
+    }
+
+    case 'MemberExpression': {
+      const object = evaluateNode(node.object, ctx, source);
+      if (object == null) return undefined;
+      const property = node.computed
+        ? evaluateNode(node.property, ctx, source)
+        : node.property.name;
+      return safeMemberRead(object, property, source);
+    }
+
+    case 'CallExpression': {
+      if (node.callee.type === 'MemberExpression') {
+        const target = evaluateNode(node.callee.object, ctx, source);
+        if (target == null) return undefined;
+        const property = node.callee.computed
+          ? evaluateNode(node.callee.property, ctx, source)
+          : node.callee.property.name;
+        const fn = safeMemberRead(target, property, source);
+        if (typeof fn !== 'function') return undefined;
+        const args = node.arguments.map(arg => evaluateNode(arg, ctx, source));
+        return fn.apply(target, args);
+      }
+
+      const fn = evaluateNode(node.callee, ctx, source);
+      if (typeof fn !== 'function') return undefined;
+      const args = node.arguments.map(arg => evaluateNode(arg, ctx, source));
+      return fn(...args);
+    }
+
+    default:
+      return undefined;
+  }
+}
+
+export function compileExpression(source) {
+  const normalized = String(source ?? '').trim();
+  if (EXPRESSION_CACHE.has(normalized)) return EXPRESSION_CACHE.get(normalized);
+
+  try {
+    const parser = new Parser(tokenize(normalized), normalized);
+    const compiled = { source: normalized, ast: parser.parseProgram() };
+    EXPRESSION_CACHE.set(normalized, compiled);
+    return compiled;
+  } catch (error) {
+    const failure = { source: normalized, error };
+    EXPRESSION_CACHE.set(normalized, failure);
+    return failure;
+  }
+}
+
+export function evaluateExpression(source, ctx = {}, options = {}) {
+  const compiled = typeof source === 'string' ? compileExpression(source) : source;
+  if (compiled?.error) {
+    reportDiagnostic(options, {
+      level: 'error',
+      domain: 'expression',
+      code: compiled.error.code ?? 'BN_EXPR_COMPILE_FAILED',
+      message: compiled.error.message,
+      expression: compiled.source,
+      error: compiled.error,
+    });
+    return undefined;
+  }
+
+  try {
+    return evaluateNode(compiled.ast, ctx, compiled.source);
+  } catch (error) {
+    reportDiagnostic(options, {
+      level: 'error',
+      domain: 'expression',
+      code: error.code ?? 'BN_EXPR_EVALUATION_FAILED',
+      message: error.message,
+      expression: compiled.source,
+      error,
+    });
+    return undefined;
+  }
+}
+
+export function clearExpressionCache() {
+  EXPRESSION_CACHE.clear();
+}

--- a/packages/runtime/src/expression.test.js
+++ b/packages/runtime/src/expression.test.js
@@ -9,7 +9,7 @@ import {
   compileExpression,
   evaluateExpression,
   clearExpressionCache,
-} from '../../../src/shared/expression.js';
+} from './expression.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/packages/runtime/src/scope.js
+++ b/packages/runtime/src/scope.js
@@ -1,4 +1,4 @@
-import { SCOPE_SLOT } from '../../../src/shared/expression.js';
+import { SCOPE_SLOT } from './expression.js';
 import { signal } from './signals.js';
 
 export function createScopeSlot(initial) {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basenative/server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Server-side rendering with streaming support for BaseNative templates",
   "type": "module",
   "exports": {

--- a/packages/server/src/expression.js
+++ b/packages/server/src/expression.js
@@ -1,0 +1,694 @@
+export const SCOPE_SLOT = Symbol.for('basenative.scopeSlot');
+
+const EXPRESSION_CACHE = new Map();
+const UNSAFE_PROPERTIES = new Set(['__proto__', 'prototype', 'constructor']);
+
+function createExpressionError(code, message, source, index = 0) {
+  const error = new SyntaxError(message);
+  error.code = code;
+  error.source = source;
+  error.index = index;
+  return error;
+}
+
+function reportDiagnostic(options, diagnostic) {
+  if (typeof options?.onDiagnostic === 'function') {
+    options.onDiagnostic(diagnostic);
+  }
+}
+
+function tokenize(source) {
+  const tokens = [];
+  let index = 0;
+
+  while (index < source.length) {
+    const char = source[index];
+
+    if (/\s/.test(char)) {
+      index++;
+      continue;
+    }
+
+    const tri = source.slice(index, index + 3);
+    const duo = source.slice(index, index + 2);
+    if (tri === '===' || tri === '!==') {
+      tokens.push({ type: 'operator', value: tri, index });
+      index += 3;
+      continue;
+    }
+    if (
+      duo === '&&' || duo === '||' || duo === '==' || duo === '!=' ||
+      duo === '<=' || duo === '>='
+    ) {
+      tokens.push({ type: 'operator', value: duo, index });
+      index += 2;
+      continue;
+    }
+
+    if ('()[]{}.,:;?'.includes(char)) {
+      tokens.push({ type: 'punct', value: char, index });
+      index++;
+      continue;
+    }
+
+    if ('+-*/%!<>'.includes(char)) {
+      tokens.push({ type: 'operator', value: char, index });
+      index++;
+      continue;
+    }
+
+    if (char === '"' || char === '\'') {
+      const quote = char;
+      const start = index;
+      index++;
+      let value = '';
+
+      while (index < source.length) {
+        const current = source[index];
+        if (current === '\\') {
+          const next = source[index + 1];
+          if (next == null) break;
+          const escapeMap = {
+            '"': '"',
+            '\'': '\'',
+            '\\': '\\',
+            n: '\n',
+            r: '\r',
+            t: '\t',
+          };
+          value += escapeMap[next] ?? next;
+          index += 2;
+          continue;
+        }
+
+        if (current === quote) {
+          index++;
+          tokens.push({ type: 'string', value, index: start });
+          value = null;
+          break;
+        }
+
+        value += current;
+        index++;
+      }
+
+      if (value !== null) {
+        throw createExpressionError(
+          'BN_EXPR_UNTERMINATED_STRING',
+          'Unterminated string literal',
+          source,
+          start
+        );
+      }
+
+      continue;
+    }
+
+    if (/[0-9]/.test(char)) {
+      const start = index;
+      let raw = char;
+      index++;
+      while (index < source.length && /[0-9.]/.test(source[index])) {
+        raw += source[index];
+        index++;
+      }
+      if (!/^(\d+|\d+\.\d+)$/.test(raw)) {
+        throw createExpressionError(
+          'BN_EXPR_INVALID_NUMBER',
+          `Invalid numeric literal "${raw}"`,
+          source,
+          start
+        );
+      }
+      tokens.push({ type: 'number', value: Number(raw), index: start });
+      continue;
+    }
+
+    if (/[A-Za-z_$]/.test(char)) {
+      const start = index;
+      let value = char;
+      index++;
+      while (index < source.length && /[A-Za-z0-9_$]/.test(source[index])) {
+        value += source[index];
+        index++;
+      }
+      tokens.push({ type: 'identifier', value, index: start });
+      continue;
+    }
+
+    throw createExpressionError(
+      'BN_EXPR_INVALID_TOKEN',
+      `Unsupported token "${char}"`,
+      source,
+      index
+    );
+  }
+
+  tokens.push({ type: 'eof', value: '', index: source.length });
+  return tokens;
+}
+
+class Parser {
+  constructor(tokens, source) {
+    this.tokens = tokens;
+    this.source = source;
+    this.index = 0;
+  }
+
+  current() {
+    return this.tokens[this.index];
+  }
+
+  advance() {
+    const token = this.current();
+    this.index++;
+    return token;
+  }
+
+  match(type, value) {
+    const token = this.current();
+    if (!token || token.type !== type) return false;
+    if (value != null && token.value !== value) return false;
+    this.index++;
+    return true;
+  }
+
+  expect(type, value, message) {
+    const token = this.current();
+    if (token?.type === type && (value == null || token.value === value)) {
+      this.index++;
+      return token;
+    }
+    throw createExpressionError(
+      'BN_EXPR_UNEXPECTED_TOKEN',
+      message ?? `Unexpected token "${token?.value ?? 'EOF'}"`,
+      this.source,
+      token?.index ?? this.source.length
+    );
+  }
+
+  parseProgram() {
+    const body = [];
+    while (this.current().type !== 'eof') {
+      if (this.match('punct', ';')) continue;
+      body.push(this.parseExpression());
+      this.match('punct', ';');
+    }
+    return { type: 'Program', body };
+  }
+
+  parseExpression() {
+    return this.parseConditional();
+  }
+
+  parseConditional() {
+    const test = this.parseLogicalOr();
+    if (!this.match('punct', '?')) return test;
+    const consequent = this.parseExpression();
+    this.expect('punct', ':', 'Expected ":" in conditional expression');
+    const alternate = this.parseExpression();
+    return { type: 'ConditionalExpression', test, consequent, alternate };
+  }
+
+  parseLogicalOr() {
+    let node = this.parseLogicalAnd();
+    while (this.match('operator', '||')) {
+      node = {
+        type: 'LogicalExpression',
+        operator: '||',
+        left: node,
+        right: this.parseLogicalAnd(),
+      };
+    }
+    return node;
+  }
+
+  parseLogicalAnd() {
+    let node = this.parseEquality();
+    while (this.match('operator', '&&')) {
+      node = {
+        type: 'LogicalExpression',
+        operator: '&&',
+        left: node,
+        right: this.parseEquality(),
+      };
+    }
+    return node;
+  }
+
+  parseEquality() {
+    let node = this.parseRelational();
+    while (true) {
+      if (this.match('operator', '===')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '===',
+          left: node,
+          right: this.parseRelational(),
+        };
+        continue;
+      }
+      if (this.match('operator', '!==')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '!==',
+          left: node,
+          right: this.parseRelational(),
+        };
+        continue;
+      }
+      if (this.match('operator', '==')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '==',
+          left: node,
+          right: this.parseRelational(),
+        };
+        continue;
+      }
+      if (this.match('operator', '!=')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '!=',
+          left: node,
+          right: this.parseRelational(),
+        };
+        continue;
+      }
+      return node;
+    }
+  }
+
+  parseRelational() {
+    let node = this.parseAdditive();
+    while (true) {
+      if (this.match('operator', '<=')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '<=',
+          left: node,
+          right: this.parseAdditive(),
+        };
+        continue;
+      }
+      if (this.match('operator', '>=')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '>=',
+          left: node,
+          right: this.parseAdditive(),
+        };
+        continue;
+      }
+      if (this.match('operator', '<')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '<',
+          left: node,
+          right: this.parseAdditive(),
+        };
+        continue;
+      }
+      if (this.match('operator', '>')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '>',
+          left: node,
+          right: this.parseAdditive(),
+        };
+        continue;
+      }
+      return node;
+    }
+  }
+
+  parseAdditive() {
+    let node = this.parseMultiplicative();
+    while (true) {
+      if (this.match('operator', '+')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '+',
+          left: node,
+          right: this.parseMultiplicative(),
+        };
+        continue;
+      }
+      if (this.match('operator', '-')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '-',
+          left: node,
+          right: this.parseMultiplicative(),
+        };
+        continue;
+      }
+      return node;
+    }
+  }
+
+  parseMultiplicative() {
+    let node = this.parseUnary();
+    while (true) {
+      if (this.match('operator', '*')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '*',
+          left: node,
+          right: this.parseUnary(),
+        };
+        continue;
+      }
+      if (this.match('operator', '/')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '/',
+          left: node,
+          right: this.parseUnary(),
+        };
+        continue;
+      }
+      if (this.match('operator', '%')) {
+        node = {
+          type: 'BinaryExpression',
+          operator: '%',
+          left: node,
+          right: this.parseUnary(),
+        };
+        continue;
+      }
+      return node;
+    }
+  }
+
+  parseUnary() {
+    if (this.match('operator', '!')) {
+      return { type: 'UnaryExpression', operator: '!', argument: this.parseUnary() };
+    }
+    if (this.match('operator', '+')) {
+      return { type: 'UnaryExpression', operator: '+', argument: this.parseUnary() };
+    }
+    if (this.match('operator', '-')) {
+      return { type: 'UnaryExpression', operator: '-', argument: this.parseUnary() };
+    }
+    return this.parsePostfix();
+  }
+
+  parsePostfix() {
+    let node = this.parsePrimary();
+
+    while (true) {
+      if (this.match('punct', '.')) {
+        const property = this.expect(
+          'identifier',
+          null,
+          'Expected a property name after "."'
+        );
+        node = {
+          type: 'MemberExpression',
+          object: node,
+          property: { type: 'Identifier', name: property.value },
+          computed: false,
+        };
+        continue;
+      }
+
+      if (this.match('punct', '[')) {
+        const property = this.parseExpression();
+        this.expect('punct', ']', 'Expected "]" after computed property');
+        node = {
+          type: 'MemberExpression',
+          object: node,
+          property,
+          computed: true,
+        };
+        continue;
+      }
+
+      if (this.match('punct', '(')) {
+        const args = [];
+        if (!this.match('punct', ')')) {
+          do {
+            args.push(this.parseExpression());
+          } while (this.match('punct', ','));
+          this.expect('punct', ')', 'Expected ")" after function arguments');
+        }
+        node = { type: 'CallExpression', callee: node, arguments: args };
+        continue;
+      }
+
+      return node;
+    }
+  }
+
+  parsePrimary() {
+    const token = this.current();
+
+    if (token.type === 'number') {
+      this.advance();
+      return { type: 'Literal', value: token.value };
+    }
+
+    if (token.type === 'string') {
+      this.advance();
+      return { type: 'Literal', value: token.value };
+    }
+
+    if (token.type === 'identifier') {
+      this.advance();
+      if (token.value === 'true') return { type: 'Literal', value: true };
+      if (token.value === 'false') return { type: 'Literal', value: false };
+      if (token.value === 'null') return { type: 'Literal', value: null };
+      if (token.value === 'undefined') return { type: 'Literal', value: undefined };
+      return { type: 'Identifier', name: token.value };
+    }
+
+    if (this.match('punct', '(')) {
+      const node = this.parseExpression();
+      this.expect('punct', ')', 'Expected ")" after grouped expression');
+      return node;
+    }
+
+    if (this.match('punct', '[')) {
+      const elements = [];
+      if (!this.match('punct', ']')) {
+        do {
+          elements.push(this.parseExpression());
+        } while (this.match('punct', ','));
+        this.expect('punct', ']', 'Expected "]" after array literal');
+      }
+      return { type: 'ArrayExpression', elements };
+    }
+
+    if (this.match('punct', '{')) {
+      const properties = [];
+      if (!this.match('punct', '}')) {
+        do {
+          const keyToken = this.current();
+          let key;
+          if (keyToken.type === 'identifier') {
+            this.advance();
+            key = keyToken.value;
+          } else if (keyToken.type === 'string' || keyToken.type === 'number') {
+            this.advance();
+            key = String(keyToken.value);
+          } else {
+            throw createExpressionError(
+              'BN_EXPR_INVALID_OBJECT_KEY',
+              'Expected an object property name',
+              this.source,
+              keyToken.index
+            );
+          }
+
+          let value;
+          if (this.match('punct', ':')) {
+            value = this.parseExpression();
+          } else {
+            value = { type: 'Identifier', name: key };
+          }
+          properties.push({ key, value });
+        } while (this.match('punct', ','));
+        this.expect('punct', '}', 'Expected "}" after object literal');
+      }
+      return { type: 'ObjectExpression', properties };
+    }
+
+    throw createExpressionError(
+      'BN_EXPR_UNEXPECTED_TOKEN',
+      `Unexpected token "${token.value}"`,
+      this.source,
+      token.index
+    );
+  }
+}
+
+export function isScopeSlot(value) {
+  return Boolean(value) && value[SCOPE_SLOT] === true && typeof value.get === 'function';
+}
+
+function resolveValue(value) {
+  return isScopeSlot(value) ? value.get() : value;
+}
+
+function lookupIdentifier(ctx, name) {
+  if (ctx == null) return undefined;
+  return resolveValue(ctx[name]);
+}
+
+function safeMemberRead(object, property, source) {
+  if (typeof property === 'string' && UNSAFE_PROPERTIES.has(property)) {
+    throw createExpressionError(
+      'BN_EXPR_UNSAFE_MEMBER',
+      `Access to "${property}" is not allowed in BaseNative expressions`,
+      source
+    );
+  }
+  return object[property];
+}
+
+function evaluateNode(node, ctx, source) {
+  switch (node.type) {
+    case 'Program': {
+      let result;
+      for (const statement of node.body) result = evaluateNode(statement, ctx, source);
+      return result;
+    }
+
+    case 'Literal':
+      return node.value;
+
+    case 'Identifier':
+      return lookupIdentifier(ctx, node.name);
+
+    case 'UnaryExpression': {
+      const value = evaluateNode(node.argument, ctx, source);
+      if (node.operator === '!') return !value;
+      if (node.operator === '+') return +value;
+      if (node.operator === '-') return -value;
+      return undefined;
+    }
+
+    case 'BinaryExpression': {
+      const left = evaluateNode(node.left, ctx, source);
+      const right = evaluateNode(node.right, ctx, source);
+      switch (node.operator) {
+        case '+': return left + right;
+        case '-': return left - right;
+        case '*': return left * right;
+        case '/': return left / right;
+        case '%': return left % right;
+        case '<': return left < right;
+        case '<=': return left <= right;
+        case '>': return left > right;
+        case '>=': return left >= right;
+        case '==': return left == right;
+        case '!=': return left != right;
+        case '===': return left === right;
+        case '!==': return left !== right;
+        default: return undefined;
+      }
+    }
+
+    case 'LogicalExpression':
+      return node.operator === '&&'
+        ? (evaluateNode(node.left, ctx, source) && evaluateNode(node.right, ctx, source))
+        : (evaluateNode(node.left, ctx, source) || evaluateNode(node.right, ctx, source));
+
+    case 'ConditionalExpression':
+      return evaluateNode(node.test, ctx, source)
+        ? evaluateNode(node.consequent, ctx, source)
+        : evaluateNode(node.alternate, ctx, source);
+
+    case 'ArrayExpression':
+      return node.elements.map(element => evaluateNode(element, ctx, source));
+
+    case 'ObjectExpression': {
+      const result = {};
+      for (const property of node.properties) {
+        result[property.key] = evaluateNode(property.value, ctx, source);
+      }
+      return result;
+    }
+
+    case 'MemberExpression': {
+      const object = evaluateNode(node.object, ctx, source);
+      if (object == null) return undefined;
+      const property = node.computed
+        ? evaluateNode(node.property, ctx, source)
+        : node.property.name;
+      return safeMemberRead(object, property, source);
+    }
+
+    case 'CallExpression': {
+      if (node.callee.type === 'MemberExpression') {
+        const target = evaluateNode(node.callee.object, ctx, source);
+        if (target == null) return undefined;
+        const property = node.callee.computed
+          ? evaluateNode(node.callee.property, ctx, source)
+          : node.callee.property.name;
+        const fn = safeMemberRead(target, property, source);
+        if (typeof fn !== 'function') return undefined;
+        const args = node.arguments.map(arg => evaluateNode(arg, ctx, source));
+        return fn.apply(target, args);
+      }
+
+      const fn = evaluateNode(node.callee, ctx, source);
+      if (typeof fn !== 'function') return undefined;
+      const args = node.arguments.map(arg => evaluateNode(arg, ctx, source));
+      return fn(...args);
+    }
+
+    default:
+      return undefined;
+  }
+}
+
+export function compileExpression(source) {
+  const normalized = String(source ?? '').trim();
+  if (EXPRESSION_CACHE.has(normalized)) return EXPRESSION_CACHE.get(normalized);
+
+  try {
+    const parser = new Parser(tokenize(normalized), normalized);
+    const compiled = { source: normalized, ast: parser.parseProgram() };
+    EXPRESSION_CACHE.set(normalized, compiled);
+    return compiled;
+  } catch (error) {
+    const failure = { source: normalized, error };
+    EXPRESSION_CACHE.set(normalized, failure);
+    return failure;
+  }
+}
+
+export function evaluateExpression(source, ctx = {}, options = {}) {
+  const compiled = typeof source === 'string' ? compileExpression(source) : source;
+  if (compiled?.error) {
+    reportDiagnostic(options, {
+      level: 'error',
+      domain: 'expression',
+      code: compiled.error.code ?? 'BN_EXPR_COMPILE_FAILED',
+      message: compiled.error.message,
+      expression: compiled.source,
+      error: compiled.error,
+    });
+    return undefined;
+  }
+
+  try {
+    return evaluateNode(compiled.ast, ctx, compiled.source);
+  } catch (error) {
+    reportDiagnostic(options, {
+      level: 'error',
+      domain: 'expression',
+      code: error.code ?? 'BN_EXPR_EVALUATION_FAILED',
+      message: error.message,
+      expression: compiled.source,
+      error,
+    });
+    return undefined;
+  }
+}
+
+export function clearExpressionCache() {
+  EXPRESSION_CACHE.clear();
+}

--- a/packages/server/src/render.js
+++ b/packages/server/src/render.js
@@ -1,5 +1,5 @@
 import { parse } from 'node-html-parser';
-import { evaluateExpression } from '../../../src/shared/expression.js';
+import { evaluateExpression } from './expression.js';
 
 function emitDiagnostic(options, diagnostic) {
   if (typeof options?.onDiagnostic === 'function') {


### PR DESCRIPTION
## Summary

Three published-package bugs blocking downstream consumers (PendingBusiness, t4bs):

- **#54** `@basenative/runtime@0.4.0` `evaluate.js` imports `../../../src/shared/expression.js` — a monorepo-relative path missing from the published tarball.
- **#55** `@basenative/router@0.4.0` types unreachable under `moduleResolution: "bundler"` because the `"exports"` map had no `types` conditional.
- **#56** `@basenative/server@0.4.0` has the same broken transitive import as `@basenative/runtime`.

## Changes

### `@basenative/runtime` 0.4.0 → 0.4.1
- Inline `src/shared/expression.js` (694 lines) into the package as `packages/runtime/src/expression.js`
- Update all internal imports (`evaluate.js`, `scope.js`, tests) to use the local path
- Package is now self-contained when published

### `@basenative/server` 0.4.0 → 0.4.1
- Same inlining at `packages/server/src/expression.js`
- Update `render.js` import

### `@basenative/router` 0.4.0 → 0.4.1
- Add `types` conditional to `"."` export, matching the fix already applied to `@basenative/auth-webauthn`:
  ```json
  {
    "exports": {
      ".": {
        "types": "./types/index.d.ts",
        "default": "./src/index.js"
      }
    }
  }
  ```

## Drift caveat

`runtime/src/expression.js` and `server/src/expression.js` are byte-identical 694-line copies. Future refactor could consolidate by having `@basenative/server` depend on `@basenative/runtime` and importing via a `runtime/expression` subpath export — that would add a new cross-package dependency and is out of scope for this bug fix.

## Test plan

- [x] `cd packages/runtime && node --test` — **422/422 pass** (107 expression-only + full suite)
- [x] `cd packages/server && node --test` — **148/148 pass**
- [x] `grep -rln "shared/expression" packages/` — no remaining references to the broken path
- [ ] Publish 0.4.1 of all three packages and verify downstream consumers (PendingBusiness, t4bs) can drop their workarounds

## Downstream cleanup after publish

- t4bs: drop the Vite alias + `src/lib/_bn-expression.js` shim documented in #54
- PendingBusiness: delete the `worker/src/types/basenative-router.d.ts` shim documented in #55
- t4bs SSR can switch from raw template literals to `@basenative/server` (referenced in #56 + DuganLabs/t4bs#24)

Closes #54, #55, #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)