### PR TITLE
fix(showcase): hydrate every interactive component, surface all packages

### DIFF
--- a/examples/express/public/showcase.js
+++ b/examples/express/public/showcase.js
@@ -1,0 +1,406 @@
+import { signal, effect } from '/basenative.js';
+
+const ready = (fn) =>
+  document.readyState === 'loading'
+    ? document.addEventListener('DOMContentLoaded', fn, { once: true })
+    : fn();
+
+ready(() => {
+  wireTabs();
+  wireDialogs();
+  wireDrawer();
+  wireDropdowns();
+  wireTooltips();
+  wireCommandPalette();
+  wireAlerts();
+  const toaster = wireToasts();
+  wireToastDemo(toaster);
+  wireToastButtons(toaster);
+  wireVirtualList();
+  wireCounter();
+  wireClock();
+});
+
+function wireTabs() {
+  for (const tablist of document.querySelectorAll('[data-bn="tabs"]')) {
+    const tabs = [...tablist.querySelectorAll('[data-bn="tab"]')];
+    const panels = [...tablist.querySelectorAll('[data-bn="tab-panel"]')];
+
+    const activate = (tab) => {
+      for (const t of tabs) t.setAttribute('aria-selected', String(t === tab));
+      for (const p of panels) p.hidden = p.getAttribute('aria-labelledby') !== tab.id;
+    };
+
+    for (const tab of tabs) {
+      tab.addEventListener('click', () => activate(tab));
+      tab.addEventListener('keydown', (e) => {
+        const i = tabs.indexOf(tab);
+        if (e.key === 'ArrowRight') {
+          e.preventDefault();
+          const next = tabs[(i + 1) % tabs.length];
+          next.focus();
+          activate(next);
+        } else if (e.key === 'ArrowLeft') {
+          e.preventDefault();
+          const prev = tabs[(i - 1 + tabs.length) % tabs.length];
+          prev.focus();
+          activate(prev);
+        } else if (e.key === 'Home') {
+          e.preventDefault();
+          tabs[0].focus();
+          activate(tabs[0]);
+        } else if (e.key === 'End') {
+          e.preventDefault();
+          tabs[tabs.length - 1].focus();
+          activate(tabs[tabs.length - 1]);
+        }
+      });
+    }
+  }
+}
+
+function wireDialogs() {
+  for (const trigger of document.querySelectorAll('[data-bn-action="open-dialog"]')) {
+    const target = document.getElementById(trigger.getAttribute('data-bn-target'));
+    if (!target) continue;
+    trigger.addEventListener('click', () => target.showModal());
+  }
+  for (const closer of document.querySelectorAll('[data-bn="dialog-close"]')) {
+    closer.addEventListener('click', () => closer.closest('[data-bn="dialog"]')?.close());
+  }
+  for (const dialog of document.querySelectorAll('[data-bn="dialog"]')) {
+    for (const btn of dialog.querySelectorAll('[data-bn="dialog-footer"] [data-bn="button"]')) {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        dialog.close();
+      });
+    }
+  }
+}
+
+function wireDrawer() {
+  for (const trigger of document.querySelectorAll('[data-bn-action="open-drawer"]')) {
+    const drawer = document.getElementById(trigger.getAttribute('data-bn-target'));
+    if (!drawer) continue;
+    const overlay = drawer.previousElementSibling?.matches?.('[data-bn="drawer-overlay"]')
+      ? drawer.previousElementSibling
+      : document.querySelector(`[data-bn="drawer-overlay"][data-for="${drawer.id}"]`);
+
+    const open = () => {
+      drawer.setAttribute('data-open', '');
+      overlay?.removeAttribute('hidden');
+      drawer.querySelector('[data-bn="drawer-close"], button')?.focus();
+    };
+    const close = () => {
+      drawer.removeAttribute('data-open');
+      overlay?.setAttribute('hidden', '');
+      trigger.focus();
+    };
+
+    trigger.addEventListener('click', open);
+    drawer.querySelector('[data-bn="drawer-close"]')?.addEventListener('click', close);
+    overlay?.addEventListener('click', close);
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && drawer.hasAttribute('data-open')) close();
+    });
+  }
+}
+
+function wireDropdowns() {
+  for (const dropdown of document.querySelectorAll('[data-bn="dropdown"]')) {
+    const trigger = dropdown.querySelector('[data-bn="dropdown-trigger"]');
+    const menu = dropdown.querySelector('[data-bn="dropdown-menu"]');
+    if (!trigger || !menu) continue;
+
+    const supportsPopover = HTMLElement.prototype.hasOwnProperty('popover');
+    if (!supportsPopover) {
+      trigger.addEventListener('click', () => {
+        menu.toggleAttribute('data-open');
+      });
+      document.addEventListener('click', (e) => {
+        if (!dropdown.contains(e.target)) menu.removeAttribute('data-open');
+      });
+    }
+
+    for (const item of menu.querySelectorAll('[data-bn="dropdown-item"]')) {
+      item.addEventListener('click', () => {
+        if (supportsPopover && menu.matches(':popover-open')) menu.hidePopover();
+        else menu.removeAttribute('data-open');
+      });
+    }
+  }
+}
+
+function wireTooltips() {
+  for (const trigger of document.querySelectorAll('[data-bn="tooltip-trigger"]')) {
+    const id = trigger.getAttribute('popovertarget');
+    if (!id) continue;
+    const tip = document.getElementById(id);
+    if (!tip) continue;
+
+    const supportsPopover = tip.hasAttribute('popover') && typeof tip.showPopover === 'function';
+
+    if (!trigger.hasAttribute('tabindex')) trigger.setAttribute('tabindex', '0');
+    trigger.setAttribute('aria-describedby', id);
+
+    const positionTip = () => {
+      const rect = trigger.getBoundingClientRect();
+      const tipRect = tip.getBoundingClientRect();
+      const pos = tip.dataset.position || 'top';
+      let top = 0,
+        left = 0;
+      if (pos === 'top') {
+        top = rect.top - tipRect.height - 8;
+        left = rect.left + rect.width / 2 - tipRect.width / 2;
+      } else if (pos === 'bottom') {
+        top = rect.bottom + 8;
+        left = rect.left + rect.width / 2 - tipRect.width / 2;
+      } else if (pos === 'left') {
+        top = rect.top + rect.height / 2 - tipRect.height / 2;
+        left = rect.left - tipRect.width - 8;
+      } else if (pos === 'right') {
+        top = rect.top + rect.height / 2 - tipRect.height / 2;
+        left = rect.right + 8;
+      }
+      const margin = 8;
+      const maxLeft = window.innerWidth - tipRect.width - margin;
+      tip.style.top = `${Math.max(margin, top + window.scrollY)}px`;
+      tip.style.left = `${Math.min(maxLeft, Math.max(margin, left + window.scrollX))}px`;
+    };
+
+    const show = () => {
+      if (supportsPopover) {
+        if (!tip.matches(':popover-open')) tip.showPopover();
+      } else {
+        tip.setAttribute('data-open', '');
+      }
+      requestAnimationFrame(positionTip);
+    };
+    const hide = () => {
+      if (supportsPopover) {
+        if (tip.matches(':popover-open')) tip.hidePopover();
+      } else {
+        tip.removeAttribute('data-open');
+      }
+    };
+
+    trigger.addEventListener('mouseenter', show);
+    trigger.addEventListener('mouseleave', hide);
+    trigger.addEventListener('focus', show);
+    trigger.addEventListener('blur', hide);
+  }
+}
+
+function wireCommandPalette() {
+  for (const trigger of document.querySelectorAll('[data-bn-action="open-command-palette"]')) {
+    const palette = document.getElementById(trigger.getAttribute('data-bn-target'));
+    if (!palette) continue;
+    trigger.addEventListener('click', () => {
+      palette.showModal();
+      palette.querySelector('[data-bn="command-input"]')?.focus();
+    });
+  }
+
+  for (const palette of document.querySelectorAll('[data-bn="command-palette"]')) {
+    const input = palette.querySelector('[data-bn="command-input"]');
+    const items = [...palette.querySelectorAll('[data-bn="command-item"]')];
+    const groups = [...palette.querySelectorAll('[data-bn="command-group"]')];
+
+    const filter = (query) => {
+      const q = query.trim().toLowerCase();
+      for (const item of items) {
+        const label =
+          item.querySelector('[data-bn="command-label"]')?.textContent.toLowerCase() ?? '';
+        item.hidden = q.length > 0 && !label.includes(q);
+      }
+      for (const group of groups) {
+        const visibleItems = group.querySelectorAll('[data-bn="command-item"]:not([hidden])');
+        group.hidden = visibleItems.length === 0;
+      }
+      const firstVisible = items.find((i) => !i.hidden);
+      for (const item of items) item.removeAttribute('aria-selected');
+      if (firstVisible) firstVisible.setAttribute('aria-selected', 'true');
+    };
+
+    input?.addEventListener('input', () => filter(input.value));
+    input?.addEventListener('keydown', (e) => {
+      const visible = items.filter((i) => !i.hidden);
+      const currentIndex = visible.findIndex((i) => i.getAttribute('aria-selected') === 'true');
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        const next = visible[(currentIndex + 1) % visible.length];
+        for (const item of items) item.removeAttribute('aria-selected');
+        next?.setAttribute('aria-selected', 'true');
+        next?.scrollIntoView({ block: 'nearest' });
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        const prev = visible[(currentIndex - 1 + visible.length) % visible.length];
+        for (const item of items) item.removeAttribute('aria-selected');
+        prev?.setAttribute('aria-selected', 'true');
+        prev?.scrollIntoView({ block: 'nearest' });
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        visible[currentIndex >= 0 ? currentIndex : 0]?.click();
+      } else if (e.key === 'Escape') {
+        palette.close();
+      }
+    });
+
+    for (const item of items) {
+      item.addEventListener('click', () => {
+        const action = item.dataset.action;
+        const label = item.querySelector('[data-bn="command-label"]')?.textContent ?? action;
+        palette.close();
+        if (input) input.value = '';
+        filter('');
+        palette.dispatchEvent(
+          new CustomEvent('command', { detail: { action, label }, bubbles: true }),
+        );
+      });
+    }
+
+    palette.addEventListener('close', () => {
+      if (input) input.value = '';
+      filter('');
+    });
+  }
+}
+
+function wireAlerts() {
+  for (const btn of document.querySelectorAll('[data-bn="alert-dismiss"]')) {
+    btn.addEventListener('click', () => btn.closest('[data-bn="alert"]')?.remove());
+  }
+}
+
+function wireToasts() {
+  const container = document.querySelector('[data-bn="toast-container"]');
+  if (!container) return null;
+
+  const toasts = signal([]);
+
+  effect(() => {
+    const list = toasts();
+    container.innerHTML = '';
+    for (const t of list) {
+      const el = document.createElement('output');
+      el.setAttribute('data-bn', 'toast');
+      el.setAttribute('data-variant', t.variant);
+      el.setAttribute('role', 'status');
+      el.textContent = t.message;
+      container.append(el);
+    }
+  });
+
+  const push = (message, variant = 'info', duration = 3200) => {
+    const id = Date.now() + Math.random();
+    toasts.set((prev) => [...prev, { id, message, variant }]);
+    if (duration > 0) {
+      setTimeout(() => {
+        toasts.set((prev) => prev.filter((t) => t.id !== id));
+      }, duration);
+    }
+    return id;
+  };
+
+  return { push, toasts };
+}
+
+function wireToastDemo(toaster) {
+  if (!toaster) return;
+
+  document.addEventListener('command', (e) => {
+    const { action, label } = e.detail;
+    toaster.push(`Ran command: ${label}`, action === 'delete' ? 'error' : 'success');
+  });
+
+  for (const item of document.querySelectorAll('[data-bn="dropdown-item"]')) {
+    item.addEventListener('click', () => {
+      const label = item.textContent.trim();
+      const action = item.dataset.action;
+      toaster.push(`${label}`, action === 'delete' ? 'error' : 'info');
+    });
+  }
+}
+
+function wireToastButtons(toaster) {
+  if (!toaster) return;
+  for (const btn of document.querySelectorAll('[data-bn-action="toast"]')) {
+    btn.addEventListener('click', () => {
+      toaster.push(btn.dataset.bnMessage || 'Toast', btn.dataset.bnVariant || 'info');
+    });
+  }
+}
+
+function wireCounter() {
+  const root = document.querySelector('[data-showcase-counter]');
+  if (!root) return;
+
+  const count = signal(0);
+  const valueEl = root.querySelector('[data-bn-counter-value]');
+  const doubledEl = root.querySelector('[data-bn-counter-doubled]');
+  const parityEl = root.querySelector('[data-bn-counter-parity]');
+
+  effect(() => {
+    const n = count();
+    if (valueEl) valueEl.textContent = String(n);
+    if (doubledEl) doubledEl.textContent = `doubled: ${n * 2}`;
+    if (parityEl) {
+      parityEl.textContent = n % 2 === 0 ? 'even' : 'odd';
+      parityEl.dataset.parity = n % 2 === 0 ? 'even' : 'odd';
+    }
+  });
+
+  root
+    .querySelector('[data-bn-action="counter-inc"]')
+    ?.addEventListener('click', () => count.set((c) => c + 1));
+  root
+    .querySelector('[data-bn-action="counter-dec"]')
+    ?.addEventListener('click', () => count.set((c) => c - 1));
+}
+
+function wireClock() {
+  const el = document.querySelector('[data-bn-clock]');
+  if (!el) return;
+  const time = signal(new Date());
+  effect(() => {
+    el.textContent = time().toLocaleTimeString();
+  });
+  setInterval(() => time.set(new Date()), 1000);
+}
+
+function wireVirtualList() {
+  for (const v of document.querySelectorAll('[data-bn="virtualizer"]')) {
+    const window_ = v.querySelector('[data-bn="virtual-window"]');
+    if (!window_) continue;
+    const itemHeight = Number(window_.dataset.itemHeight) || 40;
+    const total = Number(window_.dataset.total) || 0;
+    const overscan = 5;
+    const viewportHeight = v.clientHeight;
+    const visibleCount = Math.ceil(viewportHeight / itemHeight) + overscan * 2;
+
+    const items = [...window_.querySelectorAll('[data-bn="virtual-item"]')];
+    if (items.length === 0 || total <= items.length) return;
+
+    const allLabels = Array.from(
+      { length: total },
+      (_, i) => items[i]?.textContent ?? `Item ${i + 1}`,
+    );
+
+    const render = () => {
+      const scrollTop = v.scrollTop;
+      const startIndex = Math.max(0, Math.floor(scrollTop / itemHeight) - overscan);
+      const endIndex = Math.min(total, startIndex + visibleCount);
+      window_.style.transform = `translateY(${startIndex * itemHeight}px)`;
+      window_.innerHTML = '';
+      for (let i = startIndex; i < endIndex; i++) {
+        const el = document.createElement('div');
+        el.setAttribute('data-bn', 'virtual-item');
+        el.setAttribute('data-index', String(i));
+        el.textContent = allLabels[i] ?? `Item ${i + 1}`;
+        window_.append(el);
+      }
+    };
+
+    v.addEventListener('scroll', render, { passive: true });
+  }
+}

