### PR TITLE
chore(server): add publishConfig for GitHub Packages

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,6 +17,10 @@
     "@basenative/runtime": "workspace:*",
     "node-html-parser": "^7.0.1"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
   "files": [
     "src",
     "types"


### PR DESCRIPTION
## Summary
- Adds `publishConfig` (registry: npm.pkg.github.com, access: public) to `packages/server/package.json`
- Without this, `npm publish` from `packages/server/` defaults to npmjs.org and fails — which is why the 0.4.1 fix from #82 (expression.js import resolution) never landed on the GitHub Packages registry
- Pattern matches the `publishConfig` already present in `auth-webauthn`, `admin`, `combobox`, `doppler`, and `claude-config`

## Test plan
- [x] `npm publish` from `packages/server/` succeeds and lands `@basenative/server@0.4.1` on `https://npm.pkg.github.com`
- [ ] Downstream consumers (Greenput, PendingBusiness) can install `@basenative/server@0.4.1` and the broken `../../../src/shared/expression.js` import is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)