### PR TITLE
fix(runtime,server): publishConfig + drop workspace: protocol

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -34,5 +34,8 @@
     "reactive",
     "ssr",
     "zero-dependencies"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,7 +14,7 @@
   },
   "types": "./types/render.d.ts",
   "dependencies": {
-    "@basenative/runtime": "^0.4.0",
+    "@basenative/runtime": "workspace:^0.4.0",
     "node-html-parser": "^7.0.1"
   },
   "files": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basenative/server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Server-side rendering with streaming support for BaseNative templates",
   "type": "module",
   "exports": {
@@ -14,7 +14,7 @@
   },
   "types": "./types/render.d.ts",
   "dependencies": {
-    "@basenative/runtime": "workspace:*",
+    "@basenative/runtime": "^0.4.0",
     "node-html-parser": "^7.0.1"
   },
   "files": [
@@ -38,5 +38,8 @@
     "ssr",
     "streaming",
     "server-rendering"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,8 +346,8 @@ importers:
   packages/server:
     dependencies:
       '@basenative/runtime':
-        specifier: workspace:*
-        version: link:../runtime
+        specifier: ^0.4.0
+        version: 0.4.1
       node-html-parser:
         specifier: ^7.0.1
         version: 7.1.0
@@ -406,6 +406,9 @@ packages:
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
+
+  '@basenative/runtime@0.4.1':
+    resolution: {integrity: sha512-L61KyHhPt8sCg7OwsIwGK3nq+O4g/I8Xp7zOcZje1daR1iqQZnyx4de0SOpevBE5ajdPyjPsoK6ktugVLxiI6Q==, tarball: https://npm.pkg.github.com/download/@basenative/runtime/0.4.1/19e9d0d995086d338355d53742576572ab1ede3b}
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -2535,6 +2538,8 @@ packages:
 snapshots:
 
   '@babel/runtime@7.29.2': {}
+
+  '@basenative/runtime@0.4.1': {}
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,8 +346,8 @@ importers:
   packages/server:
     dependencies:
       '@basenative/runtime':
-        specifier: ^0.4.0
-        version: 0.4.1
+        specifier: workspace:^0.4.0
+        version: link:../runtime
       node-html-parser:
         specifier: ^7.0.1
         version: 7.1.0
@@ -406,9 +406,6 @@ packages:
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
-
-  '@basenative/runtime@0.4.1':
-    resolution: {integrity: sha512-L61KyHhPt8sCg7OwsIwGK3nq+O4g/I8Xp7zOcZje1daR1iqQZnyx4de0SOpevBE5ajdPyjPsoK6ktugVLxiI6Q==, tarball: https://npm.pkg.github.com/download/@basenative/runtime/0.4.1/19e9d0d995086d338355d53742576572ab1ede3b}
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -2538,8 +2535,6 @@ packages:
 snapshots:
 
   '@babel/runtime@7.29.2': {}
-
-  '@basenative/runtime@0.4.1': {}
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:


### PR DESCRIPTION
## Summary
- \`packages/runtime/package.json\`: add \`publishConfig.registry\` → \`https://npm.pkg.github.com\` so \`npm publish\` targets GitHub Packages without a manual \`--registry\` flag.
- \`packages/server/package.json\`: replace \`"@basenative/runtime": "workspace:*"\` with \`"^0.4.0"\` — \`npm publish\` rejects the \`workspace:\` protocol, so the published tarball needs a real version range.
- \`packages/server\` version: \`0.4.1\` → \`0.4.2\` for the dep-spec change.
- \`packages/runtime\` stays at \`0.4.1\` (publishConfig is metadata only, no code change).

## Test plan
- [x] Diff is exactly the four fields described above
- [ ] \`npm publish\` from each package directory (attempted with 30s timeout per task)