--- a/examples/express/public/styles.css
+++ b/examples/express/public/styles.css
@@ -1,11 +1,51 @@
 @layer reset, tokens, layout, components, states;
 
 @layer reset {
-  *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-  html { hanging-punctuation: first last; scroll-behavior: smooth; }
-  .visually-hidden { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip-path: inset(50%); white-space: nowrap; border: 0; }
-  .skip-link { position: absolute; inset-inline-start: -9999px; inset-block-start: -9999px; z-index: 10000; padding: 0.75rem 1rem; background: var(--accent); color: var(--surface-0); font-weight: 600; text-decoration: none; border-radius: 0 0 var(--radius-sm) 0; clip: rect(0 0 0 0); clip-path: inset(50%); overflow: hidden; white-space: nowrap; }
-  .skip-link:focus { inset-inline-start: 0; inset-block-start: 0; clip: auto; clip-path: none; overflow: visible; }
+  *,
+  *::before,
+  *::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+  html {
+    hanging-punctuation: first last;
+    scroll-behavior: smooth;
+  }
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+  .skip-link {
+    position: absolute;
+    inset-inline-start: -9999px;
+    inset-block-start: -9999px;
+    z-index: 10000;
+    padding: 0.75rem 1rem;
+    background: var(--accent);
+    color: var(--surface-0);
+    font-weight: 600;
+    text-decoration: none;
+    border-radius: 0 0 var(--radius-sm) 0;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    overflow: hidden;
+    white-space: nowrap;
+  }
+  .skip-link:focus {
+    inset-inline-start: 0;
+    inset-block-start: 0;
+    clip: auto;
+    clip-path: none;
+    overflow: visible;
+  }
 }
 
 @layer tokens {
@@ -275,8 +315,13 @@
     min-inline-size: 0;
     max-inline-size: 100%;
   }
-  body > header ul::-webkit-scrollbar { display: none; }
-  body > header li { scroll-snap-align: start; flex: 0 0 auto; }
+  body > header ul::-webkit-scrollbar {
+    display: none;
+  }
+  body > header li {
+    scroll-snap-align: start;
+    flex: 0 0 auto;
+  }
 
   body > header a {
     font-family: var(--font-family);
@@ -289,10 +334,17 @@
     display: inline-flex;
     align-items: center;
     border-radius: var(--radius-sm);
-    transition: color var(--duration-fast), background var(--duration-fast);
+    transition:
+      color var(--duration-fast),
+      background var(--duration-fast);
   }
-  body > header a:hover { color: var(--accent); background: var(--surface-2); }
-  body > header a[aria-current="page"] { color: var(--accent); }
+  body > header a:hover {
+    color: var(--accent);
+    background: var(--surface-2);
+  }
+  body > header a[aria-current='page'] {
+    color: var(--accent);
+  }
 
   main {
     flex: 1;
@@ -320,7 +372,9 @@
 
 @layer components {
   /* -- Sections -- */
-  section { margin-block-end: var(--space-2xl); }
+  section {
+    margin-block-end: var(--space-2xl);
+  }
 
   section > h2 {
     font-family: var(--font-family);
@@ -373,7 +427,7 @@
     container-name: stats;
   }
 
-  ul[role="list"][data-stat-grid] {
+  ul[role='list'][data-stat-grid] {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: var(--space-md);
@@ -381,7 +435,7 @@
     flex-direction: unset;
   }
 
-  ul[role="list"][data-stat-grid] > li {
+  ul[role='list'][data-stat-grid] > li {
     background: var(--surface-1);
     border: var(--border-width) solid var(--border);
     border-inline-start: var(--border-width) solid var(--border);
@@ -392,22 +446,24 @@
     flex-direction: column;
     justify-content: center;
     gap: var(--space-xs);
-    transition: border-color var(--duration-med), box-shadow var(--duration-med);
+    transition:
+      border-color var(--duration-med),
+      box-shadow var(--duration-med);
   }
 
-  ul[role="list"][data-stat-grid] > li:hover {
+  ul[role='list'][data-stat-grid] > li:hover {
     border-color: var(--border-accent);
     box-shadow: var(--shadow-card);
   }
 
-  ul[role="list"][data-stat-grid] strong {
+  ul[role='list'][data-stat-grid] strong {
     font-family: var(--font-family);
     font-stretch: var(--font-serif);
     font-size: var(--stat-value-size);
     color: var(--accent);
   }
 
-  ul[role="list"][data-stat-grid] span {
+  ul[role='list'][data-stat-grid] span {
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
     font-size: var(--font-size-sm);
@@ -423,11 +479,16 @@
     border-radius: var(--radius-md);
     padding: var(--space-lg);
     margin-block-end: var(--space-md);
-    transition: border-color var(--duration-med), box-shadow var(--duration-med);
+    transition:
+      border-color var(--duration-med),
+      box-shadow var(--duration-med);
     container-type: inline-size;
     container-name: card;
   }
-  article:hover { border-color: var(--border-accent); box-shadow: var(--shadow-card); }
+  article:hover {
+    border-color: var(--border-accent);
+    box-shadow: var(--shadow-card);
+  }
 
   article > header {
     margin-block-end: var(--space-sm);
@@ -465,8 +526,13 @@
   }
 
   /* -- Lists -- */
-  ul[role="list"] { list-style: none; display: flex; flex-direction: column; gap: var(--space-xs); }
-  ul[role="list"] li {
+  ul[role='list'] {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+  ul[role='list'] li {
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
     font-size: var(--font-size-base);
@@ -477,9 +543,14 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    transition: background var(--duration-fast), border-color var(--duration-fast);
+    transition:
+      background var(--duration-fast),
+      border-color var(--duration-fast);
   }
-  ul[role="list"] li:hover { background: var(--surface-3); border-inline-start-color: var(--accent); }
+  ul[role='list'] li:hover {
+    background: var(--surface-3);
+    border-inline-start-color: var(--accent);
+  }
 
   /* -- Status badges -- */
   [data-status] {
@@ -492,14 +563,36 @@
     font-weight: var(--font-weight-semibold);
     white-space: nowrap;
   }
-  [data-status="active"], [data-status="done"] { background: var(--status-active-bg); color: var(--success); }
-  [data-status="idle"], [data-status="dom"], [data-status="binding"] { background: var(--status-idle-bg); color: var(--accent); }
-  [data-status="error"] { background: var(--status-error-bg); color: var(--danger); }
-  [data-status="pending"], [data-status="server"] { background: var(--status-pending-bg); color: var(--text-2); }
-  mark[data-status="active"], mark[data-status="core"], mark[data-status="directive"] { background: var(--status-active-bg); color: var(--success); }
+  [data-status='active'],
+  [data-status='done'] {
+    background: var(--status-active-bg);
+    color: var(--success);
+  }
+  [data-status='idle'],
+  [data-status='dom'],
+  [data-status='binding'] {
+    background: var(--status-idle-bg);
+    color: var(--accent);
+  }
+  [data-status='error'] {
+    background: var(--status-error-bg);
+    color: var(--danger);
+  }
+  [data-status='pending'],
+  [data-status='server'] {
+    background: var(--status-pending-bg);
+    color: var(--text-2);
+  }
+  mark[data-status='active'],
+  mark[data-status='core'],
+  mark[data-status='directive'] {
+    background: var(--status-active-bg);
+    color: var(--success);
+  }
 
   /* -- Buttons -- */
-  button:not([data-bn]), a[role="button"] {
+  button:not([data-bn]),
+  a[role='button'] {
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
     font-size: var(--font-size-sm);
@@ -514,26 +607,57 @@
     border-radius: var(--radius-sm);
     cursor: pointer;
     text-decoration: none;
-    transition: background var(--duration-fast), border-color var(--duration-fast), color var(--duration-fast), box-shadow var(--duration-med);
+    transition:
+      background var(--duration-fast),
+      border-color var(--duration-fast),
+      color var(--duration-fast),
+      box-shadow var(--duration-med);
   }
-  button:not([data-bn]):hover, a[role="button"]:hover { background: var(--accent-dim); border-color: var(--accent); color: var(--surface-0); box-shadow: var(--shadow-btn); }
-  button:not([data-bn]):focus-visible, a[role="button"]:focus-visible { outline: var(--border-inline-width) solid var(--accent); outline-offset: var(--border-inline-width); }
-  button:not([data-bn])[data-variant="danger"] { border-color: var(--danger); color: var(--danger); }
-  button:not([data-bn])[data-variant="danger"]:hover { background: var(--danger); color: var(--surface-0); }
-  [data-variant="outline"] { background: transparent; border-color: var(--border-accent); color: var(--text-1); }
-  [data-variant="outline"]:hover { background: var(--surface-2); border-color: var(--accent); color: var(--accent); box-shadow: none; }
+  button:not([data-bn]):hover,
+  a[role='button']:hover {
+    background: var(--accent-dim);
+    border-color: var(--accent);
+    color: var(--surface-0);
+    box-shadow: var(--shadow-btn);
+  }
+  button:not([data-bn]):focus-visible,
+  a[role='button']:focus-visible {
+    outline: var(--border-inline-width) solid var(--accent);
+    outline-offset: var(--border-inline-width);
+  }
+  button:not([data-bn])[data-variant='danger'] {
+    border-color: var(--danger);
+    color: var(--danger);
+  }
+  button:not([data-bn])[data-variant='danger']:hover {
+    background: var(--danger);
+    color: var(--surface-0);
+  }
+  [data-variant='outline'] {
+    background: transparent;
+    border-color: var(--border-accent);
+    color: var(--text-1);
+  }
+  [data-variant='outline']:hover {
+    background: var(--surface-2);
+    border-color: var(--accent);
+    color: var(--accent);
+    box-shadow: none;
+  }
 
   /* -- Icons in buttons -- */
-  button:not([data-bn]) > img[src*="/icons/"] {
+  button:not([data-bn]) > img[src*='/icons/'] {
     inline-size: 1em;
     block-size: 1em;
     vertical-align: middle;
     filter: brightness(0) invert(0.9);
   }
-  button:not([data-bn]):hover > img[src*="/icons/"] { filter: brightness(0) invert(0.03); }
+  button:not([data-bn]):hover > img[src*='/icons/'] {
+    filter: brightness(0) invert(0.03);
+  }
 
   /* -- Inputs -- */
-  input[type="text"]:not([data-bn]) {
+  input[type='text']:not([data-bn]) {
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
     font-size: var(--font-size-base);
@@ -543,10 +667,17 @@
     border: var(--border-width) solid var(--border);
     border-radius: var(--radius-sm);
     outline: none;
-    transition: border-color var(--duration-med), box-shadow var(--duration-med);
+    transition:
+      border-color var(--duration-med),
+      box-shadow var(--duration-med);
   }
-  input[type="text"]:not([data-bn]):focus { border-color: var(--accent); box-shadow: var(--shadow-input), var(--shadow-btn); }
-  input[type="text"]:not([data-bn])::placeholder { color: var(--text-2); }
+  input[type='text']:not([data-bn]):focus {
+    border-color: var(--accent);
+    box-shadow: var(--shadow-input), var(--shadow-btn);
+  }
+  input[type='text']:not([data-bn])::placeholder {
+    color: var(--text-2);
+  }
 
   /* -- Textarea -- */
   textarea:not([data-bn]) {
@@ -563,13 +694,20 @@
     resize: vertical;
     field-sizing: content;
     min-block-size: 4lh;
-    transition: border-color var(--duration-med), box-shadow var(--duration-med);
+    transition:
+      border-color var(--duration-med),
+      box-shadow var(--duration-med);
   }
-  textarea:not([data-bn]):focus { border-color: var(--accent); box-shadow: var(--shadow-input), var(--shadow-btn); }
-  textarea:not([data-bn])::placeholder { color: var(--text-2); }
+  textarea:not([data-bn]):focus {
+    border-color: var(--accent);
+    box-shadow: var(--shadow-input), var(--shadow-btn);
+  }
+  textarea:not([data-bn])::placeholder {
+    color: var(--text-2);
+  }
 
   /* -- Checkbox -- */
-  input[type="checkbox"]:not([data-bn]) {
+  input[type='checkbox']:not([data-bn]) {
     appearance: none;
     inline-size: var(--control-size);
     block-size: var(--control-size);
@@ -581,13 +719,16 @@
     cursor: pointer;
     position: relative;
     flex-shrink: 0;
-    transition: background var(--duration-fast), border-color var(--duration-fast), box-shadow var(--duration-fast);
+    transition:
+      background var(--duration-fast),
+      border-color var(--duration-fast),
+      box-shadow var(--duration-fast);
   }
-  input[type="checkbox"]:not([data-bn]):checked {
+  input[type='checkbox']:not([data-bn]):checked {
     background: var(--control-checked-bg);
     border-color: var(--control-checked-border);
   }
-  input[type="checkbox"]:not([data-bn]):checked::after {
+  input[type='checkbox']:not([data-bn]):checked::after {
     content: '';
     position: absolute;
     inset-block-start: 0.125rem;
@@ -598,10 +739,13 @@
     border-width: 0 2px 2px 0;
     transform: rotate(45deg);
   }
-  input[type="checkbox"]:not([data-bn]):focus-visible { outline: var(--border-inline-width) solid var(--accent); outline-offset: var(--border-inline-width); }
+  input[type='checkbox']:not([data-bn]):focus-visible {
+    outline: var(--border-inline-width) solid var(--accent);
+    outline-offset: var(--border-inline-width);
+  }
 
   /* -- Radio -- */
-  input[type="radio"]:not([data-bn]) {
+  input[type='radio']:not([data-bn]) {
     appearance: none;
     inline-size: var(--control-size);
     block-size: var(--control-size);
@@ -613,12 +757,14 @@
     cursor: pointer;
     position: relative;
     flex-shrink: 0;
-    transition: background var(--duration-fast), border-color var(--duration-fast);
+    transition:
+      background var(--duration-fast),
+      border-color var(--duration-fast);
   }
-  input[type="radio"]:not([data-bn]):checked {
+  input[type='radio']:not([data-bn]):checked {
     border-color: var(--control-checked-border);
   }
-  input[type="radio"]:not([data-bn]):checked::after {
+  input[type='radio']:not([data-bn]):checked::after {
     content: '';
     position: absolute;
     inset-block-start: 50%;
@@ -629,19 +775,26 @@
     border-radius: 50%;
     transform: translate(-50%, -50%);
   }
-  input[type="radio"]:not([data-bn]):focus-visible { outline: var(--border-inline-width) solid var(--accent); outline-offset: var(--border-inline-width); }
+  input[type='radio']:not([data-bn]):focus-visible {
+    outline: var(--border-inline-width) solid var(--accent);
+    outline-offset: var(--border-inline-width);
+  }
 
   /* -- Range -- */
-  input[type="range"] {
+  input[type='range'] {
     appearance: none;
     inline-size: 100%;
     block-size: var(--track-height);
-    background: linear-gradient(to right, var(--track-fill) calc(var(--range-pct, 50) * 1%), var(--track-bg) calc(var(--range-pct, 50) * 1%));
+    background: linear-gradient(
+      to right,
+      var(--track-fill) calc(var(--range-pct, 50) * 1%),
+      var(--track-bg) calc(var(--range-pct, 50) * 1%)
+    );
     border-radius: var(--radius-pill);
     outline: none;
     cursor: pointer;
   }
-  input[type="range"]::-webkit-slider-thumb {
+  input[type='range']::-webkit-slider-thumb {
     appearance: none;
     inline-size: var(--thumb-size);
     block-size: var(--thumb-size);
@@ -649,13 +802,21 @@
     border: var(--border-inline-width) solid var(--surface-0);
     border-radius: 50%;
     box-shadow: 0 0 8px var(--accent-glow);
-    transition: box-shadow var(--duration-fast), scale var(--duration-fast);
+    transition:
+      box-shadow var(--duration-fast),
+      scale var(--duration-fast);
   }
-  input[type="range"]::-webkit-slider-thumb:hover { scale: 1.15; box-shadow: 0 0 16px var(--accent-glow-strong); }
-  input[type="range"]:focus-visible { outline: var(--border-inline-width) solid var(--accent); outline-offset: var(--space-xs); }
+  input[type='range']::-webkit-slider-thumb:hover {
+    scale: 1.15;
+    box-shadow: 0 0 16px var(--accent-glow-strong);
+  }
+  input[type='range']:focus-visible {
+    outline: var(--border-inline-width) solid var(--accent);
+    outline-offset: var(--space-xs);
+  }
 
   /* -- Date input -- */
-  input[type="date"] {
+  input[type='date'] {
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
     font-size: var(--font-size-base);
@@ -666,10 +827,18 @@
     border-radius: var(--radius-sm);
     outline: none;
     color-scheme: dark;
-    transition: border-color var(--duration-med), box-shadow var(--duration-med);
+    transition:
+      border-color var(--duration-med),
+      box-shadow var(--duration-med);
   }
-  input[type="date"]:focus { border-color: var(--accent); box-shadow: var(--shadow-input), var(--shadow-btn); }
-  input[type="date"]::-webkit-calendar-picker-indicator { filter: invert(0.7); cursor: pointer; }
+  input[type='date']:focus {
+    border-color: var(--accent);
+    box-shadow: var(--shadow-input), var(--shadow-btn);
+  }
+  input[type='date']::-webkit-calendar-picker-indicator {
+    filter: invert(0.7);
+    cursor: pointer;
+  }
 
   /* -- Select (base-select) -- */
   select:not([data-bn]) {
@@ -689,9 +858,14 @@
     background-repeat: no-repeat;
     background-position: right var(--space-sm) center;
     background-size: 0.625rem;
-    transition: border-color var(--duration-med), box-shadow var(--duration-med);
+    transition:
+      border-color var(--duration-med),
+      box-shadow var(--duration-med);
   }
-  select:not([data-bn]):focus { border-color: var(--accent); box-shadow: var(--shadow-input), var(--shadow-btn); }
+  select:not([data-bn]):focus {
+    border-color: var(--accent);
+    box-shadow: var(--shadow-input), var(--shadow-btn);
+  }
 
   @supports (appearance: base-select) {
     select:not([data-bn]),
@@ -722,7 +896,9 @@
       border-radius: var(--popover-radius);
       box-shadow: var(--popover-shadow);
       padding: var(--space-xs);
-      transition: opacity var(--duration-fast), scale var(--duration-fast);
+      transition:
+        opacity var(--duration-fast),
+        scale var(--duration-fast);
       transition-behavior: allow-discrete;
       opacity: 1;
       scale: 1;
@@ -744,8 +920,13 @@
       color: var(--text-0);
       transition: background var(--duration-fast);
     }
-    select:not([data-bn]) option:hover { background: var(--select-option-hover); }
-    select:not([data-bn]) option:checked { color: var(--accent); font-weight: var(--font-weight-semibold); }
+    select:not([data-bn]) option:hover {
+      background: var(--select-option-hover);
+    }
+    select:not([data-bn]) option:checked {
+      color: var(--accent);
+      font-weight: var(--font-weight-semibold);
+    }
 
     select:not([data-bn]) option::checkmark {
       color: var(--accent);
@@ -773,9 +954,19 @@
     overflow: hidden;
     background: var(--track-bg);
   }
-  progress:not([data-bn])::-webkit-progress-bar { background: var(--track-bg); border-radius: var(--radius-pill); }
-  progress:not([data-bn])::-webkit-progress-value { background: var(--track-fill); border-radius: var(--radius-pill); transition: inline-size var(--duration-med); }
-  progress:not([data-bn])::-moz-progress-bar { background: var(--track-fill); border-radius: var(--radius-pill); }
+  progress:not([data-bn])::-webkit-progress-bar {
+    background: var(--track-bg);
+    border-radius: var(--radius-pill);
+  }
+  progress:not([data-bn])::-webkit-progress-value {
+    background: var(--track-fill);
+    border-radius: var(--radius-pill);
+    transition: inline-size var(--duration-med);
+  }
+  progress:not([data-bn])::-moz-progress-bar {
+    background: var(--track-fill);
+    border-radius: var(--radius-pill);
+  }
 
   /* -- Meter -- */
   meter {
@@ -787,13 +978,32 @@
     overflow: hidden;
     background: var(--track-bg);
   }
-  meter::-webkit-meter-bar { background: var(--track-bg); border-radius: var(--radius-pill); border: none; block-size: var(--track-height); }
-  meter::-webkit-meter-optimum-value { background: var(--meter-high); border-radius: var(--radius-pill); }
-  meter::-webkit-meter-suboptimum-value { background: var(--meter-mid); border-radius: var(--radius-pill); }
-  meter::-webkit-meter-even-less-good-value { background: var(--meter-low); border-radius: var(--radius-pill); }
+  meter::-webkit-meter-bar {
+    background: var(--track-bg);
+    border-radius: var(--radius-pill);
+    border: none;
+    block-size: var(--track-height);
+  }
+  meter::-webkit-meter-optimum-value {
+    background: var(--meter-high);
+    border-radius: var(--radius-pill);
+  }
+  meter::-webkit-meter-suboptimum-value {
+    background: var(--meter-mid);
+    border-radius: var(--radius-pill);
+  }
+  meter::-webkit-meter-even-less-good-value {
+    background: var(--meter-low);
+    border-radius: var(--radius-pill);
+  }
 
   /* -- Controls nav -- */
-  nav[data-controls] { display: flex; gap: var(--space-sm); flex-wrap: wrap; margin-block-start: var(--space-md); }
+  nav[data-controls] {
+    display: flex;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+    margin-block-start: var(--space-md);
+  }
 
   /* -- Output -- */
   output {
@@ -814,7 +1024,11 @@
   }
 
   /* -- Code blocks -- */
-  pre, code { font-family: var(--font-family); font-stretch: var(--font-mono); }
+  pre,
+  code {
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+  }
   pre {
     font-size: var(--font-size-sm);
     line-height: var(--line-height-code);
@@ -829,13 +1043,28 @@
   }
 
   /* Syntax highlighting */
-  .kw { color: var(--syntax-keyword); }
-  .str { color: var(--syntax-string); }
-  .fn { color: var(--syntax-function); }
-  .num { color: var(--syntax-number); }
-  .cmt { color: var(--syntax-comment); font-style: italic; }
-  .tag { color: var(--syntax-tag); }
-  .attr { color: var(--syntax-attr); }
+  .kw {
+    color: var(--syntax-keyword);
+  }
+  .str {
+    color: var(--syntax-string);
+  }
+  .fn {
+    color: var(--syntax-function);
+  }
+  .num {
+    color: var(--syntax-number);
+  }
+  .cmt {
+    color: var(--syntax-comment);
+    font-style: italic;
+  }
+  .tag {
+    color: var(--syntax-tag);
+  }
+  .attr {
+    color: var(--syntax-attr);
+  }
 
   /* -- Labels -- */
   label:not([data-bn]) {
@@ -924,11 +1153,13 @@
     padding-inline: var(--space-sm);
   }
 
-  fieldset > label + label { margin-block-start: var(--space-md); }
+  fieldset > label + label {
+    margin-block-start: var(--space-md);
+  }
 
   /* -- Inline label (for checkbox/radio rows) -- */
-  label:not([data-bn]):has(input[type="checkbox"]),
-  label:not([data-bn]):has(input[type="radio"]) {
+  label:not([data-bn]):has(input[type='checkbox']),
+  label:not([data-bn]):has(input[type='radio']) {
     flex-direction: row;
     align-items: center;
     gap: var(--space-sm);
@@ -970,9 +1201,15 @@
     color: var(--text-1);
   }
 
-  table:not([data-bn]) tbody tr:nth-child(even) { background: var(--table-stripe); }
-  table:not([data-bn]) tbody tr { transition: background var(--duration-fast); }
-  table:not([data-bn]) tbody tr:hover { background: var(--surface-2); }
+  table:not([data-bn]) tbody tr:nth-child(even) {
+    background: var(--table-stripe);
+  }
+  table:not([data-bn]) tbody tr {
+    transition: background var(--duration-fast);
+  }
+  table:not([data-bn]) tbody tr:hover {
+    background: var(--surface-2);
+  }
 
   /* -- Blockquote -- */
   blockquote {
@@ -1047,11 +1284,18 @@
     display: flex;
     align-items: center;
     gap: var(--space-sm);
-    transition: background var(--duration-fast), color var(--duration-fast);
+    transition:
+      background var(--duration-fast),
+      color var(--duration-fast);
     border-radius: var(--radius-md);
   }
-  details:not([data-bn]) > summary:hover { background: var(--surface-2); color: var(--accent); }
-  details:not([data-bn]) > summary::-webkit-details-marker { display: none; }
+  details:not([data-bn]) > summary:hover {
+    background: var(--surface-2);
+    color: var(--accent);
+  }
+  details:not([data-bn]) > summary::-webkit-details-marker {
+    display: none;
+  }
 
   details:not([data-bn]) > summary::before {
     content: '▸';
@@ -1059,8 +1303,12 @@
     font-size: 0.85em;
     transition: rotate var(--duration-fast);
   }
-  details:not([data-bn])[open] > summary::before { rotate: 90deg; }
-  details:not([data-bn])[open] > summary { margin-block-end: 0; }
+  details:not([data-bn])[open] > summary::before {
+    rotate: 90deg;
+  }
+  details:not([data-bn])[open] > summary {
+    margin-block-end: 0;
+  }
 
   details:not([data-bn]) > :not(summary) {
     padding: var(--space-sm) var(--space-md) var(--space-md);
@@ -1078,21 +1326,36 @@
     padding: var(--space-xl);
     max-inline-size: min(90vi, 28rem);
     box-shadow: var(--dialog-shadow);
-    transition: opacity var(--duration-med), scale var(--duration-med), overlay var(--duration-med), display var(--duration-med);
+    transition:
+      opacity var(--duration-med),
+      scale var(--duration-med),
+      overlay var(--duration-med),
+      display var(--duration-med);
     transition-behavior: allow-discrete;
   }
 
   dialog:not([data-bn])::backdrop {
     background: var(--dialog-backdrop);
-    transition: opacity var(--duration-med), overlay var(--duration-med), display var(--duration-med);
+    transition:
+      opacity var(--duration-med),
+      overlay var(--duration-med),
+      display var(--duration-med);
     transition-behavior: allow-discrete;
   }
 
-  dialog:not([data-bn])[open] { opacity: 1; scale: 1; }
+  dialog:not([data-bn])[open] {
+    opacity: 1;
+    scale: 1;
+  }
 
   @starting-style {
-    dialog:not([data-bn])[open] { opacity: 0; scale: 0.95; }
-    dialog:not([data-bn])[open]::backdrop { opacity: 0; }
+    dialog:not([data-bn])[open] {
+      opacity: 0;
+      scale: 0.95;
+    }
+    dialog:not([data-bn])[open]::backdrop {
+      opacity: 0;
+    }
   }
 
   dialog:not([data-bn]) > header {
@@ -1128,16 +1391,25 @@
     border-radius: var(--popover-radius);
     box-shadow: var(--popover-shadow);
     inset: unset;
-    transition: opacity var(--duration-fast), scale var(--duration-fast), overlay var(--duration-fast), display var(--duration-fast);
+    transition:
+      opacity var(--duration-fast),
+      scale var(--duration-fast),
+      overlay var(--duration-fast),
+      display var(--duration-fast);
     transition-behavior: allow-discrete;
     opacity: 1;
     scale: 1;
   }
 
-  [popover]:not([data-bn])::backdrop { background: transparent; }
+  [popover]:not([data-bn])::backdrop {
+    background: transparent;
+  }
 
   @starting-style {
-    [popover]:not([data-bn]):popover-open { opacity: 0; scale: 0.96; }
+    [popover]:not([data-bn]):popover-open {
+      opacity: 0;
+      scale: 0.96;
+    }
   }
 
   /* Tooltip variant */
@@ -1154,7 +1426,9 @@
     max-inline-size: 20rem;
     pointer-events: none;
   }
-  output[popover]:popover-open { display: block; }
+  output[popover]:popover-open {
+    display: block;
+  }
 
   /* Dropdown menu variant */
   nav[popover] {
@@ -1164,7 +1438,9 @@
     padding: var(--space-xs);
     min-inline-size: 10rem;
   }
-  nav[popover]:popover-open { display: flex; }
+  nav[popover]:popover-open {
+    display: flex;
+  }
 
   nav[popover] a,
   nav[popover] button {
@@ -1181,7 +1457,9 @@
     text-align: start;
     inline-size: 100%;
     cursor: pointer;
-    transition: background var(--duration-fast), color var(--duration-fast);
+    transition:
+      background var(--duration-fast),
+      color var(--duration-fast);
   }
 
   nav[popover] a:hover,
@@ -1220,10 +1498,18 @@
     font-size: var(--font-size-base);
     color: var(--text-2);
     cursor: pointer;
-    transition: color var(--duration-fast), background var(--duration-fast);
+    transition:
+      color var(--duration-fast),
+      background var(--duration-fast);
   }
-  [data-datepicker-trigger]:hover { color: var(--accent); background: var(--surface-3); box-shadow: none; }
-  [data-datepicker-trigger] svg { display: block; }
+  [data-datepicker-trigger]:hover {
+    color: var(--accent);
+    background: var(--surface-3);
+    box-shadow: none;
+  }
+  [data-datepicker-trigger] svg {
+    display: block;
+  }
 
   /* -- Datepicker popover -- */
   [data-datepicker] {
@@ -1257,7 +1543,10 @@
     border-radius: var(--radius-sm);
     color: var(--text-2);
     cursor: pointer;
-    transition: background var(--duration-fast), color var(--duration-fast), border-color var(--duration-fast);
+    transition:
+      background var(--duration-fast),
+      color var(--duration-fast),
+      border-color var(--duration-fast);
   }
   [data-datepicker-prev]:hover,
   [data-datepicker-next]:hover {
@@ -1300,7 +1589,10 @@
     border: var(--border-width) solid transparent;
     color: var(--text-1);
     cursor: pointer;
-    transition: background var(--duration-fast), color var(--duration-fast), border-color var(--duration-fast);
+    transition:
+      background var(--duration-fast),
+      color var(--duration-fast),
+      border-color var(--duration-fast);
   }
 
   [data-datepicker-grid] td button:hover {
@@ -1323,19 +1615,27 @@
   }
 
   /* -- Tasks page -- */
-  [data-hydrate] > h3 { margin-block-end: var(--space-md); }
-  [data-hydrate] > nav[data-controls] { margin-block-end: var(--space-md); }
-  [data-hydrate] > output { margin-block: var(--space-sm) var(--space-md); }
+  [data-hydrate] > h3 {
+    margin-block-end: var(--space-md);
+  }
+  [data-hydrate] > nav[data-controls] {
+    margin-block-end: var(--space-md);
+  }
+  [data-hydrate] > output {
+    margin-block: var(--space-sm) var(--space-md);
+  }
   [data-hydrate] > nav[data-controls]:first-of-type {
     align-items: center;
   }
-  [data-hydrate] > nav[data-controls]:first-of-type input[type="text"] {
+  [data-hydrate] > nav[data-controls]:first-of-type input[type='text'] {
     min-inline-size: min(100%, 15rem);
     flex: 1 1 15rem;
   }
 
-  [data-hydrate] ul[role="list"] { gap: var(--space-sm); }
-  [data-hydrate] ul[role="list"] li {
+  [data-hydrate] ul[role='list'] {
+    gap: var(--space-sm);
+  }
+  [data-hydrate] ul[role='list'] li {
     padding: var(--space-md) var(--space-lg);
     border-radius: var(--radius-md);
     gap: var(--space-md);
@@ -1354,7 +1654,7 @@
     gap: var(--space-md);
     flex: 0 0 auto;
   }
-  [data-task-item] button[data-variant="danger"] {
+  [data-task-item] button[data-variant='danger'] {
     min-inline-size: 3rem;
     padding-inline: var(--space-sm);
     box-shadow: none;
@@ -1372,7 +1672,9 @@
     border: var(--border-width) solid var(--border);
     border-radius: var(--radius-sm);
     padding-inline-start: var(--space-md);
-    transition: border-color var(--duration-med), box-shadow var(--duration-med);
+    transition:
+      border-color var(--duration-med),
+      box-shadow var(--duration-med);
   }
   [data-datepicker-input]:focus-within {
     border-color: var(--accent);
@@ -1391,9 +1693,15 @@
     text-align: center;
   }
   [data-datepicker-input] input[data-date-month],
-  [data-datepicker-input] input[data-date-day] { inline-size: 2ch; }
-  [data-datepicker-input] input[data-date-year] { inline-size: 4ch; }
-  [data-datepicker-input] input::placeholder { color: var(--text-2); }
+  [data-datepicker-input] input[data-date-day] {
+    inline-size: 2ch;
+  }
+  [data-datepicker-input] input[data-date-year] {
+    inline-size: 4ch;
+  }
+  [data-datepicker-input] input::placeholder {
+    color: var(--text-2);
+  }
 
   [data-datepicker-input] > span {
     color: var(--text-2);
@@ -1425,7 +1733,9 @@
     cursor: pointer;
     padding: var(--space-xs) var(--space-sm);
     border-radius: var(--radius-sm);
-    transition: background var(--duration-fast), color var(--duration-fast);
+    transition:
+      background var(--duration-fast),
+      color var(--duration-fast);
   }
   [data-datepicker-title-btn]:hover {
     background: var(--surface-3);
@@ -1448,7 +1758,10 @@
     border-radius: var(--radius-sm);
     color: var(--text-1);
     cursor: pointer;
-    transition: background var(--duration-fast), color var(--duration-fast), border-color var(--duration-fast);
+    transition:
+      background var(--duration-fast),
+      color var(--duration-fast),
+      border-color var(--duration-fast);
   }
   [data-datepicker-months] button:hover {
     background: var(--surface-3);
@@ -1471,13 +1784,13 @@
 
   /* Stat grid: adapt columns to container width, not viewport */
   @container stats (max-width: 36rem) {
-    ul[role="list"][data-stat-grid] {
+    ul[role='list'][data-stat-grid] {
       grid-template-columns: repeat(2, 1fr);
     }
   }
 
   @container stats (max-width: 20rem) {
-    ul[role="list"][data-stat-grid] {
+    ul[role='list'][data-stat-grid] {
       grid-template-columns: 1fr;
     }
   }
@@ -1509,7 +1822,7 @@
 
   /* List items: stack content when container is narrow */
   @container card (max-width: 20rem) {
-    ul[role="list"] li {
+    ul[role='list'] li {
       flex-direction: column;
       align-items: start;
       gap: var(--space-xs);
@@ -1518,14 +1831,23 @@
 
   /* Table: horizontal scroll on narrow containers */
   @container card (max-width: 24rem) {
-    table { font-size: var(--font-size-sm); }
-    th, td { padding: var(--space-xs) var(--space-sm); }
+    table {
+      font-size: var(--font-size-sm);
+    }
+    th,
+    td {
+      padding: var(--space-xs) var(--space-sm);
+    }
   }
 
   /* Fieldset: tighter spacing on narrow containers */
   @container card (max-width: 20rem) {
-    fieldset { padding: var(--space-md); }
-    fieldset > label + label { margin-block-start: var(--space-sm); }
+    fieldset {
+      padding: var(--space-md);
+    }
+    fieldset > label + label {
+      margin-block-start: var(--space-sm);
+    }
   }
 
   /* Datepicker: compact layout on narrow cards */
@@ -1581,7 +1903,9 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    *, *::before, *::after {
+    *,
+    *::before,
+    *::after {
       animation-duration: 0.01ms !important;
       animation-iteration-count: 1 !important;
       transition-duration: 0.01ms !important;
@@ -1589,16 +1913,218 @@
   }
 
   /* -- Showcase layout helpers -- */
-  [data-showcase-row] { display: flex; gap: var(--space-md); flex-wrap: wrap; align-items: center; }
-  [data-showcase-form] { display: grid; gap: var(--space-lg); max-inline-size: 32rem; }
-  [data-showcase-stack] { display: grid; gap: var(--space-sm); }
-  [data-showcase-card] { max-inline-size: 24rem; }
+  [data-showcase-row] {
+    display: flex;
+    gap: var(--space-md);
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  [data-showcase-form] {
+    display: grid;
+    gap: var(--space-lg);
+    max-inline-size: 32rem;
+  }
+  [data-showcase-stack] {
+    display: grid;
+    gap: var(--space-sm);
+  }
+  [data-showcase-card] {
+    max-inline-size: 24rem;
+  }
+  [data-showcase-hero] {
+    display: grid;
+    gap: var(--space-sm);
+    padding-block-end: var(--space-md);
+  }
+  [data-showcase-toc] {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+    padding: var(--space-sm);
+    margin-block-start: var(--space-md);
+    background: var(--surface-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+  }
+  [data-showcase-toc] a {
+    padding: var(--space-xs) var(--space-sm);
+    border-radius: var(--radius-sm);
+    color: var(--text-1);
+    text-decoration: none;
+    font-size: 0.875rem;
+  }
+  [data-showcase-toc] a:hover {
+    background: var(--surface-2);
+    color: var(--text-0);
+  }
+  [data-showcase-toc] a:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  [data-showcase-counter] {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-md);
+    padding: var(--space-md) var(--space-lg);
+    background: var(--surface-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    font-variant-numeric: tabular-nums;
+  }
+  [data-showcase-counter] [data-bn-counter-value] {
+    font-size: 1.75rem;
+    font-weight: 600;
+    min-inline-size: 3ch;
+    text-align: center;
+    color: var(--accent);
+  }
+  [data-showcase-counter] [data-bn-counter-doubled],
+  [data-showcase-counter] [data-bn-counter-parity] {
+    color: var(--text-1);
+    font-size: 0.875rem;
+  }
+  [data-showcase-counter] [data-bn-counter-parity][data-parity='odd'] {
+    color: var(--info);
+  }
+  [data-showcase-counter] [data-bn-counter-parity][data-parity='even'] {
+    color: var(--success);
+  }
+
+  [data-bn-clock] {
+    display: inline-block;
+    padding: var(--space-sm) var(--space-md);
+    background: var(--surface-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    font-variant-numeric: tabular-nums;
+    font-size: 1.25rem;
+    color: var(--accent);
+  }
+
+  [data-showcase-package-grid] {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: var(--space-xl);
+  }
+  [data-bn-package-group] {
+    display: grid;
+    gap: var(--space-md);
+  }
+  [data-bn-package-group] > h3 {
+    margin: 0;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-2);
+  }
+  [data-bn-package-list] {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: var(--space-md);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+  }
+  [data-bn-package-card] {
+    display: grid;
+    gap: var(--space-xs);
+    padding: var(--space-md);
+    background: var(--surface-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    transition:
+      border-color var(--duration-fast) var(--ease-out-expo),
+      box-shadow var(--duration-fast) var(--ease-out-expo);
+  }
+  [data-bn-package-card]:hover {
+    border-color: var(--border-accent);
+    box-shadow: 0 0 0 1px var(--accent-glow);
+  }
+  [data-bn-package-card] code {
+    font-size: 0.85rem;
+    color: var(--accent);
+    font-weight: 500;
+    background: transparent;
+    padding: 0;
+  }
+  [data-bn-package-card] p {
+    margin: 0;
+    color: var(--text-1);
+    font-size: 0.875rem;
+  }
+
+  [data-bn='virtualizer'] {
+    background: var(--surface-1);
+  }
+  [data-bn='virtual-item'] {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding-inline: var(--space-md);
+    color: var(--text-0);
+  }
+  [data-bn='virtual-item']::before {
+    content: attr(data-index);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 2.5rem;
+    block-size: 1.25rem;
+    background: var(--surface-3);
+    color: var(--text-2);
+    border-radius: var(--radius-pill);
+    font-size: 0.75rem;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Tooltip popover positioning */
+  [data-bn='tooltip'][popover] {
+    background: var(--surface-3);
+    color: var(--text-0);
+    border: 1px solid var(--border-accent);
+    box-shadow: 0 8px 24px rgb(0 0 0 / 0.4);
+  }
+
+  /* Toast container surfaces */
+  [data-bn='toast-container'] [data-bn='toast'] {
+    background: var(--surface-2);
+    color: var(--text-0);
+    border-color: var(--border-accent);
+    box-shadow: 0 8px 24px rgb(0 0 0 / 0.45);
+    animation: bn-toast-in 0.25s var(--ease-out-back);
+  }
+  @keyframes bn-toast-in {
+    from {
+      opacity: 0;
+      transform: translateY(-8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 
   /* -- Component overrides for express theme -- */
-  [data-bn="button"] { min-block-size: 2.75rem; }
-  [data-bn="spinner"] > span { border-width: 3px; }
-  [data-bn="progress"] { block-size: var(--track-height, 0.375rem); }
-  [data-bn="progress"]::-webkit-progress-bar { background: var(--track-bg, var(--surface-2)); }
-  [data-bn="progress"]::-webkit-progress-value { background: var(--accent); }
-  [data-bn="progress"]::-moz-progress-bar { background: var(--accent); }
+  [data-bn='button'] {
+    min-block-size: 2.75rem;
+  }
+  [data-bn='spinner'] > span {
+    border-width: 3px;
+  }
+  [data-bn='progress'] {
+    block-size: var(--track-height, 0.375rem);
+  }
+  [data-bn='progress']::-webkit-progress-bar {
+    background: var(--track-bg, var(--surface-2));
+  }
+  [data-bn='progress']::-webkit-progress-value {
+    background: var(--accent);
+  }
+  [data-bn='progress']::-moz-progress-bar {
+    background: var(--accent);
+  }
 }

--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -4,22 +4,12 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { render } from '@basenative/server';
 import {
-  renderButton, renderBadge, renderAvatar,
-  renderInput, renderTextarea, renderSelect, renderCheckbox, renderRadioGroup, renderToggle,
-  renderCombobox, renderMultiselect,
-  renderAlert, renderProgress, renderSpinner, renderSkeleton,
-  renderCard, renderAccordion, renderTabs,
-  renderBreadcrumb, renderPagination,
-  renderTable, renderDataGrid,
-  renderDialog, renderDrawer, renderDropdownMenu, renderTooltip, renderCommandPalette,
-  renderTree, renderVirtualList, renderToastContainer,
-} from '../../packages/components/src/index.js';
-import {
   getComponentsPageContext,
   getHomePageContext,
   getTasksPageContext,
   navPages,
 } from './site-data.js';
+import { getShowcaseContext } from './showcase-data.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = join(__dirname, '..', '..');
@@ -53,7 +43,7 @@ function renderPage(viewFile, ctx, { title, scripts = '', activePage = '' }) {
   for (const page of navPages) {
     html = html.replace(
       `<!--${page.toUpperCase()}_ARIA-->`,
-      activePage === page ? 'aria-current="page"' : ''
+      activePage === page ? 'aria-current="page"' : '',
     );
   }
   return html;
@@ -85,7 +75,10 @@ app.get('/docs', (req, res) => {
 
 app.get('/components', (req, res) => {
   const ctx = getComponentsPageContext();
-  const html = renderPage('components.html', ctx, { title: 'Components', activePage: 'components' });
+  const html = renderPage('components.html', ctx, {
+    title: 'Components',
+    activePage: 'components',
+  });
   res.send(html);
 });
 
@@ -101,176 +94,11 @@ app.get('/test-signals', (req, res) => {
 });
 
 app.get('/showcase', (req, res) => {
-  const ctx = {
-    // Buttons
-    buttons: [
-      renderButton('Primary', { variant: 'primary' }),
-      renderButton('Secondary', { variant: 'secondary' }),
-      renderButton('Destructive', { variant: 'destructive' }),
-      renderButton('Ghost', { variant: 'ghost' }),
-      renderButton('Disabled', { variant: 'primary', disabled: true }),
-    ].join('\n'),
-
-    // Badges
-    badges: [
-      renderBadge('Default', { variant: 'default' }),
-      renderBadge('Primary', { variant: 'primary' }),
-      renderBadge('Success', { variant: 'success' }),
-      renderBadge('Warning', { variant: 'warning' }),
-      renderBadge('Error', { variant: 'error' }),
-    ].join('\n'),
-
-    // Avatars
-    avatars: [
-      renderAvatar({ name: 'Alice Johnson', size: 'sm' }),
-      renderAvatar({ name: 'Bob Smith' }),
-      renderAvatar({ name: 'Carol Davis', size: 'lg' }),
-      renderAvatar({ name: 'Dan Lee', size: 'xl' }),
-    ].join('\n'),
-
-    // Form controls
-    inputDefault: renderInput({ name: 'email', label: 'Email', type: 'email', placeholder: 'you@example.com', helpText: 'We will not share your email.' }),
-    inputError: renderInput({ name: 'username', label: 'Username', value: 'ab', error: 'Must be at least 3 characters' }),
-    textarea: renderTextarea({ name: 'bio', label: 'Bio', placeholder: 'Tell us about yourself...', rows: 3 }),
-    select: renderSelect({ name: 'role', label: 'Role', items: ['Admin', 'Editor', 'Viewer'], placeholder: 'Choose a role' }),
-    combobox: renderCombobox({ name: 'framework', label: 'Framework', items: ['Angular', 'React', 'Vue', 'Svelte', 'Solid'], placeholder: 'Search frameworks...' }),
-    multiselect: renderMultiselect({ name: 'tags', label: 'Tags', items: ['JavaScript', 'TypeScript', 'CSS', 'HTML', 'Node.js'], selected: ['JavaScript', 'CSS'] }),
-    checkbox: renderCheckbox({ name: 'terms', label: 'I agree to the terms and conditions' }),
-    radioGroup: renderRadioGroup({ name: 'plan', label: 'Plan', items: ['Free', 'Pro', 'Enterprise'], selected: 'Pro' }),
-    toggle: renderToggle({ name: 'notifications', label: 'Email notifications', checked: true }),
-
-    // Feedback
-    alertInfo: renderAlert('This is an informational message.', { variant: 'info' }),
-    alertSuccess: renderAlert('Operation completed successfully.', { variant: 'success' }),
-    alertWarning: renderAlert('Proceed with caution.', { variant: 'warning' }),
-    alertError: renderAlert('Something went wrong.', { variant: 'error', dismissible: true }),
-    progress: renderProgress({ value: 65, max: 100, label: 'Upload progress' }),
-    spinner: renderSpinner({ label: 'Loading' }),
-    spinnerLg: renderSpinner({ size: 'lg', label: 'Loading' }),
-    skeleton: renderSkeleton({ width: '100%', height: '1rem', count: 3 }),
-
-    // Cards & layout
-    card: renderCard({ header: 'Card Title', body: '<p>Card body content with descriptive text about the feature or item being presented.</p>', footer: 'Updated 2 hours ago' }),
-    accordion: renderAccordion({ items: [
-      { title: 'What is BaseNative?', content: 'A lightweight signals-based runtime for native template elements with ~120 lines of client code.' },
-      { title: 'How does SSR work?', content: 'The server renderer evaluates @if, @for, @switch directives at request time and returns clean HTML.' },
-      { title: 'What about hydration?', content: 'The client hydrate() function walks the DOM tree, binds reactive expressions, and attaches event handlers.' },
-    ] }),
-    tabs: renderTabs({ tabs: [
-      { id: 'overview', label: 'Overview', content: '<p>BaseNative brings Angular-inspired control flow to native template elements.</p>' },
-      { id: 'features', label: 'Features', content: '<p>Signals, computed values, effects, SSR, hydration, and template directives.</p>' },
-      { id: 'api', label: 'API', content: '<p>signal(), computed(), effect(), hydrate(), render().</p>' },
-    ] }),
-
-    // Navigation
-    breadcrumb: renderBreadcrumb({ items: [
-      { label: 'Home', href: '/' },
-      { label: 'Components', href: '/components' },
-      { label: 'Showcase' },
-    ] }),
-    pagination: renderPagination({ currentPage: 3, totalPages: 10, baseUrl: '/showcase' }),
-
-    // Data
-    table: renderTable({
-      columns: [
-        { key: 'name', label: 'Name' },
-        { key: 'role', label: 'Role' },
-        { key: 'status', label: 'Status' },
-      ],
-      rows: [
-        { name: 'Alice Johnson', role: 'Admin', status: 'Active' },
-        { name: 'Bob Smith', role: 'Editor', status: 'Active' },
-        { name: 'Carol Davis', role: 'Viewer', status: 'Inactive' },
-      ],
-      caption: 'Team members',
-    }),
-    datagrid: renderDataGrid({
-      columns: [
-        { key: 'task', label: 'Task', sortable: true },
-        { key: 'assignee', label: 'Assignee', sortable: true },
-        { key: 'priority', label: 'Priority' },
-        { key: 'status', label: 'Status' },
-      ],
-      rows: [
-        { id: 1, task: 'Design token system', assignee: 'Alice', priority: 'High', status: 'Done' },
-        { id: 2, task: 'Signal reactivity', assignee: 'Bob', priority: 'High', status: 'Done' },
-        { id: 3, task: 'Server rendering', assignee: 'Carol', priority: 'Medium', status: 'Active' },
-        { id: 4, task: 'Client hydration', assignee: 'Dan', priority: 'Medium', status: 'Pending' },
-        { id: 5, task: 'Component library', assignee: 'Alice', priority: 'Low', status: 'Active' },
-      ],
-      sortBy: 'task',
-      sortDir: 'asc',
-      selectable: true,
-      caption: 'Project tasks',
-    }),
-    tree: renderTree({
-      items: [
-        { id: '1', label: 'src', icon: '\u{1F4C1}', children: [
-          { id: '1-1', label: 'runtime', icon: '\u{1F4C1}', children: [
-            { id: '1-1-1', label: 'signals.js', icon: '\u{1F4C4}' },
-            { id: '1-1-2', label: 'hydrate.js', icon: '\u{1F4C4}' },
-            { id: '1-1-3', label: 'bind.js', icon: '\u{1F4C4}' },
-          ]},
-          { id: '1-2', label: 'server', icon: '\u{1F4C1}', children: [
-            { id: '1-2-1', label: 'render.js', icon: '\u{1F4C4}' },
-          ]},
-        ]},
-        { id: '2', label: 'examples', icon: '\u{1F4C1}', children: [
-          { id: '2-1', label: 'express', icon: '\u{1F4C1}' },
-          { id: '2-2', label: 'enterprise', icon: '\u{1F4C1}' },
-        ]},
-      ],
-      expanded: new Set(['1', '1-1']),
-      selected: '1-1-1',
-    }),
-    virtualList: renderVirtualList({
-      items: Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`),
-      itemHeight: 40,
-      containerHeight: 200,
-    }),
-
-    // Overlays
-    dialog: renderDialog({
-      title: 'Confirm Action',
-      content: '<p>Are you sure you want to proceed? This action cannot be undone.</p>',
-      footer: renderButton('Cancel', { variant: 'secondary' }) + renderButton('Confirm', { variant: 'primary' }),
-      id: 'demo-dialog',
-    }),
-    drawer: renderDrawer({
-      title: 'Settings',
-      content: '<p>Drawer body content goes here. This slides in from the edge of the viewport.</p>',
-      position: 'right',
-      id: 'demo-drawer',
-    }),
-    dropdown: renderDropdownMenu({
-      trigger: 'Actions',
-      items: [
-        { label: 'Edit', action: 'edit', icon: '\u{270F}\u{FE0F}' },
-        { label: 'Duplicate', action: 'duplicate', icon: '\u{1F4CB}' },
-        { separator: true },
-        { label: 'Delete', action: 'delete', icon: '\u{1F5D1}\u{FE0F}' },
-      ],
-    }),
-    tooltip: renderTooltip({
-      trigger: 'Hover me',
-      content: 'This is a tooltip with helpful context',
-      position: 'top',
-    }),
-    commandPalette: renderCommandPalette({
-      commands: [
-        { label: 'Go to Home', action: 'home', group: 'Navigation', icon: '\u{1F3E0}' },
-        { label: 'Go to Tasks', action: 'tasks', group: 'Navigation', icon: '\u{2705}' },
-        { label: 'New Task', action: 'new-task', group: 'Actions', icon: '\u{2795}', shortcut: 'Ctrl+N' },
-        { label: 'Search', action: 'search', group: 'Actions', icon: '\u{1F50D}', shortcut: 'Ctrl+K' },
-      ],
-      id: 'demo-cmd',
-    }),
-
-    toastContainer: renderToastContainer('top-right'),
-  };
+  const ctx = getShowcaseContext();
   const html = renderPage('showcase.html', ctx, { title: 'Showcase', activePage: 'showcase' });
   res.send(html);
 });
+
 
 // -- API --
 
@@ -286,7 +114,7 @@ app.post('/api/tasks', (req, res) => {
 
 app.delete('/api/tasks/:id', (req, res) => {
   const id = parseInt(req.params.id, 10);
-  const idx = tasks.findIndex(t => t.id === id);
+  const idx = tasks.findIndex((t) => t.id === id);
   if (idx === -1) return res.status(404).json({ error: 'not found' });
   tasks.splice(idx, 1);
   res.status(204).end();
@@ -322,7 +150,9 @@ const watchDirs = [
 for (const dir of watchDirs) {
   try {
     watch(dir, { recursive: true }, () => notifyReload());
-  } catch { /* dir may not exist in CI */ }
+  } catch {
+    /* dir may not exist in CI */
+  }
 }
 
 const PORT = process.env.PORT || 3000;

--- a/examples/express/showcase-data.js
+++ b/examples/express/showcase-data.js
@@ -1,0 +1,644 @@
+import {
+  renderButton,
+  renderBadge,
+  renderAvatar,
+  renderInput,
+  renderTextarea,
+  renderSelect,
+  renderCheckbox,
+  renderRadioGroup,
+  renderToggle,
+  renderCombobox,
+  renderMultiselect,
+  renderAlert,
+  renderProgress,
+  renderSpinner,
+  renderSkeleton,
+  renderCard,
+  renderAccordion,
+  renderTabs,
+  renderBreadcrumb,
+  renderPagination,
+  renderTable,
+  renderDataGrid,
+  renderDialog,
+  renderDrawer,
+  renderDropdownMenu,
+  renderTooltip,
+  renderCommandPalette,
+  renderTree,
+  renderVirtualList,
+  renderToastContainer,
+  renderCalendar,
+  renderPipeline,
+  renderLayoutGrid,
+} from '../../packages/components/src/index.js';
+
+export const PACKAGES = [
+  {
+    name: '@basenative/runtime',
+    tag: 'core',
+    summary: 'Signal-based web runtime over native HTML — zero build step, ~5KB gzipped.',
+  },
+  {
+    name: '@basenative/server',
+    tag: 'core',
+    summary: 'Server-side rendering with @if / @for / @switch evaluation and streaming.',
+  },
+  {
+    name: '@basenative/router',
+    tag: 'core',
+    summary: 'SSR-aware path routing with named params, wildcards, and history API.',
+  },
+  {
+    name: '@basenative/forms',
+    tag: 'core',
+    summary: 'Signal-based form state with dirty / touched tracking and schema adapters.',
+  },
+  {
+    name: '@basenative/components',
+    tag: 'ui',
+    summary: '25+ semantic UI components with CSS-custom-property theming.',
+  },
+  {
+    name: '@basenative/markdown',
+    tag: 'ui',
+    summary: 'Zero-dependency ESM markdown parser and SSR-safe HTML renderer.',
+  },
+  {
+    name: '@basenative/visual-builder',
+    tag: 'ui',
+    summary: 'Drag-and-drop component builder — composes layouts, generates BaseNative code.',
+  },
+  {
+    name: '@basenative/builder',
+    tag: 'ui',
+    summary: 'Signal-based drag-and-drop component builder runtime for layout editors.',
+  },
+  {
+    name: '@basenative/keyboard',
+    tag: 'ui',
+    summary: 'Layout-agnostic on-screen virtual keyboard primitive — themable and signal-driven.',
+  },
+  {
+    name: '@basenative/icons',
+    tag: 'ui',
+    summary: 'Icon system with the curated SVG set used by BaseNative components.',
+  },
+  {
+    name: '@basenative/fonts',
+    tag: 'ui',
+    summary: 'Font-loading utilities and the bundled Inter font for theme.css.',
+  },
+  {
+    name: '@basenative/favicon',
+    tag: 'ui',
+    summary: 'SVG-first favicon generator: maskable, manifest, and apple-touch-icon tags.',
+  },
+  {
+    name: '@basenative/auth',
+    tag: 'data',
+    summary: 'Sessions, RBAC, password hashing, OAuth2/OIDC.',
+  },
+  {
+    name: '@basenative/auth-webauthn',
+    tag: 'data',
+    summary: 'Passkey adapter for @basenative/auth — Workers/Pages handlers included.',
+  },
+  {
+    name: '@basenative/db',
+    tag: 'data',
+    summary: 'Query builder with SQLite, Postgres, and Cloudflare D1 adapters.',
+  },
+  {
+    name: '@basenative/middleware',
+    tag: 'data',
+    summary: 'CORS, rate-limit, CSRF, and signal-aware request adapters.',
+  },
+  {
+    name: '@basenative/tenant',
+    tag: 'data',
+    summary: 'Multi-tenant middleware with subdomain resolution and row-level scoping.',
+  },
+  {
+    name: '@basenative/upload',
+    tag: 'data',
+    summary: 'File upload handling with R2 and S3 adapters.',
+  },
+  {
+    name: '@basenative/persist',
+    tag: 'data',
+    summary: 'Signal-driven local persistence with TTL and conflict resolution.',
+  },
+  {
+    name: '@basenative/realtime',
+    tag: 'data',
+    summary: 'SSE + WebSocket connections exposed as reactive signals.',
+  },
+  {
+    name: '@basenative/fetch',
+    tag: 'data',
+    summary: 'Signal-based resource fetching with cache and SSR preload.',
+  },
+  {
+    name: '@basenative/notify',
+    tag: 'data',
+    summary: 'Email via SMTP and SendGrid with template rendering.',
+  },
+  {
+    name: '@basenative/i18n',
+    tag: 'data',
+    summary: 'ICU messages, locale detection, and the @t template directive.',
+  },
+  {
+    name: '@basenative/date',
+    tag: 'data',
+    summary: 'Date utilities, timezone handling, and relative time formatting.',
+  },
+  {
+    name: '@basenative/flags',
+    tag: 'data',
+    summary: 'Feature flags with percentage rollouts and the @feature directive.',
+  },
+  {
+    name: '@basenative/logger',
+    tag: 'data',
+    summary: 'Structured logging with multiple transports and child loggers.',
+  },
+  {
+    name: '@basenative/config',
+    tag: 'data',
+    summary: 'Type-safe environment configuration loading and validation.',
+  },
+  {
+    name: '@basenative/integrations',
+    tag: 'data',
+    summary: 'Headless wrappers for Plaid, Stripe, and other third parties.',
+  },
+  {
+    name: '@basenative/share',
+    tag: 'data',
+    summary: 'Web Share API with clipboard fallback and OG-redirect landing pages.',
+  },
+  {
+    name: '@basenative/og-image',
+    tag: 'data',
+    summary: 'Worker-runtime OG / social-share PNG renderer with KV-cached fonts.',
+  },
+  {
+    name: '@basenative/admin',
+    tag: 'data',
+    summary: 'Pluggable admin / moderation surface — protected routes, audit log.',
+  },
+  {
+    name: '@basenative/marketplace',
+    tag: 'data',
+    summary: 'Community component marketplace runtime and registry helpers.',
+  },
+  {
+    name: '@basenative/station',
+    tag: 'data',
+    summary: 'Queue-driven local-inference primitive with vLLM + Workers AI fallback.',
+  },
+  {
+    name: '@basenative/cli',
+    tag: 'tools',
+    summary: 'The bn CLI — create, prd, speckit, gh, nx, deploy, doctor.',
+  },
+  {
+    name: '@basenative/claude-config',
+    tag: 'tools',
+    summary: 'Bundled Claude Code subagents, skills, and slash commands.',
+  },
+  {
+    name: '@basenative/doppler',
+    tag: 'tools',
+    summary: 'Thin DX layer around Doppler — local-dev wrapper, CI helper, validation.',
+  },
+  {
+    name: '@basenative/wrangler-preset',
+    tag: 'tools',
+    summary: 'Pinned Wrangler version + typed wrangler.toml fragment generator.',
+  },
+  {
+    name: '@basenative/eslint-config',
+    tag: 'tools',
+    summary: 'Shared ESLint flat-config — security, hygiene, zero-noise defaults.',
+  },
+  {
+    name: '@basenative/tsconfig',
+    tag: 'tools',
+    summary: 'Shared base tsconfigs — strict, modern, runtime-targeted.',
+  },
+];
+
+const PACKAGE_GROUPS = [
+  { tag: 'core', label: 'Runtime core' },
+  { tag: 'ui', label: 'UI & rendering' },
+  { tag: 'data', label: 'Data, auth & infra' },
+  { tag: 'tools', label: 'Tooling & DX' },
+];
+
+function renderPackageCards() {
+  const groupHtml = PACKAGE_GROUPS.map((group) => {
+    const cards = PACKAGES.filter((p) => p.tag === group.tag)
+      .map(
+        (p) => `<li data-bn-package-card data-tag="${p.tag}">
+  <code>${p.name}</code>
+  <p>${p.summary}</p>
+</li>`,
+      )
+      .join('');
+    return `<li data-bn-package-group>
+  <h3>${group.label}</h3>
+  <ul data-bn-package-list>${cards}</ul>
+</li>`;
+  }).join('');
+  return groupHtml;
+}
+
+function calendarStartOfWeek() {
+  const d = new Date();
+  const day = d.getDay();
+  d.setDate(d.getDate() - day);
+  d.setHours(0, 0, 0, 0);
+  return d.toISOString().split('T')[0];
+}
+
+function calendarEvents(startDate) {
+  const base = new Date(startDate);
+  const isoAt = (offsetDays, hour, minute = 0) => {
+    const d = new Date(base);
+    d.setDate(d.getDate() + offsetDays);
+    d.setHours(hour, minute, 0, 0);
+    return d.toISOString().slice(0, 16);
+  };
+  return [
+    {
+      id: 'e1',
+      title: 'Sprint review',
+      start: isoAt(1, 9, 0),
+      end: isoAt(1, 10, 30),
+      status: 'scheduled',
+      assignee: 'Alice',
+    },
+    {
+      id: 'e2',
+      title: 'Customer call: Greenput',
+      start: isoAt(2, 13, 0),
+      end: isoAt(2, 14, 0),
+      status: 'in_progress',
+      assignee: 'Bob',
+    },
+    {
+      id: 'e3',
+      title: 'Release cut',
+      start: isoAt(4, 16, 0),
+      end: isoAt(4, 17, 0),
+      status: 'completed',
+      assignee: 'Carol',
+    },
+    {
+      id: 'e4',
+      title: 'Office hours',
+      start: isoAt(5, 11, 0),
+      end: isoAt(5, 12, 0),
+      status: 'scheduled',
+      assignee: 'Dan',
+    },
+  ];
+}
+
+export function getShowcaseContext() {
+  const startDate = calendarStartOfWeek();
+
+  return {
+    buttons: [
+      renderButton('Primary', { variant: 'primary' }),
+      renderButton('Secondary', { variant: 'secondary' }),
+      renderButton('Destructive', { variant: 'destructive' }),
+      renderButton('Ghost', { variant: 'ghost' }),
+      renderButton('Disabled', { variant: 'primary', disabled: true }),
+    ].join('\n'),
+    badges: [
+      renderBadge('Default', { variant: 'default' }),
+      renderBadge('Primary', { variant: 'primary' }),
+      renderBadge('Success', { variant: 'success' }),
+      renderBadge('Warning', { variant: 'warning' }),
+      renderBadge('Error', { variant: 'error' }),
+    ].join('\n'),
+    avatars: [
+      renderAvatar({ name: 'Alice Johnson', size: 'sm' }),
+      renderAvatar({ name: 'Bob Smith' }),
+      renderAvatar({ name: 'Carol Davis', size: 'lg' }),
+      renderAvatar({ name: 'Dan Lee', size: 'xl' }),
+    ].join('\n'),
+
+    inputDefault: renderInput({
+      name: 'email',
+      label: 'Email',
+      type: 'email',
+      placeholder: 'you@example.com',
+      helpText: 'We will not share your email.',
+    }),
+    inputError: renderInput({
+      name: 'username',
+      label: 'Username',
+      value: 'ab',
+      error: 'Must be at least 3 characters',
+    }),
+    textarea: renderTextarea({
+      name: 'bio',
+      label: 'Bio',
+      placeholder: 'Tell us about yourself...',
+      rows: 3,
+    }),
+    select: renderSelect({
+      name: 'role',
+      label: 'Role',
+      items: ['Admin', 'Editor', 'Viewer'],
+      placeholder: 'Choose a role',
+    }),
+    combobox: renderCombobox({
+      name: 'framework',
+      label: 'Framework',
+      items: ['Angular', 'React', 'Vue', 'Svelte', 'Solid'],
+      placeholder: 'Search frameworks...',
+    }),
+    multiselect: renderMultiselect({
+      name: 'tags',
+      label: 'Tags',
+      items: ['JavaScript', 'TypeScript', 'CSS', 'HTML', 'Node.js'],
+      selected: ['JavaScript', 'CSS'],
+    }),
+    checkbox: renderCheckbox({ name: 'terms', label: 'I agree to the terms and conditions' }),
+    radioGroup: renderRadioGroup({
+      name: 'plan',
+      label: 'Plan',
+      items: ['Free', 'Pro', 'Enterprise'],
+      selected: 'Pro',
+    }),
+    toggle: renderToggle({ name: 'notifications', label: 'Email notifications', checked: true }),
+
+    alertInfo: renderAlert('This is an informational message.', { variant: 'info' }),
+    alertSuccess: renderAlert('Operation completed successfully.', { variant: 'success' }),
+    alertWarning: renderAlert('Proceed with caution.', { variant: 'warning' }),
+    alertError: renderAlert('Something went wrong.', { variant: 'error', dismissible: true }),
+    progress: renderProgress({ value: 65, max: 100, label: 'Upload progress' }),
+    spinner: renderSpinner({ label: 'Loading' }),
+    spinnerLg: renderSpinner({ size: 'lg', label: 'Loading' }),
+    skeleton: renderSkeleton({ width: '100%', height: '1rem', count: 3 }),
+
+    card: renderCard({
+      header: 'Card Title',
+      body: '<p>Card body content with descriptive text about the feature or item being presented.</p>',
+      footer: 'Updated 2 hours ago',
+    }),
+    accordion: renderAccordion({
+      items: [
+        {
+          title: 'What is BaseNative?',
+          content:
+            'A lightweight signals-based runtime for native template elements with ~120 lines of client code.',
+        },
+        {
+          title: 'How does SSR work?',
+          content:
+            'The server renderer evaluates @if, @for, @switch directives at request time and returns clean HTML.',
+        },
+        {
+          title: 'What about hydration?',
+          content:
+            'The client hydrate() function walks the DOM tree, binds reactive expressions, and attaches event handlers.',
+        },
+      ],
+    }),
+    tabs: renderTabs({
+      tabs: [
+        {
+          id: 'overview',
+          label: 'Overview',
+          content:
+            '<p>BaseNative brings Angular-inspired control flow to native template elements.</p>',
+        },
+        {
+          id: 'features',
+          label: 'Features',
+          content:
+            '<p>Signals, computed values, effects, SSR, hydration, and template directives.</p>',
+        },
+        {
+          id: 'api',
+          label: 'API',
+          content:
+            '<p><code>signal()</code>, <code>computed()</code>, <code>effect()</code>, <code>hydrate()</code>, <code>render()</code>.</p>',
+        },
+      ],
+    }),
+    layoutGrid: renderLayoutGrid({
+      id: 'showcase-layout-grid',
+      columns: 6,
+      gap: '0.75rem',
+      cells: [
+        { id: 'g1', label: 'Header', colSpan: 6 },
+        { id: 'g2', label: 'Sidebar', colSpan: 2, rowSpan: 2 },
+        { id: 'g3', label: 'Main content', colSpan: 4 },
+        { id: 'g4', label: 'Aside', colSpan: 4 },
+        { id: 'g5', label: 'Footer', colSpan: 6 },
+      ],
+    }),
+
+    breadcrumb: renderBreadcrumb({
+      items: [
+        { label: 'Home', href: '/' },
+        { label: 'Components', href: '/components' },
+        { label: 'Showcase' },
+      ],
+    }),
+    pagination: renderPagination({ currentPage: 3, totalPages: 10, baseUrl: '/showcase' }),
+
+    table: renderTable({
+      columns: [
+        { key: 'name', label: 'Name' },
+        { key: 'role', label: 'Role' },
+        { key: 'status', label: 'Status' },
+      ],
+      rows: [
+        { name: 'Alice Johnson', role: 'Admin', status: 'Active' },
+        { name: 'Bob Smith', role: 'Editor', status: 'Active' },
+        { name: 'Carol Davis', role: 'Viewer', status: 'Inactive' },
+      ],
+      caption: 'Team members',
+    }),
+    datagrid: renderDataGrid({
+      columns: [
+        { key: 'task', label: 'Task', sortable: true },
+        { key: 'assignee', label: 'Assignee', sortable: true },
+        { key: 'priority', label: 'Priority' },
+        { key: 'status', label: 'Status' },
+      ],
+      rows: [
+        { id: 1, task: 'Design token system', assignee: 'Alice', priority: 'High', status: 'Done' },
+        { id: 2, task: 'Signal reactivity', assignee: 'Bob', priority: 'High', status: 'Done' },
+        {
+          id: 3,
+          task: 'Server rendering',
+          assignee: 'Carol',
+          priority: 'Medium',
+          status: 'Active',
+        },
+        { id: 4, task: 'Client hydration', assignee: 'Dan', priority: 'Medium', status: 'Pending' },
+        { id: 5, task: 'Component library', assignee: 'Alice', priority: 'Low', status: 'Active' },
+      ],
+      sortBy: 'task',
+      sortDir: 'asc',
+      selectable: true,
+      caption: 'Project tasks',
+    }),
+    tree: renderTree({
+      items: [
+        {
+          id: '1',
+          label: 'src',
+          icon: '\u{1F4C1}',
+          children: [
+            {
+              id: '1-1',
+              label: 'runtime',
+              icon: '\u{1F4C1}',
+              children: [
+                { id: '1-1-1', label: 'signals.js', icon: '\u{1F4C4}' },
+                { id: '1-1-2', label: 'hydrate.js', icon: '\u{1F4C4}' },
+                { id: '1-1-3', label: 'bind.js', icon: '\u{1F4C4}' },
+              ],
+            },
+            {
+              id: '1-2',
+              label: 'server',
+              icon: '\u{1F4C1}',
+              children: [{ id: '1-2-1', label: 'render.js', icon: '\u{1F4C4}' }],
+            },
+          ],
+        },
+        {
+          id: '2',
+          label: 'examples',
+          icon: '\u{1F4C1}',
+          children: [
+            { id: '2-1', label: 'express', icon: '\u{1F4C1}' },
+            { id: '2-2', label: 'enterprise', icon: '\u{1F4C1}' },
+          ],
+        },
+      ],
+      expanded: new Set(['1', '1-1']),
+      selected: '1-1-1',
+    }),
+    virtualList: renderVirtualList({
+      items: Array.from(
+        { length: 200 },
+        (_, i) => `Row ${i + 1} — generated server-side, scrolled client-side`,
+      ),
+      itemHeight: 44,
+      containerHeight: 240,
+    }),
+    calendar: renderCalendar({
+      startDate,
+      events: calendarEvents(startDate),
+      hours: { start: 8, end: 18 },
+    }),
+    pipeline: renderPipeline({
+      columns: [
+        { id: 'todo', title: 'Todo' },
+        { id: 'doing', title: 'In progress' },
+        { id: 'done', title: 'Done' },
+      ],
+      cards: [
+        {
+          id: 'c1',
+          columnId: 'todo',
+          title: 'Wire showcase hydration',
+          subtitle: 'web',
+          status: 'scheduled',
+        },
+        { id: 'c2', columnId: 'todo', title: 'Audit page navigation', subtitle: 'web' },
+        {
+          id: 'c3',
+          columnId: 'doing',
+          title: 'Render every package',
+          subtitle: 'docs',
+          description: 'Cards for all 30+ @basenative/* packages.',
+        },
+        {
+          id: 'c4',
+          columnId: 'done',
+          title: 'Fix Open dialog handler',
+          subtitle: 'overlay',
+          status: 'completed',
+        },
+        {
+          id: 'c5',
+          columnId: 'done',
+          title: 'Tooltip hover',
+          subtitle: 'overlay',
+          status: 'completed',
+        },
+      ],
+    }),
+
+    dialog: renderDialog({
+      title: 'Confirm Action',
+      content: '<p>Are you sure you want to proceed? This action cannot be undone.</p>',
+      footer:
+        renderButton('Cancel', { variant: 'secondary' }) +
+        renderButton('Confirm', { variant: 'primary' }),
+      id: 'demo-dialog',
+    }),
+    drawer: renderDrawer({
+      title: 'Settings',
+      content:
+        '<p>Drawer body content goes here. This slides in from the edge of the viewport.</p>',
+      position: 'right',
+      id: 'demo-drawer',
+    }),
+    dropdown: renderDropdownMenu({
+      trigger: 'Actions',
+      items: [
+        { label: 'Edit', action: 'edit', icon: '\u{270F}\u{FE0F}' },
+        { label: 'Duplicate', action: 'duplicate', icon: '\u{1F4CB}' },
+        { separator: true },
+        { label: 'Delete', action: 'delete', icon: '\u{1F5D1}\u{FE0F}' },
+      ],
+    }),
+    tooltip: renderTooltip({
+      trigger: 'Hover me',
+      content: 'This is a tooltip with helpful context. Triggers on hover or focus.',
+      position: 'top',
+    }),
+    commandPalette: renderCommandPalette({
+      commands: [
+        { label: 'Go to Home', action: 'home', group: 'Navigation', icon: '\u{1F3E0}' },
+        { label: 'Go to Tasks', action: 'tasks', group: 'Navigation', icon: '\u{2705}' },
+        {
+          label: 'New Task',
+          action: 'new-task',
+          group: 'Actions',
+          icon: '\u{2795}',
+          shortcut: 'Ctrl+N',
+        },
+        {
+          label: 'Search',
+          action: 'search',
+          group: 'Actions',
+          icon: '\u{1F50D}',
+          shortcut: 'Ctrl+K',
+        },
+      ],
+      id: 'demo-cmd',
+    }),
+
+    toastContainer: renderToastContainer('top-right'),
+
+    packageCount: PACKAGES.length,
+    packageCards: renderPackageCards(),
+  };
+}

--- a/examples/express/site-data.js
+++ b/examples/express/site-data.js
@@ -48,28 +48,31 @@ export function getComponentsPageContext() {
     readinessStats: [
       { label: 'Current Milestone', value: 'v0.4+' },
       { label: 'Browser Support', value: '4 engines' },
-      { label: 'Public Packages', value: '5' },
+      { label: 'Public Packages', value: '39' },
       { label: 'Advanced Widgets', value: 'Shipped' },
     ],
     releaseStages: [
       {
         milestone: 'v0.2',
         focus: 'Trust blockers',
-        outcome: 'CSP-safe expressions, keyed reconciliation, hydration diagnostics, browser feature helpers, honest docs.',
+        outcome:
+          'CSP-safe expressions, keyed reconciliation, hydration diagnostics, browser feature helpers, honest docs.',
         status: 'Implemented',
         tone: 'done',
       },
       {
         milestone: 'v0.3',
         focus: 'Pilot baseline',
-        outcome: 'Router, forms, semantic component baseline, reference business app, edge deployment example, published metrics.',
+        outcome:
+          'Router, forms, semantic component baseline, reference business app, edge deployment example, published metrics.',
         status: 'Implemented',
         tone: 'done',
       },
       {
         milestone: 'v0.4+',
         focus: 'Workflow breadth',
-        outcome: 'Dialog, drawer, menu, tabs, shell navigation, loading states, and DX hardening after pilot evidence is green.',
+        outcome:
+          'Dialog, drawer, menu, tabs, shell navigation, loading states, and DX hardening after pilot evidence is green.',
         status: 'Implemented',
         tone: 'done',
       },
@@ -79,25 +82,29 @@ export function getComponentsPageContext() {
         item: 'Template evaluation',
         state: 'Done',
         tone: 'done',
-        notes: 'Client and server now share a constrained expression parser/interpreter instead of eval-like execution.',
+        notes:
+          'Client and server now share a constrained expression parser/interpreter instead of eval-like execution.',
       },
       {
         item: '@for track identity',
         state: 'Done',
         tone: 'done',
-        notes: 'Keyed reconciliation preserves DOM segments and supports reorder behavior needed for business UIs.',
+        notes:
+          'Keyed reconciliation preserves DOM segments and supports reorder behavior needed for business UIs.',
       },
       {
         item: 'Hydration diagnostics',
         state: 'Done',
         tone: 'done',
-        notes: 'Hydration now exposes mismatch reporting hooks and deterministic markers for SSR handoff.',
+        notes:
+          'Hydration now exposes mismatch reporting hooks and deterministic markers for SSR handoff.',
       },
       {
         item: 'Browser capability policy',
         state: 'Done',
         tone: 'done',
-        notes: 'Dialog, popover, anchor positioning, and base-select are detected centrally with documented fallbacks.',
+        notes:
+          'Dialog, popover, anchor positioning, and base-select are detected centrally with documented fallbacks.',
       },
     ],
     packageSurface: [
@@ -137,31 +144,36 @@ export function getComponentsPageContext() {
         category: 'SSR and hydration',
         status: 'Ready',
         tone: 'done',
-        detail: 'Server rendering and client hydration are in place with diagnostics and keyed updates.',
+        detail:
+          'Server rendering and client hydration are in place with diagnostics and keyed updates.',
       },
       {
         category: 'Forms and validation',
         status: 'Ready',
         tone: 'done',
-        detail: 'Field system, validation primitives, form orchestration, and schema adapters are implemented.',
+        detail:
+          'Field system, validation primitives, form orchestration, and schema adapters are implemented.',
       },
       {
         category: 'Routing and layouts',
         status: 'Ready',
         tone: 'done',
-        detail: 'Client-side routing, SSR-aware resolution, pattern matching, and link interception are implemented.',
+        detail:
+          'Client-side routing, SSR-aware resolution, pattern matching, and link interception are implemented.',
       },
       {
         category: 'Async data and errors',
         status: 'Ready',
         tone: 'done',
-        detail: 'Runtime is the home for resources, diagnostics, and global error surfaces in v0.x.',
+        detail:
+          'Runtime is the home for resources, diagnostics, and global error surfaces in v0.x.',
       },
       {
         category: 'Accessibility and browser policy',
         status: 'Ready',
         tone: 'done',
-        detail: 'Browser support, fallbacks, semantic defaults, and component a11y contracts are documented and enforced.',
+        detail:
+          'Browser support, fallbacks, semantic defaults, and component a11y contracts are documented and enforced.',
       },
     ],
     p0Components: [
@@ -251,15 +263,18 @@ export function getComponentsPageContext() {
     deferredWork: [
       {
         item: 'Combobox, multiselect, date and time inputs',
-        reason: 'Implemented — combobox and multiselect shipped; date and time inputs planned for next cycle.',
+        reason:
+          'Implemented — combobox and multiselect shipped; date and time inputs planned for next cycle.',
       },
       {
         item: 'Tree, data grid, treegrid, virtualizer',
-        reason: 'Implemented — all four components shipped with keyboard support and virtual scroll.',
+        reason:
+          'Implemented — all four components shipped with keyboard support and virtual scroll.',
       },
       {
         item: 'Broad workflow widgets',
-        reason: 'Implemented — dialog, drawer, tabs, accordion, breadcrumb, tooltip, dropdown menu, and command palette shipped.',
+        reason:
+          'Implemented — dialog, drawer, tabs, accordion, breadcrumb, tooltip, dropdown menu, and command palette shipped.',
       },
     ],
   };

--- a/examples/express/views/components.html
+++ b/examples/express/views/components.html
@@ -1,6 +1,10 @@
 <section data-hero>
   <h2>Enterprise <em>Readiness</em></h2>
-  <p>BaseNative is a semantic SSR application foundation for evergreen browsers. Every milestone from trust blockers through workflow breadth is now implemented, with all packages, components, and advanced widgets shipped.</p>
+  <p>
+    BaseNative is a semantic SSR application foundation for evergreen browsers. Every milestone from
+    trust blockers through workflow breadth is now implemented, with all packages, components, and
+    advanced widgets shipped.
+  </p>
 </section>
 
 <section data-stats>
@@ -16,7 +20,11 @@
 
 <section>
   <h2>Release <em>Gates</em></h2>
-  <p>The roadmap is split into trust, pilot, and breadth milestones so enterprise workflows expand only after the core runtime proves it can hold up under SSR, hydration, and browser-policy constraints.</p>
+  <p>
+    The roadmap is split into trust, pilot, and breadth milestones so enterprise workflows expand
+    only after the core runtime proves it can hold up under SSR, hydration, and browser-policy
+    constraints.
+  </p>
 
   <article>
     <header><h3>Milestone plan</h3></header>
@@ -45,7 +53,10 @@
 
 <section>
   <h2>Trust <em>Blockers</em></h2>
-  <p>The first visible requirement for enterprise use was removing the unsafe and ambiguous parts of the runtime story. These are the core items that were addressed before broader package work.</p>
+  <p>
+    The first visible requirement for enterprise use was removing the unsafe and ambiguous parts of
+    the runtime story. These are the core items that were addressed before broader package work.
+  </p>
 
   <article>
     <header><h3>v0.2 trust release scope</h3></header>
@@ -72,7 +83,12 @@
 
 <section>
   <h2>Package <em>Surface</em></h2>
-  <p>The public API is kept deliberately small. Runtime, server, components, router, and forms are the five public packages — each with a clear responsibility and no sprawl of loosely defined exports.</p>
+  <p>
+    The public API is layered. Runtime, server, components, router, and forms are the headline core
+    — each with a clear responsibility. A wider
+    <a href="/showcase#packages">@basenative ecosystem</a> covers data, auth, realtime,
+    observability, and tooling.
+  </p>
 
   <article>
     <header><h3>Public packages</h3></header>
@@ -99,7 +115,10 @@
 
 <section>
   <h2>Workflow <em>Parity</em></h2>
-  <p>The target is not React or Angular component interop. The target is parity across the enterprise workflow categories teams actually rely on when shipping SSR business applications.</p>
+  <p>
+    The target is not React or Angular component interop. The target is parity across the enterprise
+    workflow categories teams actually rely on when shipping SSR business applications.
+  </p>
 
   <article>
     <header><h3>Enterprise workflow coverage</h3></header>
@@ -126,7 +145,11 @@
 
 <section>
   <h2>P0 Component <em>Baseline</em></h2>
-  <p>The first semantic component set is intentionally boring and business-focused: form foundations, feedback surfaces, and table-list primitives that cover the common full-stack app path before advanced widgets.</p>
+  <p>
+    The first semantic component set is intentionally boring and business-focused: form foundations,
+    feedback surfaces, and table-list primitives that cover the common full-stack app path before
+    advanced widgets.
+  </p>
 
   <article>
     <header><h3>Pilot component order</h3></header>
@@ -155,7 +178,10 @@
 
 <section>
   <h2>Browser <em>Policy</em></h2>
-  <p>BaseNative is targeting current Chrome, Edge, Firefox, and Safari in <code>v0.x</code>. Newer platform APIs are used only when a documented fallback keeps the workflow intact.</p>
+  <p>
+    BaseNative is targeting current Chrome, Edge, Firefox, and Safari in <code>v0.x</code>. Newer
+    platform APIs are used only when a documented fallback keeps the workflow intact.
+  </p>
 
   <article>
     <header><h3>Capability and fallback matrix</h3></header>
@@ -182,7 +208,10 @@
 
 <section>
   <h2>Advanced <em>Widgets</em></h2>
-  <p>High-complexity widgets that were previously deferred are now implemented with CSP safety, accessibility contracts, keyboard support, and virtual scroll where applicable.</p>
+  <p>
+    High-complexity widgets that were previously deferred are now implemented with CSP safety,
+    accessibility contracts, keyboard support, and virtual scroll where applicable.
+  </p>
 
   <article>
     <header><h3>Explicitly deferred</h3></header>
@@ -209,11 +238,20 @@
   <h2>What This <em>Means</em></h2>
   <article>
     <header><h3>Current position</h3></header>
-    <p>BaseNative is a CSP-safe, SSR-first application foundation with a complete component library, forms system, client-side router, and full browser policy coverage. All trust, pilot, and breadth milestones are implemented.</p>
+    <p>
+      BaseNative is a CSP-safe, SSR-first application foundation with a complete component library,
+      forms system, client-side router, and full browser policy coverage. All trust, pilot, and
+      breadth milestones are implemented.
+    </p>
   </article>
 
   <article>
     <header><h3>What shipped</h3></header>
-    <p>Five public packages, eight pilot components, advanced widgets (dialog, drawer, tabs, tree, data grid, virtualizer, command palette), field system with validation, client-side routing with SSR resolution, and design tokens with density and theming support.</p>
+    <p>
+      Five core packages plus 30+ ecosystem packages, eight pilot components, advanced widgets
+      (dialog, drawer, tabs, tree, data grid, virtualizer, command palette), field system with
+      validation, client-side routing with SSR resolution, and design tokens with density and
+      theming support.
+    </p>
   </article>
 </section>

--- a/examples/express/views/showcase.html
+++ b/examples/express/views/showcase.html
@@ -1,90 +1,84 @@
 <section>
-  <h2>Component <em>Showcase</em></h2>
-  <p>Every component in the BaseNative design system, server-rendered and styled from the core CSS. Each section below is a live render call — no mockups.</p>
+  <hgroup data-showcase-hero>
+    <h2>Component <em>Showcase</em></h2>
+    <p>
+      Every component in the BaseNative design system, server-rendered and signal-hydrated. Every
+      section is a live render call &mdash; no mockups, no screenshots, no separate framework.
+    </p>
+  </hgroup>
+  <nav data-showcase-toc aria-label="Showcase sections">
+    <a href="#buttons">Buttons</a>
+    <a href="#badges">Badges</a>
+    <a href="#avatars">Avatars</a>
+    <a href="#forms">Forms</a>
+    <a href="#feedback">Feedback</a>
+    <a href="#layout">Layout</a>
+    <a href="#navigation">Navigation</a>
+    <a href="#data">Data</a>
+    <a href="#overlays">Overlays</a>
+    <a href="#runtime">Runtime</a>
+    <a href="#packages">Packages</a>
+  </nav>
 </section>
 
-<section>
+<section id="buttons">
   <h2>Buttons</h2>
   <article>
     <header><h3>Variants</h3></header>
-    <nav data-showcase-row>
-      {{ buttons }}
-    </nav>
+    <nav data-showcase-row>{{ buttons }}</nav>
   </article>
 </section>
 
-<section>
+<section id="badges">
   <h2>Badges</h2>
   <article>
     <header><h3>Variants</h3></header>
-    <nav data-showcase-row>
-      {{ badges }}
-    </nav>
+    <nav data-showcase-row>{{ badges }}</nav>
   </article>
 </section>
 
-<section>
+<section id="avatars">
   <h2>Avatars</h2>
   <article>
     <header><h3>Sizes and fallbacks</h3></header>
-    <nav data-showcase-row>
-      {{ avatars }}
-    </nav>
+    <nav data-showcase-row>{{ avatars }}</nav>
   </article>
 </section>
 
-<section>
+<section id="forms">
   <h2>Form <em>Controls</em></h2>
   <article>
     <header><h3>Inputs</h3></header>
-    <div data-showcase-form>
-      {{ inputDefault }}
-      {{ inputError }}
-    </div>
+    <div data-showcase-form>{{ inputDefault }} {{ inputError }}</div>
   </article>
   <article>
     <header><h3>Textarea</h3></header>
-    <div data-showcase-form>
-      {{ textarea }}
-    </div>
+    <div data-showcase-form>{{ textarea }}</div>
   </article>
   <article>
     <header><h3>Select</h3></header>
-    <div data-showcase-form>
-      {{ select }}
-    </div>
+    <div data-showcase-form>{{ select }}</div>
   </article>
   <article>
     <header><h3>Combobox</h3></header>
-    <div data-showcase-form>
-      {{ combobox }}
-    </div>
+    <div data-showcase-form>{{ combobox }}</div>
   </article>
   <article>
     <header><h3>Multiselect</h3></header>
-    <div data-showcase-form>
-      {{ multiselect }}
-    </div>
+    <div data-showcase-form>{{ multiselect }}</div>
   </article>
   <article>
     <header><h3>Checkbox, radio, toggle</h3></header>
-    <div data-showcase-form>
-      {{ checkbox }}
-      {{ radioGroup }}
-      {{ toggle }}
-    </div>
+    <div data-showcase-form>{{ checkbox }} {{ radioGroup }} {{ toggle }}</div>
   </article>
 </section>
 
-<section>
+<section id="feedback">
   <h2>Feedback</h2>
   <article>
     <header><h3>Alerts</h3></header>
     <div data-showcase-stack>
-      {{ alertInfo }}
-      {{ alertSuccess }}
-      {{ alertWarning }}
-      {{ alertError }}
+      {{ alertInfo }} {{ alertSuccess }} {{ alertWarning }} {{ alertError }}
     </div>
   </article>
   <article>
@@ -93,38 +87,72 @@
   </article>
   <article>
     <header><h3>Spinner</h3></header>
-    <nav data-showcase-row>
-      {{ spinner }}
-      {{ spinnerLg }}
-    </nav>
+    <nav data-showcase-row>{{ spinner }} {{ spinnerLg }}</nav>
   </article>
   <article>
     <header><h3>Skeleton</h3></header>
     {{ skeleton }}
   </article>
+  <article>
+    <header><h3>Toast</h3></header>
+    <p>Trigger a live toast notification from a signal-driven container.</p>
+    <nav data-showcase-row>
+      <button
+        data-bn="button"
+        data-variant="primary"
+        data-bn-action="toast"
+        data-bn-variant="success"
+        data-bn-message="Saved successfully"
+      >
+        Show success
+      </button>
+      <button
+        data-bn="button"
+        data-variant="secondary"
+        data-bn-action="toast"
+        data-bn-variant="info"
+        data-bn-message="New build available"
+      >
+        Show info
+      </button>
+      <button
+        data-bn="button"
+        data-variant="destructive"
+        data-bn-action="toast"
+        data-bn-variant="error"
+        data-bn-message="Failed to publish"
+      >
+        Show error
+      </button>
+    </nav>
+  </article>
 </section>
 
-<section>
+<section id="layout">
   <h2>Cards <em>&amp; Layout</em></h2>
   <article>
     <header><h3>Card</h3></header>
-    <div data-showcase-card>
-      {{ card }}
-    </div>
+    <div data-showcase-card>{{ card }}</div>
   </article>
   <article>
     <header><h3>Accordion</h3></header>
-    <div data-showcase-form>
-      {{ accordion }}
-    </div>
+    <div data-showcase-form>{{ accordion }}</div>
   </article>
   <article>
     <header><h3>Tabs</h3></header>
     {{ tabs }}
   </article>
+  <article>
+    <header><h3>Layout grid</h3></header>
+    <p>
+      From <code>@basenative/components</code>, a flex grid that wraps to a column on small
+      viewports.
+    </p>
+    {{ layoutGrid }}
+  </article>
 </section>
 
-<section>
+<section id="navigation">
   <h2>Navigation</h2>
   <article>
     <header><h3>Breadcrumb</h3></header>
@@ -136,7 +164,7 @@
   </article>
 </section>
 
-<section>
+<section id="data">
   <h2>Data</h2>
   <article>
     <header><h3>Table</h3></header>
@@ -148,28 +176,49 @@
   </article>
   <article>
     <header><h3>Tree</h3></header>
-    <div data-showcase-card>
-      {{ tree }}
-    </div>
+    <div data-showcase-card>{{ tree }}</div>
   </article>
   <article>
     <header><h3>Virtual list</h3></header>
-    <div data-showcase-form>
-      {{ virtualList }}
-    </div>
+    <p>50 rows server-rendered as a windowed slice; the rest hydrate on scroll.</p>
+    <div data-showcase-form>{{ virtualList }}</div>
+  </article>
+  <article>
+    <header><h3>Calendar</h3></header>
+    <p><code>@basenative/components/calendar</code> &mdash; week view with draggable events.</p>
+    {{ calendar }}
+  </article>
+  <article>
+    <header><h3>Pipeline (kanban)</h3></header>
+    <p><code>renderPipeline()</code> &mdash; status columns with draggable cards.</p>
+    {{ pipeline }}
   </article>
 </section>
 
-<section>
+<section id="overlays">
   <h2>Overlays</h2>
   <article>
     <header><h3>Dialog</h3></header>
-    <button data-bn="button" data-variant="secondary" onclick="document.getElementById('demo-dialog').showModal()">Open dialog</button>
+    <button
+      data-bn="button"
+      data-variant="secondary"
+      data-bn-action="open-dialog"
+      data-bn-target="demo-dialog"
+    >
+      Open dialog
+    </button>
     {{ dialog }}
   </article>
   <article>
     <header><h3>Drawer</h3></header>
-    <button data-bn="button" data-variant="secondary" onclick="openDrawer()">Open drawer</button>
+    <button
+      data-bn="button"
+      data-variant="secondary"
+      data-bn-action="open-drawer"
+      data-bn-target="demo-drawer"
+    >
+      Open drawer
+    </button>
     {{ drawer }}
   </article>
   <article>
@@ -182,54 +231,66 @@
   </article>
   <article>
     <header><h3>Command palette</h3></header>
-    <button data-bn="button" data-variant="secondary" onclick="document.getElementById('demo-cmd').showModal()">Open command palette</button>
+    <button
+      data-bn="button"
+      data-variant="secondary"
+      data-bn-action="open-command-palette"
+      data-bn-target="demo-cmd"
+    >
+      Open command palette
+    </button>
     {{ commandPalette }}
   </article>
 </section>
 
+<section id="runtime">
+  <h2>Runtime <em>Primitives</em></h2>
+  <article>
+    <header><h3>Counter (signal + effect)</h3></header>
+    <p>Live signal hydration. Increment and watch every dependent expression update.</p>
+    <div data-showcase-counter>
+      <button
+        data-bn="button"
+        data-variant="secondary"
+        data-bn-action="counter-dec"
+        aria-label="Decrement"
+      >
+        &minus;
+      </button>
+      <output data-bn-counter-value aria-live="polite">0</output>
+      <button
+        data-bn="button"
+        data-variant="primary"
+        data-bn-action="counter-inc"
+        aria-label="Increment"
+      >
+        +
+      </button>
+      <span data-bn-counter-doubled>doubled: 0</span>
+      <span data-bn-counter-parity>even</span>
+    </div>
+  </article>
+  <article>
+    <header><h3>Live clock (effect cleanup)</h3></header>
+    <p>
+      An <code>effect()</code> with a return cleanup runs on every tick and unsubscribes on
+      navigation.
+    </p>
+    <output data-bn-clock>&mdash;</output>
+  </article>
+</section>
+
+<section id="packages">
+  <h2>Packages <em>at a glance</em></h2>
+  <p>
+    BaseNative ships {{ packageCount }} <code>@basenative/*</code> packages. The runtime is the
+    heart, but the ecosystem covers servers, data, auth, realtime, observability, and tooling.
+  </p>
+  <ul data-showcase-package-grid>
+    {{ packageCards }}
+  </ul>
+</section>
+
 {{ toastContainer }}
 
-<script type="module">
-// -- Tabs --
-document.querySelectorAll('[data-bn="tab"]').forEach(tab => {
-  tab.addEventListener('click', () => {
-    const tabs = tab.closest('[data-bn="tabs"]');
-    tabs.querySelectorAll('[data-bn="tab"]').forEach(t => t.setAttribute('aria-selected', 'false'));
-    tabs.querySelectorAll('[data-bn="tab-panel"]').forEach(p => p.hidden = true);
-    tab.setAttribute('aria-selected', 'true');
-    const panel = tabs.querySelector('#' + tab.getAttribute('aria-controls'));
-    if (panel) panel.hidden = false;
-  });
-});
-
-// -- Accordion (native details/summary) --
-// Already interactive via native <details> — no JS needed
-
-// -- Dialog --
-document.querySelectorAll('[data-bn="dialog-close"]').forEach(btn => {
-  btn.addEventListener('click', () => btn.closest('[data-bn="dialog"]')?.close());
-});
-
-// -- Drawer --
-const drawer = document.getElementById('demo-drawer');
-const drawerOverlay = document.querySelector('[data-bn="drawer-overlay"]');
-function openDrawer() {
-  drawer?.setAttribute('data-open', '');
-  drawerOverlay?.removeAttribute('hidden');
-}
-function closeDrawer() {
-  drawer?.removeAttribute('data-open');
-  drawerOverlay?.setAttribute('hidden', '');
-}
-document.querySelector('[data-bn="drawer-close"]')?.addEventListener('click', closeDrawer);
-drawerOverlay?.addEventListener('click', closeDrawer);
-
-// -- Alert dismiss --
-document.querySelectorAll('[data-bn="alert-dismiss"]').forEach(btn => {
-  btn.addEventListener('click', () => btn.closest('[data-bn="alert"]')?.remove());
-});
-
-// -- Toast demo --
-import { signal, effect } from '/basenative.js';
-const toastCount = signal(0);
-</script>
+<script type="module" src="/showcase.js"></script>

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -7,23 +7,13 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { render } from '../packages/server/src/render.js';
 import {
-  renderButton, renderBadge, renderAvatar,
-  renderInput, renderTextarea, renderSelect, renderCheckbox, renderRadioGroup, renderToggle,
-  renderCombobox, renderMultiselect,
-  renderAlert, renderProgress, renderSpinner, renderSkeleton,
-  renderCard, renderAccordion, renderTabs,
-  renderBreadcrumb, renderPagination,
-  renderTable, renderDataGrid,
-  renderDialog, renderDrawer, renderDropdownMenu, renderTooltip, renderCommandPalette,
-  renderTree, renderVirtualList, renderToastContainer,
-} from '../packages/components/src/index.js';
-import {
   getComponentsPageContext,
   getHomePageContext,
   getTasksPageContext,
   navPages,
   staticTasks,
 } from '../examples/express/site-data.js';
+import { getShowcaseContext } from '../examples/express/showcase-data.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
@@ -43,7 +33,7 @@ function renderPage(viewFile, ctx, { title, scripts = '', activePage = '' }) {
   for (const page of navPages) {
     html = html.replace(
       `<!--${page.toUpperCase()}_ARIA-->`,
-      activePage === page ? 'aria-current="page"' : ''
+      activePage === page ? 'aria-current="page"' : '',
     );
   }
   return html;
@@ -107,155 +97,7 @@ const pages = {
     view: 'showcase.html',
     title: 'Showcase',
     activePage: 'showcase',
-    ctx: {
-      buttons: [
-        renderButton('Primary', { variant: 'primary' }),
-        renderButton('Secondary', { variant: 'secondary' }),
-        renderButton('Destructive', { variant: 'destructive' }),
-        renderButton('Ghost', { variant: 'ghost' }),
-        renderButton('Disabled', { variant: 'primary', disabled: true }),
-      ].join('\n'),
-      badges: [
-        renderBadge('Default', { variant: 'default' }),
-        renderBadge('Primary', { variant: 'primary' }),
-        renderBadge('Success', { variant: 'success' }),
-        renderBadge('Warning', { variant: 'warning' }),
-        renderBadge('Error', { variant: 'error' }),
-      ].join('\n'),
-      avatars: [
-        renderAvatar({ name: 'Alice Johnson', size: 'sm' }),
-        renderAvatar({ name: 'Bob Smith' }),
-        renderAvatar({ name: 'Carol Davis', size: 'lg' }),
-        renderAvatar({ name: 'Dan Lee', size: 'xl' }),
-      ].join('\n'),
-      inputDefault: renderInput({ name: 'email', label: 'Email', type: 'email', placeholder: 'you@example.com', helpText: 'We will not share your email.' }),
-      inputError: renderInput({ name: 'username', label: 'Username', value: 'ab', error: 'Must be at least 3 characters' }),
-      textarea: renderTextarea({ name: 'bio', label: 'Bio', placeholder: 'Tell us about yourself...', rows: 3 }),
-      select: renderSelect({ name: 'role', label: 'Role', items: ['Admin', 'Editor', 'Viewer'], placeholder: 'Choose a role' }),
-      combobox: renderCombobox({ name: 'framework', label: 'Framework', items: ['Angular', 'React', 'Vue', 'Svelte', 'Solid'], placeholder: 'Search frameworks...' }),
-      multiselect: renderMultiselect({ name: 'tags', label: 'Tags', items: ['JavaScript', 'TypeScript', 'CSS', 'HTML', 'Node.js'], selected: ['JavaScript', 'CSS'] }),
-      checkbox: renderCheckbox({ name: 'terms', label: 'I agree to the terms and conditions' }),
-      radioGroup: renderRadioGroup({ name: 'plan', label: 'Plan', items: ['Free', 'Pro', 'Enterprise'], selected: 'Pro' }),
-      toggle: renderToggle({ name: 'notifications', label: 'Email notifications', checked: true }),
-      alertInfo: renderAlert('This is an informational message.', { variant: 'info' }),
-      alertSuccess: renderAlert('Operation completed successfully.', { variant: 'success' }),
-      alertWarning: renderAlert('Proceed with caution.', { variant: 'warning' }),
-      alertError: renderAlert('Something went wrong.', { variant: 'error', dismissible: true }),
-      progress: renderProgress({ value: 65, max: 100, label: 'Upload progress' }),
-      spinner: renderSpinner({ label: 'Loading' }),
-      spinnerLg: renderSpinner({ size: 'lg', label: 'Loading' }),
-      skeleton: renderSkeleton({ width: '100%', height: '1rem', count: 3 }),
-      card: renderCard({ header: 'Card Title', body: '<p>Card body content with descriptive text about the feature or item being presented.</p>', footer: 'Updated 2 hours ago' }),
-      accordion: renderAccordion({ items: [
-        { title: 'What is BaseNative?', content: 'A lightweight signals-based runtime for native template elements with ~120 lines of client code.' },
-        { title: 'How does SSR work?', content: 'The server renderer evaluates @if, @for, @switch directives at request time and returns clean HTML.' },
-        { title: 'What about hydration?', content: 'The client hydrate() function walks the DOM tree, binds reactive expressions, and attaches event handlers.' },
-      ] }),
-      tabs: renderTabs({ tabs: [
-        { id: 'overview', label: 'Overview', content: '<p>BaseNative brings Angular-inspired control flow to native template elements.</p>' },
-        { id: 'features', label: 'Features', content: '<p>Signals, computed values, effects, SSR, hydration, and template directives.</p>' },
-        { id: 'api', label: 'API', content: '<p>signal(), computed(), effect(), hydrate(), render().</p>' },
-      ] }),
-      breadcrumb: renderBreadcrumb({ items: [
-        { label: 'Home', href: '/' },
-        { label: 'Components', href: '/components' },
-        { label: 'Showcase' },
-      ] }),
-      pagination: renderPagination({ currentPage: 3, totalPages: 10, baseUrl: '/showcase' }),
-      table: renderTable({
-        columns: [
-          { key: 'name', label: 'Name' },
-          { key: 'role', label: 'Role' },
-          { key: 'status', label: 'Status' },
-        ],
-        rows: [
-          { name: 'Alice Johnson', role: 'Admin', status: 'Active' },
-          { name: 'Bob Smith', role: 'Editor', status: 'Active' },
-          { name: 'Carol Davis', role: 'Viewer', status: 'Inactive' },
-        ],
-        caption: 'Team members',
-      }),
-      datagrid: renderDataGrid({
-        columns: [
-          { key: 'task', label: 'Task', sortable: true },
-          { key: 'assignee', label: 'Assignee', sortable: true },
-          { key: 'priority', label: 'Priority' },
-          { key: 'status', label: 'Status' },
-        ],
-        rows: [
-          { id: 1, task: 'Design token system', assignee: 'Alice', priority: 'High', status: 'Done' },
-          { id: 2, task: 'Signal reactivity', assignee: 'Bob', priority: 'High', status: 'Done' },
-          { id: 3, task: 'Server rendering', assignee: 'Carol', priority: 'Medium', status: 'Active' },
-          { id: 4, task: 'Client hydration', assignee: 'Dan', priority: 'Medium', status: 'Pending' },
-          { id: 5, task: 'Component library', assignee: 'Alice', priority: 'Low', status: 'Active' },
-        ],
-        sortBy: 'task',
-        sortDir: 'asc',
-        selectable: true,
-        caption: 'Project tasks',
-      }),
-      tree: renderTree({
-        items: [
-          { id: '1', label: 'src', icon: '\u{1F4C1}', children: [
-            { id: '1-1', label: 'runtime', icon: '\u{1F4C1}', children: [
-              { id: '1-1-1', label: 'signals.js', icon: '\u{1F4C4}' },
-              { id: '1-1-2', label: 'hydrate.js', icon: '\u{1F4C4}' },
-              { id: '1-1-3', label: 'bind.js', icon: '\u{1F4C4}' },
-            ]},
-            { id: '1-2', label: 'server', icon: '\u{1F4C1}', children: [
-              { id: '1-2-1', label: 'render.js', icon: '\u{1F4C4}' },
-            ]},
-          ]},
-          { id: '2', label: 'examples', icon: '\u{1F4C1}', children: [
-            { id: '2-1', label: 'express', icon: '\u{1F4C1}' },
-            { id: '2-2', label: 'enterprise', icon: '\u{1F4C1}' },
-          ]},
-        ],
-        expanded: new Set(['1', '1-1']),
-        selected: '1-1-1',
-      }),
-      virtualList: renderVirtualList({
-        items: Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`),
-        itemHeight: 40,
-        containerHeight: 200,
-      }),
-      dialog: renderDialog({
-        title: 'Confirm Action',
-        content: '<p>Are you sure you want to proceed? This action cannot be undone.</p>',
-        footer: renderButton('Cancel', { variant: 'secondary' }) + renderButton('Confirm', { variant: 'primary' }),
-        id: 'demo-dialog',
-      }),
-      drawer: renderDrawer({
-        title: 'Settings',
-        content: '<p>Drawer body content goes here. This slides in from the edge of the viewport.</p>',
-        position: 'right',
-        id: 'demo-drawer',
-      }),
-      dropdown: renderDropdownMenu({
-        trigger: 'Actions',
-        items: [
-          { label: 'Edit', action: 'edit', icon: '\u{270F}\u{FE0F}' },
-          { label: 'Duplicate', action: 'duplicate', icon: '\u{1F4CB}' },
-          { separator: true },
-          { label: 'Delete', action: 'delete', icon: '\u{1F5D1}\u{FE0F}' },
-        ],
-      }),
-      tooltip: renderTooltip({
-        trigger: 'Hover me',
-        content: 'This is a tooltip with helpful context',
-        position: 'top',
-      }),
-      commandPalette: renderCommandPalette({
-        commands: [
-          { label: 'Go to Home', action: 'home', group: 'Navigation', icon: '\u{1F3E0}' },
-          { label: 'Go to Tasks', action: 'tasks', group: 'Navigation', icon: '\u{2705}' },
-          { label: 'New Task', action: 'new-task', group: 'Actions', icon: '\u{2795}', shortcut: 'Ctrl+N' },
-          { label: 'Search', action: 'search', group: 'Actions', icon: '\u{1F50D}', shortcut: 'Ctrl+K' },
-        ],
-        id: 'demo-cmd',
-      }),
-      toastContainer: renderToastContainer('top-right'),
-    },
+    ctx: getShowcaseContext(),
   },
 };
 
@@ -273,13 +115,23 @@ for (const [route, { view, title, activePage, ctx }] of Object.entries(pages)) {
 cpSync(join(express, 'public', 'styles.css'), join(dist, 'styles.css'));
 cpSync(join(express, 'public', 'theme.css'), join(dist, 'theme.css'));
 cpSync(join(express, 'public', 'basenative.js'), join(dist, 'basenative.js'));
+cpSync(join(express, 'public', 'showcase.js'), join(dist, 'showcase.js'));
 cpSync(join(express, 'public', 'favicon.svg'), join(dist, 'favicon.svg'));
 
 // Copy component CSS (served as /bn-css/ in Express, must exist in dist)
 const bnCssDir = join(dist, 'bn-css');
 mkdirSync(bnCssDir, { recursive: true });
 const componentSrc = join(root, 'packages', 'components', 'src');
-for (const file of ['index.css', 'layers.css', 'reset.css', 'tokens.css', 'theme.css', 'layout.css', 'components.css', 'states.css']) {
+for (const file of [
+  'index.css',
+  'layers.css',
+  'reset.css',
+  'tokens.css',
+  'theme.css',
+  'layout.css',
+  'components.css',
+  'states.css',
+]) {
   cpSync(join(componentSrc, file), join(bnCssDir, file));
 }
 


### PR DESCRIPTION
## Summary

- Every interactive showcase component (dialog, drawer, dropdown, tooltip, command palette, tabs, accordion, alerts, toasts) now actually works end-to-end. Root cause: inline `onclick=\"openDrawer()\"` referenced a function defined inside `<script type=\"module\">`, which is module-scoped — onclick attributes only see globals — so the buttons silently did nothing.
- Showcase content expanded to surface the wider `@basenative/*` ecosystem (visual-builder layout grid, calendar, kanban pipeline, runtime counter/clock, and a grouped Packages grid listing all 39 packages with descriptions).
- Site cleanup: Components page no longer claims \"Five public packages\" and links to the new ecosystem grid; readiness stat corrected to 39.

## What changed

- New `examples/express/public/showcase.js` — dedicated boot script using BaseNative `signal()` / `effect()` for the toast container, counter, and live clock. All component triggers use `data-bn-action` attributes, no inline onclick.
- New `examples/express/showcase-data.js` — central showcase context so the Express dev server and the static `dist/` build always render the same thing.
- `views/showcase.html` rewritten to be a proper TOC-driven page covering Buttons, Badges, Avatars, Forms, Feedback, Layout (incl. layout grid), Navigation, Data (incl. virtual list, calendar, pipeline), Overlays, Runtime primitives, and Packages.
- Tooltip is wired on hover / focus rather than relying on `popovertarget` (a `<span>` can't auto-toggle the Popover API).
- Command-palette items dispatch a `command` event that the toast container picks up.
- `build-pages.js` now copies `showcase.js` into `dist/` and uses `getShowcaseContext()`.

## Test plan

- [x] Click every interactive showcase component in a fresh browser session — dialog, drawer (open/close/overlay/escape), dropdown, tooltip on hover, command palette (filter + arrow keys + Enter), tabs (arrow keys), accordion, alert dismiss, toast buttons, counter, virtual-list scroll
- [x] `node --test packages/components/src/components.test.js` — 90 / 90 pass
- [x] `node scripts/build-pages.js` — static build emits all 7 routes and copies `/showcase.js` into `dist/`
- [x] Verify `/`, `/tasks`, `/playground`, `/docs`, `/components`, `/showcase` render with no console errors and no broken nav links
- [ ] Visual review on production after deploy

## Pre-existing test failures (not introduced here)

`packages/runtime/src/csp.test.js` has 5 failures looking for `src/shared/` at the repo root, which was relocated to `packages/runtime/src/shared/` in commit ce9ff49. The csp.test.js fixture path wasn't updated then. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)