### PR TITLE
fix(showcase,components): repair broken interactive components

### DIFF
--- a/examples/express/public/showcase.js
+++ b/examples/express/public/showcase.js
@@ -23,16 +23,17 @@ const actions = {
     if (!drawer) return;
     drawer.setAttribute('data-open', '');
     const overlay = drawer.previousElementSibling;
-    if (overlay?.matches('[data-bn="drawer-overlay"]')) overlay.removeAttribute('hidden');
+    if (overlay?.matches('[data-bn="drawer-overlay"]')) overlay.setAttribute('data-open', '');
   },
 
   'close-drawer': (target) => {
-    const drawer = target.closest('[data-bn="drawer"]')
-      ?? document.querySelector('[data-bn="drawer"][data-open]');
+    const drawer =
+      target.closest('[data-bn="drawer"]') ??
+      document.querySelector('[data-bn="drawer"][data-open]');
     if (!drawer) return;
     drawer.removeAttribute('data-open');
     const overlay = drawer.previousElementSibling;
-    if (overlay?.matches('[data-bn="drawer-overlay"]')) overlay.setAttribute('hidden', '');
+    if (overlay?.matches('[data-bn="drawer-overlay"]')) overlay.removeAttribute('data-open');
   },
 
   'dismiss-alert': (target) => {
@@ -76,11 +77,11 @@ document.addEventListener('click', (event) => {
 // Drawer: clicking the overlay closes the drawer
 document.addEventListener('click', (event) => {
   const overlay = event.target.closest('[data-bn="drawer-overlay"]');
-  if (!overlay || overlay.hasAttribute('hidden')) return;
+  if (!overlay || !overlay.hasAttribute('data-open')) return;
   const drawer = overlay.nextElementSibling;
   if (drawer?.matches('[data-bn="drawer"]')) {
     drawer.removeAttribute('data-open');
-    overlay.setAttribute('hidden', '');
+    overlay.removeAttribute('data-open');
   }
 });
 
@@ -90,7 +91,9 @@ document.querySelectorAll('[data-bn="tab"]').forEach((tab) => {
   tab.addEventListener('click', () => {
     const tabs = tab.closest('[data-bn="tabs"]');
     if (!tabs) return;
-    tabs.querySelectorAll('[data-bn="tab"]').forEach((t) => t.setAttribute('aria-selected', 'false'));
+    tabs
+      .querySelectorAll('[data-bn="tab"]')
+      .forEach((t) => t.setAttribute('aria-selected', 'false'));
     tabs.querySelectorAll('[data-bn="tab-panel"]').forEach((p) => (p.hidden = true));
     tab.setAttribute('aria-selected', 'true');
     const panel = tabs.querySelector('#' + tab.getAttribute('aria-controls'));

--- a/examples/express/public/showcase.js
+++ b/examples/express/public/showcase.js
@@ -1,0 +1,168 @@
+// Showcase page interactivity.
+// Uses data-bn-action delegation so the SSR HTML stays declarative
+// and the BaseNative no-inline-handlers axiom is preserved.
+
+import { signal, effect } from '/basenative.js';
+
+// -------- Action delegation --------
+
+const actions = {
+  'open-dialog': (target) => {
+    const id = target?.dataset.bnTarget;
+    const dialog = id && document.getElementById(id);
+    dialog?.showModal?.();
+  },
+
+  'close-dialog': (target) => {
+    target.closest('[data-bn="dialog"], [data-bn="command-palette"]')?.close?.();
+  },
+
+  'open-drawer': (target) => {
+    const id = target?.dataset.bnTarget;
+    const drawer = id && document.getElementById(id);
+    if (!drawer) return;
+    drawer.setAttribute('data-open', '');
+    const overlay = drawer.previousElementSibling;
+    if (overlay?.matches('[data-bn="drawer-overlay"]')) overlay.removeAttribute('hidden');
+  },
+
+  'close-drawer': (target) => {
+    const drawer = target.closest('[data-bn="drawer"]')
+      ?? document.querySelector('[data-bn="drawer"][data-open]');
+    if (!drawer) return;
+    drawer.removeAttribute('data-open');
+    const overlay = drawer.previousElementSibling;
+    if (overlay?.matches('[data-bn="drawer-overlay"]')) overlay.setAttribute('hidden', '');
+  },
+
+  'dismiss-alert': (target) => {
+    target.closest('[data-bn="alert"]')?.remove();
+  },
+
+  'remove-tag': (target) => {
+    const tag = target.closest('[data-bn="tag"]');
+    if (!tag) return;
+    const value = tag.dataset.value;
+    const root = tag.closest('[data-bn="multiselect"]');
+    const select = root?.querySelector('select');
+    if (select) {
+      const option = select.querySelector(`option[value="${CSS.escape(value)}"]`);
+      if (option) option.selected = false;
+    }
+    tag.remove();
+  },
+
+  'open-command-palette': (target) => {
+    const id = target?.dataset.bnTarget;
+    const palette = id && document.getElementById(id);
+    palette?.showModal?.();
+    palette?.querySelector('[data-bn="command-input"]')?.focus();
+  },
+
+  'run-command': (target) => {
+    const palette = target.closest('[data-bn="command-palette"]');
+    palette?.close?.();
+  },
+};
+
+document.addEventListener('click', (event) => {
+  const trigger = event.target.closest('[data-bn-action]');
+  if (!trigger) return;
+  const action = actions[trigger.dataset.bnAction];
+  if (!action) return;
+  action(trigger, event);
+});
+
+// Drawer: clicking the overlay closes the drawer
+document.addEventListener('click', (event) => {
+  const overlay = event.target.closest('[data-bn="drawer-overlay"]');
+  if (!overlay || overlay.hasAttribute('hidden')) return;
+  const drawer = overlay.nextElementSibling;
+  if (drawer?.matches('[data-bn="drawer"]')) {
+    drawer.removeAttribute('data-open');
+    overlay.setAttribute('hidden', '');
+  }
+});
+
+// -------- Tabs (existing behaviour) --------
+
+document.querySelectorAll('[data-bn="tab"]').forEach((tab) => {
+  tab.addEventListener('click', () => {
+    const tabs = tab.closest('[data-bn="tabs"]');
+    if (!tabs) return;
+    tabs.querySelectorAll('[data-bn="tab"]').forEach((t) => t.setAttribute('aria-selected', 'false'));
+    tabs.querySelectorAll('[data-bn="tab-panel"]').forEach((p) => (p.hidden = true));
+    tab.setAttribute('aria-selected', 'true');
+    const panel = tabs.querySelector('#' + tab.getAttribute('aria-controls'));
+    if (panel) panel.hidden = false;
+  });
+});
+
+// -------- Dropdown menu --------
+//
+// `popovertarget` toggles popover visibility natively, but the popover
+// renders in the top-layer with `position: fixed; inset: 0` by default,
+// landing in the top-left. We anchor it to the trigger's bounding rect
+// via CSS custom properties; positioning rules live in components.css.
+
+function positionDropdown(trigger, menu) {
+  const rect = trigger.getBoundingClientRect();
+  menu.style.setProperty('--bn-dropdown-top', `${rect.bottom + 4}px`);
+  menu.style.setProperty('--bn-dropdown-left', `${rect.left}px`);
+}
+
+document.querySelectorAll('[data-bn="dropdown-trigger"]').forEach((trigger) => {
+  const id = trigger.getAttribute('popovertarget');
+  const menu = id && document.getElementById(id);
+  if (!menu) return;
+  trigger.addEventListener('click', () => {
+    positionDropdown(trigger, menu);
+  });
+  // If popover API is not supported, fall back to manual toggle
+  if (typeof menu.showPopover !== 'function') {
+    trigger.removeAttribute('popovertarget');
+    trigger.addEventListener('click', () => {
+      const open = menu.hasAttribute('data-open');
+      if (open) menu.removeAttribute('data-open');
+      else menu.setAttribute('data-open', '');
+      positionDropdown(trigger, menu);
+    });
+  }
+});
+
+// -------- Tooltip --------
+//
+// `popover` on the tooltip span gives us top-layer rendering, but no
+// hover wiring. Show on mouseenter/focus, hide on the inverse.
+
+document.querySelectorAll('[data-bn="tooltip-trigger"]').forEach((trigger) => {
+  const id = trigger.getAttribute('popovertarget');
+  const tip = id && document.getElementById(id);
+  if (!tip) return;
+
+  function position() {
+    const rect = trigger.getBoundingClientRect();
+    tip.style.setProperty('--bn-tooltip-top', `${rect.top - 8}px`);
+    tip.style.setProperty('--bn-tooltip-left', `${rect.left + rect.width / 2}px`);
+  }
+  function show() {
+    position();
+    tip.showPopover?.();
+  }
+  function hide() {
+    tip.hidePopover?.();
+  }
+
+  trigger.addEventListener('mouseenter', show);
+  trigger.addEventListener('mouseleave', hide);
+  trigger.addEventListener('focus', show);
+  trigger.addEventListener('blur', hide);
+});
+
+// -------- Toast demo (kept from original showcase) --------
+
+const toastCount = signal(0);
+effect(() => {
+  // Reading keeps the signal alive; toast UI can subscribe later.
+  void toastCount();
+});

--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -268,7 +268,11 @@ app.get('/showcase', (req, res) => {
 
     toastContainer: renderToastContainer('top-right'),
   };
-  const html = renderPage('showcase.html', ctx, { title: 'Showcase', activePage: 'showcase' });
+  const html = renderPage('showcase.html', ctx, {
+    title: 'Showcase',
+    activePage: 'showcase',
+    scripts: '<script type="module" src="/showcase.js"></script>',
+  });
   res.send(html);
 });
 

--- a/examples/express/views/showcase.html
+++ b/examples/express/views/showcase.html
@@ -164,12 +164,12 @@
   <h2>Overlays</h2>
   <article>
     <header><h3>Dialog</h3></header>
-    <button data-bn="button" data-variant="secondary" onclick="document.getElementById('demo-dialog').showModal()">Open dialog</button>
+    <button data-bn="button" data-variant="secondary" data-bn-action="open-dialog" data-bn-target="demo-dialog">Open dialog</button>
     {{ dialog }}
   </article>
   <article>
     <header><h3>Drawer</h3></header>
-    <button data-bn="button" data-variant="secondary" onclick="openDrawer()">Open drawer</button>
+    <button data-bn="button" data-variant="secondary" data-bn-action="open-drawer" data-bn-target="demo-drawer">Open drawer</button>
     {{ drawer }}
   </article>
   <article>
@@ -182,54 +182,9 @@
   </article>
   <article>
     <header><h3>Command palette</h3></header>
-    <button data-bn="button" data-variant="secondary" onclick="document.getElementById('demo-cmd').showModal()">Open command palette</button>
+    <button data-bn="button" data-variant="secondary" data-bn-action="open-command-palette" data-bn-target="demo-cmd">Open command palette</button>
     {{ commandPalette }}
   </article>
 </section>
 
 {{ toastContainer }}
-
-<script type="module">
-// -- Tabs --
-document.querySelectorAll('[data-bn="tab"]').forEach(tab => {
-  tab.addEventListener('click', () => {
-    const tabs = tab.closest('[data-bn="tabs"]');
-    tabs.querySelectorAll('[data-bn="tab"]').forEach(t => t.setAttribute('aria-selected', 'false'));
-    tabs.querySelectorAll('[data-bn="tab-panel"]').forEach(p => p.hidden = true);
-    tab.setAttribute('aria-selected', 'true');
-    const panel = tabs.querySelector('#' + tab.getAttribute('aria-controls'));
-    if (panel) panel.hidden = false;
-  });
-});
-
-// -- Accordion (native details/summary) --
-// Already interactive via native <details> — no JS needed
-
-// -- Dialog --
-document.querySelectorAll('[data-bn="dialog-close"]').forEach(btn => {
-  btn.addEventListener('click', () => btn.closest('[data-bn="dialog"]')?.close());
-});
-
-// -- Drawer --
-const drawer = document.getElementById('demo-drawer');
-const drawerOverlay = document.querySelector('[data-bn="drawer-overlay"]');
-function openDrawer() {
-  drawer?.setAttribute('data-open', '');
-  drawerOverlay?.removeAttribute('hidden');
-}
-function closeDrawer() {
-  drawer?.removeAttribute('data-open');
-  drawerOverlay?.setAttribute('hidden', '');
-}
-document.querySelector('[data-bn="drawer-close"]')?.addEventListener('click', closeDrawer);
-drawerOverlay?.addEventListener('click', closeDrawer);
-
-// -- Alert dismiss --
-document.querySelectorAll('[data-bn="alert-dismiss"]').forEach(btn => {
-  btn.addEventListener('click', () => btn.closest('[data-bn="alert"]')?.remove());
-});
-
-// -- Toast demo --
-import { signal, effect } from '/basenative.js';
-const toastCount = signal(0);
-</script>

--- a/packages/components/src/alert.js
+++ b/packages/components/src/alert.js
@@ -11,7 +11,7 @@ export function renderAlert(content, options = {}) {
   let html = `<div data-bn="alert" data-variant="${variant}" role="${role}">`;
   html += `<span data-bn="alert-content">${content}</span>`;
   if (dismissible) {
-    html += `<button data-bn="alert-dismiss" type="button" aria-label="Dismiss">×</button>`;
+    html += `<button data-bn="alert-dismiss" data-bn-action="dismiss-alert" type="button" aria-label="Dismiss">×</button>`;
   }
   html += `</div>`;
   return html;

--- a/packages/components/src/command-palette.js
+++ b/packages/components/src/command-palette.js
@@ -23,7 +23,7 @@ export function renderCommandPalette(options = {}) {
       .map(cmd => {
         const icon = cmd.icon ? `<span data-bn="command-icon">${cmd.icon}</span>` : '';
         const shortcut = cmd.shortcut ? `<kbd data-bn="command-shortcut">${cmd.shortcut}</kbd>` : '';
-        return `<button data-bn="command-item" role="option" data-action="${cmd.action ?? cmd.id ?? ''}" type="button">${icon}<span data-bn="command-label">${cmd.label}</span>${shortcut}</button>`;
+        return `<button data-bn="command-item" role="option" data-action="${cmd.action ?? cmd.id ?? ''}" data-bn-action="run-command" type="button">${icon}<span data-bn="command-label">${cmd.label}</span>${shortcut}</button>`;
       })
       .join('');
     groupsHtml += `<div data-bn="command-group" role="group" aria-label="${groupName}">

--- a/packages/components/src/components.css
+++ b/packages/components/src/components.css
@@ -1,1277 +1,1682 @@
 @layer components {
-/* BaseNative Component Styles */
+  /* BaseNative Component Styles */
 
-/* === Button === */
-[data-bn="button"] {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--bn-space-2);
-  padding: var(--bn-space-component-y) var(--bn-space-component-x);
-  font-family: var(--bn-font-family);
-  font-size: var(--bn-font-size-component);
-  font-weight: var(--bn-font-weight-medium);
-  line-height: var(--bn-line-height-tight);
-  border: 1px solid transparent;
-  border-radius: var(--bn-radius-md);
-  cursor: pointer;
-  transition: background-color var(--bn-transition-fast), border-color var(--bn-transition-fast);
-}
-[data-bn="button"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
-[data-bn="button"]:disabled { opacity: 0.5; cursor: not-allowed; }
-[data-bn="button"][data-variant="primary"] {
-  background: var(--bn-color-primary-600);
-  color: var(--bn-color-white);
-}
-[data-bn="button"][data-variant="primary"]:hover:not(:disabled) { background: var(--bn-color-primary-700); }
-[data-bn="button"][data-variant="secondary"] {
-  background: var(--bn-color-surface);
-  color: var(--bn-color-text);
-  border-color: var(--bn-color-border);
-}
-[data-bn="button"][data-variant="secondary"]:hover:not(:disabled) { background: var(--bn-color-surface-muted); }
-[data-bn="button"][data-variant="destructive"] {
-  background: var(--bn-color-error-600);
-  color: var(--bn-color-white);
-}
-[data-bn="button"][data-variant="destructive"]:hover:not(:disabled) { background: var(--bn-color-error-500); }
-[data-bn="button"][data-variant="ghost"] {
-  background: transparent;
-  color: var(--bn-color-text);
-}
-[data-bn="button"][data-variant="ghost"]:hover:not(:disabled) { background: var(--bn-color-surface-muted); }
-
-/* === Field === */
-[data-bn="field"] {
-  display: flex;
-  flex-direction: column;
-  gap: var(--bn-space-1);
-}
-[data-bn="field"] label {
-  font-size: var(--bn-font-size-sm);
-  font-weight: var(--bn-font-weight-medium);
-  color: var(--bn-color-text);
-}
-[data-bn="field-help"] {
-  font-size: var(--bn-font-size-xs);
-  color: var(--bn-color-text-muted);
-}
-[data-bn="field-error"] {
-  font-size: var(--bn-font-size-xs);
-  color: var(--bn-color-error-600);
-}
-
-/* === Input & Textarea === */
-[data-bn="input"], [data-bn="textarea"], [data-bn="select"] {
-  padding: var(--bn-space-component-y) var(--bn-space-component-x);
-  font-family: var(--bn-font-family);
-  font-size: var(--bn-font-size-component);
-  color: var(--bn-color-text);
-  background: var(--bn-color-surface);
-  border: 1px solid var(--bn-color-border);
-  border-radius: var(--bn-radius-md);
-  transition: border-color var(--bn-transition-fast);
-}
-[data-bn="input"]:focus, [data-bn="textarea"]:focus, [data-bn="select"]:focus {
-  border-color: var(--bn-color-border-focus);
-  box-shadow: var(--bn-focus-ring);
-  outline: none;
-}
-[data-bn="input"][aria-invalid="true"], [data-bn="textarea"][aria-invalid="true"], [data-bn="select"][aria-invalid="true"] {
-  border-color: var(--bn-color-error-500);
-}
-[data-bn="input"]:disabled, [data-bn="textarea"]:disabled, [data-bn="select"]:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  background: var(--bn-color-surface-muted);
-}
-
-/* === Checkbox & Radio & Toggle === */
-[data-bn="checkbox-label"], [data-bn="radio-label"], [data-bn="toggle-label"] {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--bn-space-2);
-  font-size: var(--bn-font-size-component);
-  cursor: pointer;
-}
-[data-bn="checkbox"], [data-bn="radio"] {
-  appearance: none;
-  width: 1.125rem;
-  height: 1.125rem;
-  background: var(--bn-color-surface);
-  border: var(--bn-border-width) solid var(--bn-color-border-strong);
-  cursor: pointer;
-  flex-shrink: 0;
-  position: relative;
-  transition: background-color var(--bn-transition-fast), border-color var(--bn-transition-fast);
-}
-[data-bn="checkbox"] { border-radius: var(--bn-radius-sm); }
-[data-bn="radio"] { border-radius: var(--bn-radius-full); }
-[data-bn="checkbox"]:checked, [data-bn="radio"]:checked {
-  background: var(--bn-color-accent-600);
-  border-color: var(--bn-color-accent-600);
-}
-[data-bn="checkbox"]:checked::after {
-  content: '';
-  position: absolute;
-  top: 1px;
-  left: 4px;
-  width: 5px;
-  height: 9px;
-  border: solid var(--bn-color-white);
-  border-width: 0 2px 2px 0;
-  transform: rotate(45deg);
-}
-[data-bn="radio"]:checked::after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 6px;
-  height: 6px;
-  background: var(--bn-color-white);
-  border-radius: var(--bn-radius-full);
-  transform: translate(-50%, -50%);
-}
-[data-bn="checkbox"]:focus-visible, [data-bn="radio"]:focus-visible {
-  box-shadow: var(--bn-focus-ring);
-  outline: none;
-}
-[data-bn="radio-group"] {
-  border: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--bn-space-2);
-}
-[data-bn="radio-group"] legend {
-  font-size: var(--bn-font-size-sm);
-  font-weight: var(--bn-font-weight-medium);
-  margin-bottom: var(--bn-space-2);
-}
-[data-bn="toggle"] {
-  appearance: none;
-  width: 2.5rem;
-  height: 1.375rem;
-  background: var(--bn-color-gray-300);
-  border-radius: var(--bn-radius-full);
-  position: relative;
-  cursor: pointer;
-  transition: background-color var(--bn-transition-fast);
-}
-[data-bn="toggle"]::before {
-  content: '';
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 1rem;
-  height: 1rem;
-  background: var(--bn-color-white);
-  border-radius: var(--bn-radius-full);
-  transition: transform var(--bn-transition-fast);
-}
-[data-bn="toggle"]:checked { background: var(--bn-color-primary-600); }
-[data-bn="toggle"]:checked::before { transform: translateX(1.125rem); }
-[data-bn="toggle"]:focus-visible { box-shadow: var(--bn-focus-ring); }
-
-/* === Alert === */
-[data-bn="alert"] {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--bn-space-2);
-  padding: var(--bn-space-3) var(--bn-space-4);
-  border-radius: var(--bn-radius-md);
-  font-size: var(--bn-font-size-sm);
-  border: 1px solid;
-}
-[data-bn="alert"][data-variant="info"] { background: var(--bn-color-info-bg); border-color: var(--bn-color-info-border); color: var(--bn-color-info-text); }
-[data-bn="alert"][data-variant="success"] { background: var(--bn-color-success-bg); border-color: var(--bn-color-success-border); color: var(--bn-color-success-text); }
-[data-bn="alert"][data-variant="warning"] { background: var(--bn-color-warning-bg); border-color: var(--bn-color-warning-border); color: var(--bn-color-warning-text); }
-[data-bn="alert"][data-variant="error"] { background: var(--bn-color-error-bg); border-color: var(--bn-color-error-border); color: var(--bn-color-error-text); }
-[data-bn="alert-dismiss"] {
-  margin-left: auto;
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: var(--bn-font-size-lg);
-  line-height: 1;
-  opacity: 0.6;
-}
-[data-bn="alert-dismiss"]:hover { opacity: 1; }
-[data-bn="alert-dismiss"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; border-radius: var(--bn-radius-sm); }
-
-/* === Toast === */
-[data-bn="toast-container"] {
-  position: fixed;
-  z-index: var(--bn-z-toast);
-  display: flex;
-  flex-direction: column;
-  gap: var(--bn-space-2);
-  padding: var(--bn-space-4);
-  pointer-events: none;
-}
-[data-bn="toast-container"][data-position="top-right"] { top: 0; right: 0; }
-[data-bn="toast-container"][data-position="top-left"] { top: 0; left: 0; }
-[data-bn="toast-container"][data-position="bottom-right"] { bottom: 0; right: 0; }
-[data-bn="toast-container"][data-position="bottom-left"] { bottom: 0; left: 0; }
-
-/* === Table === */
-[data-bn="table-container"] { overflow-x: auto; }
-[data-bn="table"] {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--bn-font-size-sm);
-}
-[data-bn="table"] caption {
-  font-size: var(--bn-font-size-sm);
-  color: var(--bn-color-text-muted);
-  text-align: left;
-  padding-bottom: var(--bn-space-2);
-}
-[data-bn="table"] th {
-  text-align: left;
-  padding: var(--bn-space-3) var(--bn-space-4);
-  font-weight: var(--bn-font-weight-medium);
-  color: var(--bn-color-text-muted);
-  border-bottom: 1px solid var(--bn-color-border);
-}
-[data-bn="table"] td {
-  padding: var(--bn-space-3) var(--bn-space-4);
-  border-bottom: 1px solid var(--bn-color-border);
-  color: var(--bn-color-text);
-}
-[data-bn="table"] tbody tr:nth-child(even) { background: rgb(255 255 255 / 0.02); }
-[data-bn="table"] tbody tr:hover { background: var(--bn-color-surface-subtle); }
-[data-bn="table-empty"] {
-  text-align: center;
-  color: var(--bn-color-text-muted);
-  padding: var(--bn-space-8) !important;
-}
-
-/* === Pagination === */
-[data-bn="pagination"] ul {
-  display: flex;
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  gap: var(--bn-space-1);
-}
-[data-bn="pagination"] a, [data-bn="pagination"] span {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 2rem;
-  height: 2rem;
-  padding: 0 var(--bn-space-2);
-  font-size: var(--bn-font-size-sm);
-  border-radius: var(--bn-radius-md);
-  text-decoration: none;
-  color: var(--bn-color-text);
-}
-[data-bn="pagination"] a:hover { background: var(--bn-color-surface-muted); }
-[data-bn="pagination"] a:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
-[data-bn="pagination"] a[aria-current="page"] {
-  background: var(--bn-color-primary-600);
-  color: var(--bn-color-white);
-}
-[data-bn="pagination"] span[aria-disabled] { opacity: 0.4; cursor: default; }
-
-/* === Badge === */
-[data-bn="badge"] {
-  display: inline-flex;
-  align-items: center;
-  padding: var(--bn-space-1) var(--bn-space-2);
-  font-size: var(--bn-font-size-xs);
-  font-weight: var(--bn-font-weight-medium);
-  border-radius: var(--bn-radius-full);
-  line-height: 1;
-}
-[data-bn="badge"][data-variant="default"] { background: var(--bn-color-border); color: var(--bn-color-text); }
-[data-bn="badge"][data-variant="primary"] { background: var(--bn-color-info-bg); color: var(--bn-color-info-text); }
-[data-bn="badge"][data-variant="success"] { background: var(--bn-color-success-badge-bg); color: var(--bn-color-success-badge-text); }
-[data-bn="badge"][data-variant="warning"] { background: var(--bn-color-warning-badge-bg); color: var(--bn-color-warning-badge-text); }
-[data-bn="badge"][data-variant="error"] { background: var(--bn-color-error-badge-bg); color: var(--bn-color-error-badge-text); }
-
-/* === Card === */
-[data-bn="card"] {
-  background: var(--bn-color-surface);
-  border: 1px solid var(--bn-color-border);
-  border-radius: var(--bn-radius-lg);
-  overflow: hidden;
-}
-[data-bn="card-header"] {
-  padding: var(--bn-space-4) var(--bn-space-6);
-  border-bottom: 1px solid var(--bn-color-border);
-  font-weight: var(--bn-font-weight-semibold);
-}
-[data-bn="card-body"] { padding: var(--bn-space-4) var(--bn-space-6); }
-[data-bn="card-footer"] {
-  padding: var(--bn-space-4) var(--bn-space-6);
-  border-top: 1px solid var(--bn-color-border);
-  background: var(--bn-color-surface-subtle);
-}
-
-/* === Progress === */
-[data-bn="progress"] {
-  width: 100%;
-  height: 0.5rem;
-  border-radius: var(--bn-radius-full);
-  appearance: none;
-  border: none;
-  background: var(--bn-color-surface-muted);
-}
-[data-bn="progress"]::-webkit-progress-bar { background: var(--bn-color-surface-muted); border-radius: var(--bn-radius-full); }
-[data-bn="progress"]::-webkit-progress-value { background: var(--bn-color-accent-600); border-radius: var(--bn-radius-full); }
-[data-bn="progress"]::-moz-progress-bar { background: var(--bn-color-accent-600); border-radius: var(--bn-radius-full); }
-
-/* === Spinner === */
-[data-bn="spinner"] {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-[data-bn="spinner"] > span {
-  width: 1.25rem;
-  height: 1.25rem;
-  border: 2px solid var(--bn-color-border);
-  border-top-color: var(--bn-color-accent-600);
-  border-radius: var(--bn-radius-full);
-  animation: bn-spin 0.6s linear infinite;
-}
-[data-bn="spinner"][data-size="sm"] > span { width: 1rem; height: 1rem; }
-[data-bn="spinner"][data-size="lg"] > span { width: 2rem; height: 2rem; }
-@keyframes bn-spin { to { transform: rotate(360deg); } }
-
-/* === Skeleton === */
-[data-bn="skeleton"] {
-  background: linear-gradient(90deg, var(--bn-color-surface-muted) 25%, var(--bn-color-border) 50%, var(--bn-color-surface-muted) 75%);
-  background-size: 200% 100%;
-  animation: bn-shimmer 1.5s infinite;
-  border-radius: var(--bn-radius-md);
-}
-[data-bn="skeleton"][data-variant="circle"] { border-radius: var(--bn-radius-full); }
-@keyframes bn-shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
-
-/* === Accordion === */
-[data-bn="accordion"] {
-  display: flex;
-  flex-direction: column;
-}
-[data-bn="accordion-item"] {
-  border: var(--bn-border-width) solid var(--bn-color-border);
-  border-radius: var(--bn-radius-lg);
-  overflow: hidden;
-}
-[data-bn="accordion-item"] + [data-bn="accordion-item"] { margin-top: calc(-1 * var(--bn-border-width)); border-top-left-radius: 0; border-top-right-radius: 0; }
-[data-bn="accordion-item"]:first-child { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
-[data-bn="accordion-item"]:only-child { border-radius: var(--bn-radius-lg); }
-[data-bn="accordion-header"] {
-  display: flex;
-  align-items: center;
-  gap: var(--bn-space-2);
-  padding: var(--bn-space-component-y) var(--bn-space-component-x);
-  font-size: var(--bn-font-size-component);
-  font-weight: var(--bn-font-weight-medium);
-  background: var(--bn-color-surface);
-  cursor: pointer;
-  border: none;
-  width: 100%;
-  text-align: left;
-  color: var(--bn-color-text);
-  list-style: none;
-}
-[data-bn="accordion-header"]::before {
-  content: '\25B8';
-  font-size: 0.75em;
-  color: var(--bn-color-accent-600);
-  transition: rotate var(--bn-transition-fast);
-  flex-shrink: 0;
-}
-[data-bn="accordion-header"]::-webkit-details-marker { display: none; }
-[data-bn="accordion-item"][open] > [data-bn="accordion-header"]::before { rotate: 90deg; }
-[data-bn="accordion-header"]:hover { background: var(--bn-color-surface-subtle); }
-[data-bn="accordion-header"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; position: relative; z-index: 1; }
-[data-bn="accordion-content"] {
-  padding: var(--bn-space-3) var(--bn-space-4);
-  font-size: var(--bn-font-size-sm);
-  color: var(--bn-color-text);
-  border-top: var(--bn-border-width) solid var(--bn-color-border);
-}
-
-/* === Avatar === */
-[data-bn="avatar"] {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: var(--bn-radius-full);
-  overflow: hidden;
-  background: var(--bn-color-border-strong);
-  color: var(--bn-color-text);
-  font-weight: var(--bn-font-weight-semibold);
-  font-size: var(--bn-font-size-sm);
-  flex-shrink: 0;
-}
-[data-bn="avatar"][data-size="sm"] { width: 2rem; height: 2rem; font-size: var(--bn-font-size-xs); }
-[data-bn="avatar"][data-size="lg"] { width: 3rem; height: 3rem; font-size: var(--bn-font-size-base); }
-[data-bn="avatar"][data-size="xl"] { width: 4rem; height: 4rem; font-size: var(--bn-font-size-lg); }
-[data-bn="avatar"][data-shape="square"] { border-radius: var(--bn-radius-lg); }
-[data-bn="avatar-img"] { width: 100%; height: 100%; object-fit: cover; }
-[data-bn="avatar-initials"] { line-height: 1; user-select: none; }
-
-/* === Breadcrumb === */
-[data-bn="breadcrumb"] { font-size: var(--bn-font-size-sm); }
-[data-bn="breadcrumb-list"] {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: var(--bn-space-1);
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-[data-bn="breadcrumb-item"] { display: inline-flex; align-items: center; gap: var(--bn-space-1); }
-[data-bn="breadcrumb-item"] a {
-  color: var(--bn-color-text-link);
-  text-decoration: none;
-}
-[data-bn="breadcrumb-item"] a:hover { color: var(--bn-color-text); text-decoration: underline; }
-[data-bn="breadcrumb-item"] a:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; border-radius: var(--bn-radius-sm); }
-[data-bn="breadcrumb-item"][aria-current] { color: var(--bn-color-text); font-weight: var(--bn-font-weight-semibold); }
-[data-bn="breadcrumb-separator"] {
-  color: var(--bn-color-text-subtle);
-  font-size: var(--bn-font-size-xs);
-  user-select: none;
-}
-
-/* === Combobox === */
-[data-bn="combobox"] { position: relative; }
-[data-bn="combobox-input"] {
-  padding: var(--bn-space-component-y) var(--bn-space-component-x);
-  font-family: var(--bn-font-family);
-  font-size: var(--bn-font-size-component);
-  color: var(--bn-color-text);
-  background: var(--bn-color-surface);
-  border: var(--bn-border-width) solid var(--bn-color-border);
-  border-radius: var(--bn-radius-md);
-  width: 100%;
-  transition: border-color var(--bn-transition-fast);
-}
-[data-bn="combobox-input"]:focus {
-  border-color: var(--bn-color-border-focus);
-  box-shadow: var(--bn-focus-ring);
-  outline: none;
-}
-[data-bn="combobox-input"][aria-invalid="true"] { border-color: var(--bn-color-error-500); }
-[data-bn="combobox-input"]:disabled { opacity: 0.5; cursor: not-allowed; background: var(--bn-color-surface-muted); }
-
-/* === Command Palette === */
-[data-bn="command-palette"] {
-  border: none;
-  padding: 0;
-  border-radius: var(--bn-radius-xl);
-  background: var(--bn-color-surface);
-  box-shadow: var(--bn-shadow-lg);
-  max-width: 32rem;
-  width: 90vi;
-  max-height: min(24rem, 80vh);
-  overflow: hidden;
-  /* Reset zeroes margin globally; restore UA centering for modal dialogs. */
-  margin: auto;
-}
-[data-bn="command-palette"][open] {
-  display: flex;
-  flex-direction: column;
-}
-[data-bn="command-palette"]::backdrop {
-  background: rgb(0 0 0 / 0.4);
-  backdrop-filter: blur(4px);
-}
-[data-bn="command-header"] {
-  padding: var(--bn-space-3) var(--bn-space-4);
-  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
-}
-[data-bn="command-input"] {
-  width: 100%;
-  padding: var(--bn-space-2) 0;
-  border: none;
-  background: transparent;
-  font-size: var(--bn-font-size-base);
-  color: var(--bn-color-text);
-  outline: none;
-}
-[data-bn="command-input"]::placeholder { color: var(--bn-color-text-subtle); }
-[data-bn="command-list"] {
-  overflow-y: auto;
-  flex: 1;
-  padding: var(--bn-space-2);
-}
-[data-bn="command-group"] { margin-bottom: var(--bn-space-2); }
-[data-bn="command-group-label"] {
-  padding: var(--bn-space-1) var(--bn-space-2);
-  font-size: var(--bn-font-size-xs);
-  font-weight: var(--bn-font-weight-medium);
-  color: var(--bn-color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: var(--bn-letter-spacing-wide);
-}
-[data-bn="command-item"] {
-  display: flex;
-  align-items: center;
-  gap: var(--bn-space-3);
-  padding: var(--bn-space-2) var(--bn-space-3);
-  border-radius: var(--bn-radius-md);
-  cursor: pointer;
-  color: var(--bn-color-text);
-  font-size: var(--bn-font-size-sm);
-}
-[data-bn="command-item"]:hover, [data-bn="command-item"][aria-selected="true"] { background: var(--bn-color-surface-muted); }
-[data-bn="command-item"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
-[data-bn="command-icon"] { flex-shrink: 0; width: 1rem; height: 1rem; color: var(--bn-color-text-muted); }
-[data-bn="command-label"] { flex: 1; }
-[data-bn="command-shortcut"] {
-  font-family: var(--bn-font-mono);
-  font-size: var(--bn-font-size-xs);
-  color: var(--bn-color-text-subtle);
-}
-[data-bn="command-footer"] {
-  padding: var(--bn-space-2) var(--bn-space-4);
-  border-top: var(--bn-border-width) solid var(--bn-color-border);
-  font-size: var(--bn-font-size-xs);
-  color: var(--bn-color-text-muted);
-}
-
-/* === Data Grid === */
-[data-bn="datagrid"] {
-  border: var(--bn-border-width) solid var(--bn-color-border);
-  border-radius: var(--bn-radius-lg);
-  overflow: hidden;
-}
-[data-bn="datagrid-scroll"] { overflow-x: auto; }
-[data-bn="datagrid-table"] {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--bn-font-size-sm);
-}
-[data-bn="datagrid-th"] {
-  text-align: left;
-  padding: var(--bn-space-3) var(--bn-space-4);
-  font-weight: var(--bn-font-weight-medium);
-  color: var(--bn-color-text-muted);
-  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
-  background: var(--bn-color-surface-subtle);
-  position: sticky;
-  top: 0;
-  white-space: nowrap;
-  user-select: none;
-}
-[data-bn="datagrid-th"][data-sortable] { cursor: pointer; }
-[data-bn="datagrid-th"][data-sortable]:hover { color: var(--bn-color-text); }
-[data-bn="datagrid-th"][data-sortable]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
-[data-bn="datagrid-th"][data-sorted]::after {
-  content: '';
-  display: inline-block;
-  width: 0;
-  height: 0;
-  margin-left: var(--bn-space-1);
-  vertical-align: middle;
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-}
-[data-bn="datagrid-th"][data-sorted="asc"]::after { border-bottom: 4px solid currentColor; }
-[data-bn="datagrid-th"][data-sorted="desc"]::after { border-top: 4px solid currentColor; }
-[data-bn="datagrid-th-select"], [data-bn="datagrid-td-select"] {
-  width: 2.5rem;
-  text-align: center;
-}
-[data-bn="datagrid"] input[type="checkbox"] {
-  appearance: none;
-  width: 1rem;
-  height: 1rem;
-  background: var(--bn-color-surface);
-  border: var(--bn-border-width) solid var(--bn-color-border-strong);
-  border-radius: var(--bn-radius-sm);
-  cursor: pointer;
-  position: relative;
-}
-[data-bn="datagrid"] input[type="checkbox"]:checked {
-  background: var(--bn-color-accent-600);
-  border-color: var(--bn-color-accent-600);
-}
-[data-bn="datagrid"] input[type="checkbox"]:checked::after {
-  content: '';
-  position: absolute;
-  top: 1px;
-  left: 3px;
-  width: 4px;
-  height: 7px;
-  border: solid var(--bn-color-white);
-  border-width: 0 2px 2px 0;
-  transform: rotate(45deg);
-}
-[data-bn="datagrid"] input[type="checkbox"]:focus-visible {
-  box-shadow: var(--bn-focus-ring);
-  outline: none;
-}
-[data-bn="datagrid-row"]:hover { background: var(--bn-color-surface-subtle); }
-[data-bn="datagrid-td"] {
-  padding: var(--bn-space-3) var(--bn-space-4);
-  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
-  color: var(--bn-color-text);
-}
-[data-bn="datagrid-empty"] {
-  text-align: center;
-  color: var(--bn-color-text-muted);
-  padding: var(--bn-space-8);
-}
-[data-bn="datagrid-footer"] {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--bn-space-3) var(--bn-space-4);
-  border-top: var(--bn-border-width) solid var(--bn-color-border);
-  background: var(--bn-color-surface-subtle);
-}
-[data-bn="datagrid-info"] {
-  font-size: var(--bn-font-size-xs);
-  color: var(--bn-color-text-muted);
-}
-
-/* === Dialog === */
-[data-bn="dialog"] {
-  border: none;
-  padding: 0;
-  border-radius: var(--bn-radius-xl);
-  background: var(--bn-color-surface);
-  box-shadow: var(--bn-shadow-lg);
-  max-width: 28rem;
-  width: 90vi;
-  color: var(--bn-color-text);
-  /* Reset zeroes margin on every element; restore UA centering for modal dialogs. */
-  margin: auto;
-}
-[data-bn="dialog"]::backdrop {
-  background: rgb(0 0 0 / 0.4);
-  backdrop-filter: blur(4px);
-}
-[data-bn="dialog"][data-size="sm"] { max-width: 20rem; }
-[data-bn="dialog"][data-size="lg"] { max-width: 40rem; }
-[data-bn="dialog-header"] {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--bn-space-4) var(--bn-space-6);
-  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
-}
-[data-bn="dialog-title"] {
-  font-size: var(--bn-font-size-lg);
-  font-weight: var(--bn-font-weight-semibold);
-}
-[data-bn="dialog-close"] {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border: none;
-  background: transparent;
-  border-radius: var(--bn-radius-md);
-  cursor: pointer;
-  color: var(--bn-color-text-muted);
-  font-size: var(--bn-font-size-lg);
-}
-[data-bn="dialog-close"]:hover { background: var(--bn-color-surface-muted); color: var(--bn-color-text); }
-[data-bn="dialog-close"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
-[data-bn="dialog-body"] { padding: var(--bn-space-4) var(--bn-space-6); }
-[data-bn="dialog-footer"] {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--bn-space-2);
-  padding: var(--bn-space-4) var(--bn-space-6);
-  border-top: var(--bn-border-width) solid var(--bn-color-border);
-}
-
-/* === Drawer === */
-[data-bn="drawer"] {
-  display: none;
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  z-index: var(--bn-z-modal);
-  background: var(--bn-color-surface);
-  box-shadow: var(--bn-shadow-lg);
-  flex-direction: column;
-  width: 20rem;
-}
-[data-bn="drawer"][data-position="left"] { right: auto; left: 0; }
-[data-bn="drawer"][data-open] { display: flex; }
-[data-bn="drawer"][data-size="sm"] { width: 16rem; }
-[data-bn="drawer"][data-size="lg"] { width: 28rem; }
-[data-bn="drawer-overlay"] {
-  position: fixed;
-  inset: 0;
-  z-index: calc(var(--bn-z-modal) - 1);
-  background: rgb(0 0 0 / 0.4);
-  backdrop-filter: blur(2px);
-}
-[data-bn="drawer-overlay"][hidden] { display: none; }
-[data-bn="drawer-header"] {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--bn-space-4) var(--bn-space-6);
-  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
-}
-[data-bn="drawer-title"] {
-  font-size: var(--bn-font-size-lg);
-  font-weight: var(--bn-font-weight-semibold);
-}
-[data-bn="drawer-close"] {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border: none;
-  background: transparent;
-  border-radius: var(--bn-radius-md);
-  cursor: pointer;
-  color: var(--bn-color-text-muted);
-}
-[data-bn="drawer-close"]:hover { background: var(--bn-color-surface-muted); color: var(--bn-color-text); }
-[data-bn="drawer-close"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
-[data-bn="drawer-body"] { padding: var(--bn-space-4) var(--bn-space-6); flex: 1; overflow-y: auto; }
-
-/* === Dropdown Menu === */
-[data-bn="dropdown"] { position: relative; display: inline-flex; }
-[data-bn="dropdown-trigger"] {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--bn-space-2);
-  padding: var(--bn-space-component-y) var(--bn-space-component-x);
-  font-family: var(--bn-font-family);
-  font-size: var(--bn-font-size-component);
-  font-weight: var(--bn-font-weight-medium);
-  background: var(--bn-color-surface);
-  color: var(--bn-color-text);
-  border: var(--bn-border-width) solid var(--bn-color-border);
-  border-radius: var(--bn-radius-md);
-  cursor: pointer;
-}
-[data-bn="dropdown-trigger"]:hover { background: var(--bn-color-surface-muted); }
-[data-bn="dropdown-trigger"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
-[data-bn="dropdown-menu"] {
-  /* Anchored via CSS vars set by showcase.js when the popover toggles. */
-  position: fixed;
-  inset: auto;
-  top: var(--bn-dropdown-top, 0);
-  left: var(--bn-dropdown-left, 0);
-  margin: 0;
-  z-index: var(--bn-z-dropdown);
-  min-width: 10rem;
-  padding: var(--bn-space-1);
-  background: var(--bn-color-surface);
-  border: var(--bn-border-width) solid var(--bn-color-border);
-  border-radius: var(--bn-radius-lg);
-  box-shadow: var(--bn-shadow-md);
-}
-[data-bn="dropdown-menu"]:popover-open,
-[data-bn="dropdown-menu"][data-open] {
-  display: flex;
-  flex-direction: column;
-}
-/* Fallback for browsers without the popover API */
-[data-bn="dropdown-menu"]:not([data-open]):not(:popover-open) {
-  display: none;
-}
-[data-bn="dropdown-item"] {
-  display: flex;
-  align-items: center;
-  gap: var(--bn-space-2);
-  padding: var(--bn-space-2) var(--bn-space-3);
-  font-size: var(--bn-font-size-sm);
-  color: var(--bn-color-text);
-  border: none;
-  background: transparent;
-  border-radius: var(--bn-radius-md);
-  cursor: pointer;
-  text-align: left;
-  width: 100%;
-}
-[data-bn="dropdown-item"]:hover { background: var(--bn-color-surface-muted); }
-[data-bn="dropdown-item"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
-[data-bn="dropdown-item"][aria-disabled="true"] { opacity: 0.5; cursor: not-allowed; }
-[data-bn="dropdown-icon"] { flex-shrink: 0; width: 1rem; height: 1rem; color: var(--bn-color-text-muted); }
-[data-bn="dropdown-shortcut"] {
-  margin-left: auto;
-  font-family: var(--bn-font-mono);
-  font-size: var(--bn-font-size-xs);
-  color: var(--bn-color-text-subtle);
-}
-[data-bn="dropdown-separator"] {
-  height: var(--bn-border-width);
-  background: var(--bn-color-border);
-  margin: var(--bn-space-1) 0;
-}
-
-/* === Multiselect === */
-[data-bn="multiselect"] { position: relative; }
-[data-bn="multiselect"] select[hidden] { display: none; }
-[data-bn="multiselect"][data-disabled] { opacity: 0.5; pointer-events: none; }
-[data-bn="multiselect-container"] {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--bn-space-1);
-  padding: var(--bn-space-1) var(--bn-space-2);
-  min-height: 2.5rem;
-  background: var(--bn-color-surface);
-  border: var(--bn-border-width) solid var(--bn-color-border);
-  border-radius: var(--bn-radius-md);
-  cursor: text;
-  transition: border-color var(--bn-transition-fast);
-}
-[data-bn="multiselect-container"]:focus-within {
-  border-color: var(--bn-color-border-focus);
-  box-shadow: var(--bn-focus-ring);
-}
-[data-bn="multiselect-tags"] {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--bn-space-1);
-}
-[data-bn="tag"] {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--bn-space-1);
-  padding: var(--bn-space-1) var(--bn-space-2);
-  font-size: var(--bn-font-size-xs);
-  font-weight: var(--bn-font-weight-medium);
-  background: var(--bn-color-surface-muted);
-  border-radius: var(--bn-radius-full);
-  color: var(--bn-color-text);
-  line-height: 1;
-}
-[data-bn="tag-remove"] {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1rem;
-  height: 1rem;
-  border: none;
-  background: transparent;
-  border-radius: var(--bn-radius-full);
-  cursor: pointer;
-  color: var(--bn-color-text-muted);
-  font-size: var(--bn-font-size-xs);
-  line-height: 1;
-}
-[data-bn="tag-remove"]:hover { background: var(--bn-color-border); color: var(--bn-color-text); }
-[data-bn="tag-remove"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
-[data-bn="multiselect-search"] {
-  border: none;
-  outline: none;
-  background: transparent;
-  font-size: var(--bn-font-size-component);
-  color: var(--bn-color-text);
-  flex: 1;
-  min-width: 4rem;
-  padding: var(--bn-space-1) 0;
-}
-
-/* === Tabs === */
-[data-bn="tabs"] { display: flex; flex-direction: column; }
-[data-bn="tab-list"] {
-  display: flex;
-  gap: 0;
-  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
-}
-[data-bn="tab"] {
-  padding: var(--bn-space-2) var(--bn-space-4);
-  font-size: var(--bn-font-size-sm);
-  font-weight: var(--bn-font-weight-medium);
-  color: var(--bn-color-text-muted);
-  background: transparent;
-  border: none;
-  border-bottom: 3px solid transparent;
-  cursor: pointer;
-  margin-bottom: calc(-1 * var(--bn-border-width));
-  transition: color var(--bn-transition-fast), border-color var(--bn-transition-fast);
-}
-[data-bn="tab"]:hover { color: var(--bn-color-text); }
-[data-bn="tab"][aria-selected="true"] {
-  color: var(--bn-color-text);
-  border-bottom-color: var(--bn-color-accent-600);
-}
-[data-bn="tab"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; position: relative; z-index: 1; }
-[data-bn="tab"]:disabled { opacity: 0.5; cursor: not-allowed; }
-[data-bn="tab-panel"] { padding: var(--bn-space-4) 0; }
-[data-bn="tab-panel"][hidden] { display: none; }
-/* Tabs: pills variant */
-[data-bn="tabs"][data-variant="pills"] [data-bn="tab-list"] { border-bottom: none; gap: var(--bn-space-1); }
-[data-bn="tabs"][data-variant="pills"] [data-bn="tab"] {
-  border-bottom: none;
-  border-radius: var(--bn-radius-md);
-  margin-bottom: 0;
-}
-[data-bn="tabs"][data-variant="pills"] [data-bn="tab"][aria-selected="true"] {
-  background: var(--bn-color-surface-muted);
-  color: var(--bn-color-text);
-}
-
-/* === Toast (individual item) === */
-[data-bn="toast"] {
-  pointer-events: auto;
-  display: flex;
-  align-items: flex-start;
-  gap: var(--bn-space-2);
-  padding: var(--bn-space-3) var(--bn-space-4);
-  background: var(--bn-color-surface);
-  border: var(--bn-border-width) solid var(--bn-color-border);
-  border-radius: var(--bn-radius-lg);
-  box-shadow: var(--bn-shadow-md);
-  font-size: var(--bn-font-size-sm);
-  color: var(--bn-color-text);
-  max-width: 24rem;
-}
-[data-bn="toast"][data-variant="success"] { border-color: var(--bn-color-success-border); }
-[data-bn="toast"][data-variant="error"] { border-color: var(--bn-color-error-border); }
-[data-bn="toast"][data-variant="warning"] { border-color: var(--bn-color-warning-border); }
-[data-bn="toast"][data-variant="info"] { border-color: var(--bn-color-info-border); }
-
-/* === Tooltip === */
-[data-bn="tooltip"] {
-  position: fixed;
-  inset: auto;
-  top: var(--bn-tooltip-top, 0);
-  left: var(--bn-tooltip-left, 0);
-  margin: 0;
-  transform: translate(-50%, -100%);
-  z-index: var(--bn-z-dropdown);
-  max-width: 20rem;
-  padding: var(--bn-space-2) var(--bn-space-3);
-  background: var(--bn-color-surface-inverse);
-  color: var(--bn-color-text-inverse);
-  font-size: var(--bn-font-size-xs);
-  border-radius: var(--bn-radius-md);
-  pointer-events: none;
-  white-space: normal;
-  line-height: var(--bn-line-height-normal);
-}
-[data-bn="tooltip-trigger"] { cursor: default; }
-
-/* === Tree === */
-[data-bn="tree"] {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  font-size: var(--bn-font-size-sm);
-}
-[data-bn="tree-item"] { display: flex; flex-direction: column; }
-[data-bn="tree-item-content"] {
-  display: flex;
-  align-items: center;
-  gap: var(--bn-space-1);
-  padding: var(--bn-space-1) var(--bn-space-2);
-  border-radius: var(--bn-radius-md);
-  cursor: pointer;
-  color: var(--bn-color-text);
-}
-[data-bn="tree-item-content"]:hover { background: var(--bn-color-surface-subtle); }
-[data-bn="tree-item-content"][data-selected] { background: var(--bn-color-primary-50); color: var(--bn-color-primary-700); }
-[data-bn="tree-item-content"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; position: relative; z-index: 1; }
-[data-bn="tree-indent"] { flex-shrink: 0; }
-[data-bn="tree-toggle"] {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.25rem;
-  height: 1.25rem;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  color: var(--bn-color-text-muted);
-  border-radius: var(--bn-radius-sm);
-  flex-shrink: 0;
-}
-[data-bn="tree-toggle"]:hover { background: var(--bn-color-surface-muted); }
-[data-bn="tree-toggle"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
-[data-bn="tree-icon"] { flex-shrink: 0; width: 1rem; height: 1rem; color: var(--bn-color-text-muted); }
-[data-bn="tree-label"] { flex: 1; }
-[data-bn="tree-children"] {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-/* Tree item indentation via data-level */
-[data-bn="tree-item"][data-level="1"] [data-bn="tree-item-content"] { padding-left: var(--bn-space-6); }
-[data-bn="tree-item"][data-level="2"] [data-bn="tree-item-content"] { padding-left: var(--bn-space-10); }
-[data-bn="tree-item"][data-level="3"] [data-bn="tree-item-content"] { padding-left: var(--bn-space-16); }
-/* Tree Grid */
-[data-bn="treegrid"] { width: 100%; border-collapse: collapse; font-size: var(--bn-font-size-sm); }
-[data-bn="treegrid-row"] { cursor: pointer; }
-[data-bn="treegrid-row"]:hover { background: var(--bn-color-surface-subtle); }
-[data-bn="treegrid-row"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
-
-/* === Virtualizer === */
-[data-bn="virtualizer"] {
-  overflow: auto;
-  border: var(--bn-border-width) solid var(--bn-color-border);
-  border-radius: var(--bn-radius-lg);
-}
-[data-bn="virtual-window"] { position: relative; }
-[data-bn="virtual-item"] {
-  padding: var(--bn-space-3) var(--bn-space-4);
-  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
-  font-size: var(--bn-font-size-sm);
-}
-[data-bn="virtual-item"]:last-child { border-bottom: none; }
-
-/* === Calendar === */
-[data-bn="calendar"] {
-  position: relative;
-  overflow: auto;
-  border: var(--bn-border-width) solid var(--bn-color-border);
-  border-radius: var(--bn-radius-md);
-  background: var(--bn-color-surface);
-}
-[data-bn="calendar-grid"] {
-  display: grid;
-  grid-template-columns: 4rem repeat(var(--bn-calendar-cols, 7), 1fr);
-  grid-template-rows: auto repeat(var(--bn-calendar-hours, 12), minmax(3.5rem, 1fr));
-  min-height: 0;
-}
-[data-bn="calendar-corner"] {
-  grid-column: 1;
-  grid-row: 1;
-  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
-  border-right: var(--bn-border-width) solid var(--bn-color-border);
-  background: var(--bn-color-surface-muted);
-}
-[data-bn="calendar-day-header"] {
-  grid-row: 1;
-  padding: var(--bn-space-2) var(--bn-space-3);
-  font-size: var(--bn-font-size-sm);
-  font-weight: var(--bn-font-weight-semibold);
-  text-align: center;
-  border-bottom: var(--bn-border-width) solid var(--bn-color-border);
-  border-right: var(--bn-border-width) solid var(--bn-color-border);
-  background: var(--bn-color-surface-muted);
-}
-[data-bn="calendar-day-header"]:last-of-type { border-right: none; }
-[data-bn="calendar-time-gutter"] {
-  grid-column: 1;
-  grid-row: 2 / -1;
-  position: relative;
-  border-right: var(--bn-border-width) solid var(--bn-color-border);
-}
-[data-bn="calendar-time-label"] {
-  position: absolute;
-  right: var(--bn-space-2);
-  font-size: var(--bn-font-size-xs);
-  color: var(--bn-color-text-muted);
-  line-height: 1;
-  transform: translateY(-50%);
-}
-[data-bn="calendar-day-column"] {
-  position: relative;
-  display: grid;
-  grid-row: 2 / -1;
-  grid-template-rows: subgrid;
-  border-right: var(--bn-border-width) solid var(--bn-color-border);
-}
-[data-bn="calendar-day-column"]:last-of-type { border-right: none; }
-[data-bn="calendar-slot"] {
-  border-bottom: var(--bn-border-width) solid var(--bn-color-border-light, var(--bn-color-border));
-  transition: background-color var(--bn-transition-fast);
-}
-[data-bn="calendar-slot"][data-drop-target] {
-  background: var(--bn-color-primary-50, hsl(210 100% 95%));
-}
-[data-bn="calendar-event"] {
-  position: absolute;
-  inset-inline: var(--bn-space-1);
-  display: flex;
-  flex-direction: column;
-  gap: var(--bn-space-half, 0.125rem);
-  padding: var(--bn-space-1) var(--bn-space-2);
-  background: var(--bn-calendar-event-color, var(--bn-color-primary-100));
-  border-left: 3px solid var(--bn-calendar-event-color, var(--bn-color-primary-600));
-  border-radius: var(--bn-radius-sm);
-  font-size: var(--bn-font-size-xs);
-  cursor: grab;
-  overflow: hidden;
-  z-index: 1;
-}
-[data-bn="calendar-event"][data-dragging] { opacity: 0.5; cursor: grabbing; }
-[data-bn="calendar-event"][data-status="scheduled"] {
-  --bn-calendar-event-color: var(--bn-color-primary-600);
-  background: var(--bn-color-primary-50);
-}
-[data-bn="calendar-event"][data-status="in_progress"] {
-  --bn-calendar-event-color: var(--bn-color-warning-500, hsl(38 90% 50%));
-  background: var(--bn-color-warning-50, hsl(38 90% 95%));
-}
-[data-bn="calendar-event"][data-status="completed"] {
-  --bn-calendar-event-color: var(--bn-color-success-500, hsl(145 55% 40%));
-  background: var(--bn-color-success-50, hsl(145 55% 95%));
-}
-[data-bn="calendar-event-title"] {
-  font-weight: var(--bn-font-weight-semibold);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-[data-bn="calendar-event-assignee"] {
-  color: var(--bn-color-text-muted);
-}
-[data-bn="calendar-event-time"] {
-  color: var(--bn-color-text-muted);
-}
-
-/* Pipeline block (draggable card for sidebar dispatch) */
-[data-bn="pipeline-block"] {
-  display: flex;
-  flex-direction: column;
-  gap: var(--bn-space-1);
-  padding: var(--bn-space-2) var(--bn-space-3);
-  background: var(--bn-color-surface);
-  border: var(--bn-border-width) solid var(--bn-color-border);
-  border-radius: var(--bn-radius-md);
-  cursor: grab;
-  transition: box-shadow var(--bn-transition-fast), border-color var(--bn-transition-fast);
-}
-[data-bn="pipeline-block"]:hover {
-  border-color: var(--bn-color-primary-300);
-  box-shadow: var(--bn-shadow-sm);
-}
-[data-bn="pipeline-block"][data-dragging] { opacity: 0.5; cursor: grabbing; }
-[data-bn="pipeline-block-title"] {
-  font-weight: var(--bn-font-weight-medium);
-  font-size: var(--bn-font-size-sm);
-}
-[data-bn="pipeline-block-subtitle"] {
-  font-size: var(--bn-font-size-xs);
-  color: var(--bn-color-text-muted);
-}
-
-[data-bn="calendar-empty"] {
-  padding: var(--bn-space-8);
-  text-align: center;
-  color: var(--bn-color-text-muted);
-  font-size: var(--bn-font-size-sm);
-}
-
-/* Pipeline / Kanban component */
-[data-bn="pipeline"] {
-  display: grid;
-  grid-auto-flow: column;
-  gap: var(--bn-space-4);
-  overflow-x: auto;
-  padding: var(--bn-space-3);
-  background: var(--bn-color-surface-muted);
-  border-radius: var(--bn-radius-md);
-  min-height: 20rem;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  [data-bn="pipeline"] [data-bn="pipeline-card"] {
-    transition: none;
+  /* === Button === */
+  [data-bn='button'] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--bn-space-2);
+    padding: var(--bn-space-component-y) var(--bn-space-component-x);
+    font-family: var(--bn-font-family);
+    font-size: var(--bn-font-size-component);
+    font-weight: var(--bn-font-weight-medium);
+    line-height: var(--bn-line-height-tight);
+    border: 1px solid transparent;
+    border-radius: var(--bn-radius-md);
+    cursor: pointer;
+    transition:
+      background-color var(--bn-transition-fast),
+      border-color var(--bn-transition-fast);
   }
-}
+  [data-bn='button']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+  [data-bn='button']:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  [data-bn='button'][data-variant='primary'] {
+    background: var(--bn-color-primary-600);
+    color: var(--bn-color-white);
+  }
+  [data-bn='button'][data-variant='primary']:hover:not(:disabled) {
+    background: var(--bn-color-primary-700);
+  }
+  [data-bn='button'][data-variant='secondary'] {
+    background: var(--bn-color-surface);
+    color: var(--bn-color-text);
+    border-color: var(--bn-color-border);
+  }
+  [data-bn='button'][data-variant='secondary']:hover:not(:disabled) {
+    background: var(--bn-color-surface-muted);
+  }
+  [data-bn='button'][data-variant='destructive'] {
+    background: var(--bn-color-error-600);
+    color: var(--bn-color-white);
+  }
+  [data-bn='button'][data-variant='destructive']:hover:not(:disabled) {
+    background: var(--bn-color-error-500);
+  }
+  [data-bn='button'][data-variant='ghost'] {
+    background: transparent;
+    color: var(--bn-color-text);
+  }
+  [data-bn='button'][data-variant='ghost']:hover:not(:disabled) {
+    background: var(--bn-color-surface-muted);
+  }
 
-[data-bn="pipeline-column"] {
-  flex: 0 0 min(100%, 20rem);
-  display: flex;
-  flex-direction: column;
-  gap: var(--bn-space-2);
-  min-height: 0;
-}
+  /* === Field === */
+  [data-bn='field'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--bn-space-1);
+  }
+  [data-bn='field'] label {
+    font-size: var(--bn-font-size-sm);
+    font-weight: var(--bn-font-weight-medium);
+    color: var(--bn-color-text);
+  }
+  [data-bn='field-help'] {
+    font-size: var(--bn-font-size-xs);
+    color: var(--bn-color-text-muted);
+  }
+  [data-bn='field-error'] {
+    font-size: var(--bn-font-size-xs);
+    color: var(--bn-color-error-600);
+  }
 
-[data-bn="pipeline-column-header"] {
-  font-weight: var(--bn-font-weight-semibold);
-  font-size: var(--bn-font-size-sm);
-  color: var(--bn-color-text);
-  padding: var(--bn-space-2) 0;
-  border-bottom: 2px solid var(--bn-color-border);
-}
+  /* === Input & Textarea === */
+  [data-bn='input'],
+  [data-bn='textarea'],
+  [data-bn='select'] {
+    padding: var(--bn-space-component-y) var(--bn-space-component-x);
+    font-family: var(--bn-font-family);
+    font-size: var(--bn-font-size-component);
+    color: var(--bn-color-text);
+    background: var(--bn-color-surface);
+    border: 1px solid var(--bn-color-border);
+    border-radius: var(--bn-radius-md);
+    transition: border-color var(--bn-transition-fast);
+  }
+  [data-bn='input']:focus,
+  [data-bn='textarea']:focus,
+  [data-bn='select']:focus {
+    border-color: var(--bn-color-border-focus);
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+  [data-bn='input'][aria-invalid='true'],
+  [data-bn='textarea'][aria-invalid='true'],
+  [data-bn='select'][aria-invalid='true'] {
+    border-color: var(--bn-color-error-500);
+  }
+  [data-bn='input']:disabled,
+  [data-bn='textarea']:disabled,
+  [data-bn='select']:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    background: var(--bn-color-surface-muted);
+  }
 
-[data-bn="pipeline-column-cards"] {
-  display: flex;
-  flex-direction: column;
-  gap: var(--bn-space-2);
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-  padding: var(--bn-space-1);
-  border-radius: var(--bn-radius-md);
-  transition: background-color var(--bn-transition-fast);
-}
+  /* === Checkbox & Radio & Toggle === */
+  [data-bn='checkbox-label'],
+  [data-bn='radio-label'],
+  [data-bn='toggle-label'] {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--bn-space-2);
+    font-size: var(--bn-font-size-component);
+    cursor: pointer;
+  }
+  [data-bn='checkbox'],
+  [data-bn='radio'] {
+    appearance: none;
+    width: 1.125rem;
+    height: 1.125rem;
+    background: var(--bn-color-surface);
+    border: var(--bn-border-width) solid var(--bn-color-border-strong);
+    cursor: pointer;
+    flex-shrink: 0;
+    position: relative;
+    transition:
+      background-color var(--bn-transition-fast),
+      border-color var(--bn-transition-fast);
+  }
+  [data-bn='checkbox'] {
+    border-radius: var(--bn-radius-sm);
+  }
+  [data-bn='radio'] {
+    border-radius: var(--bn-radius-full);
+  }
+  [data-bn='checkbox']:checked,
+  [data-bn='radio']:checked {
+    background: var(--bn-color-accent-600);
+    border-color: var(--bn-color-accent-600);
+  }
+  [data-bn='checkbox']:checked::after {
+    content: '';
+    position: absolute;
+    top: 1px;
+    left: 4px;
+    width: 5px;
+    height: 9px;
+    border: solid var(--bn-color-white);
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+  }
+  [data-bn='radio']:checked::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 6px;
+    height: 6px;
+    background: var(--bn-color-white);
+    border-radius: var(--bn-radius-full);
+    transform: translate(-50%, -50%);
+  }
+  [data-bn='checkbox']:focus-visible,
+  [data-bn='radio']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+  [data-bn='radio-group'] {
+    border: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--bn-space-2);
+  }
+  [data-bn='radio-group'] legend {
+    font-size: var(--bn-font-size-sm);
+    font-weight: var(--bn-font-weight-medium);
+    margin-bottom: var(--bn-space-2);
+  }
+  [data-bn='toggle'] {
+    appearance: none;
+    width: 2.5rem;
+    height: 1.375rem;
+    background: var(--bn-color-gray-300);
+    border-radius: var(--bn-radius-full);
+    position: relative;
+    cursor: pointer;
+    transition: background-color var(--bn-transition-fast);
+  }
+  [data-bn='toggle']::before {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 1rem;
+    height: 1rem;
+    background: var(--bn-color-white);
+    border-radius: var(--bn-radius-full);
+    transition: transform var(--bn-transition-fast);
+  }
+  [data-bn='toggle']:checked {
+    background: var(--bn-color-primary-600);
+  }
+  [data-bn='toggle']:checked::before {
+    transform: translateX(1.125rem);
+  }
+  [data-bn='toggle']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+  }
 
-[data-bn="pipeline-column-cards"][data-drop-target] {
-  background-color: var(--bn-color-primary-50, hsl(210 100% 95%));
-  border: 2px dashed var(--bn-color-primary-200, hsl(210 100% 85%));
-}
+  /* === Alert === */
+  [data-bn='alert'] {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--bn-space-2);
+    padding: var(--bn-space-3) var(--bn-space-4);
+    border-radius: var(--bn-radius-md);
+    font-size: var(--bn-font-size-sm);
+    border: 1px solid;
+  }
+  [data-bn='alert'][data-variant='info'] {
+    background: var(--bn-color-info-bg);
+    border-color: var(--bn-color-info-border);
+    color: var(--bn-color-info-text);
+  }
+  [data-bn='alert'][data-variant='success'] {
+    background: var(--bn-color-success-bg);
+    border-color: var(--bn-color-success-border);
+    color: var(--bn-color-success-text);
+  }
+  [data-bn='alert'][data-variant='warning'] {
+    background: var(--bn-color-warning-bg);
+    border-color: var(--bn-color-warning-border);
+    color: var(--bn-color-warning-text);
+  }
+  [data-bn='alert'][data-variant='error'] {
+    background: var(--bn-color-error-bg);
+    border-color: var(--bn-color-error-border);
+    color: var(--bn-color-error-text);
+  }
+  [data-bn='alert-dismiss'] {
+    margin-left: auto;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: var(--bn-font-size-lg);
+    line-height: 1;
+    opacity: 0.6;
+  }
+  [data-bn='alert-dismiss']:hover {
+    opacity: 1;
+  }
+  [data-bn='alert-dismiss']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+    border-radius: var(--bn-radius-sm);
+  }
 
-[data-bn="pipeline-card"] {
-  display: flex;
-  flex-direction: column;
-  gap: var(--bn-space-1);
-  padding: var(--bn-space-2);
-  background: var(--bn-color-surface);
-  border: 1px solid var(--bn-color-border);
-  border-radius: var(--bn-radius-md);
-  cursor: grab;
-  transition: box-shadow var(--bn-transition-fast), transform var(--bn-transition-fast);
-  user-select: none;
-}
+  /* === Toast === */
+  [data-bn='toast-container'] {
+    position: fixed;
+    z-index: var(--bn-z-toast);
+    display: flex;
+    flex-direction: column;
+    gap: var(--bn-space-2);
+    padding: var(--bn-space-4);
+    pointer-events: none;
+  }
+  [data-bn='toast-container'][data-position='top-right'] {
+    top: 0;
+    right: 0;
+  }
+  [data-bn='toast-container'][data-position='top-left'] {
+    top: 0;
+    left: 0;
+  }
+  [data-bn='toast-container'][data-position='bottom-right'] {
+    bottom: 0;
+    right: 0;
+  }
+  [data-bn='toast-container'][data-position='bottom-left'] {
+    bottom: 0;
+    left: 0;
+  }
 
-[data-bn="pipeline-card"]:hover {
-  box-shadow: var(--bn-shadow-md);
-  transform: translateY(-2px);
-}
+  /* === Table === */
+  [data-bn='table-container'] {
+    overflow-x: auto;
+  }
+  [data-bn='table'] {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--bn-font-size-sm);
+  }
+  [data-bn='table'] caption {
+    font-size: var(--bn-font-size-sm);
+    color: var(--bn-color-text-muted);
+    text-align: left;
+    padding-bottom: var(--bn-space-2);
+  }
+  [data-bn='table'] th {
+    text-align: left;
+    padding: var(--bn-space-3) var(--bn-space-4);
+    font-weight: var(--bn-font-weight-medium);
+    color: var(--bn-color-text-muted);
+    border-bottom: 1px solid var(--bn-color-border);
+  }
+  [data-bn='table'] td {
+    padding: var(--bn-space-3) var(--bn-space-4);
+    border-bottom: 1px solid var(--bn-color-border);
+    color: var(--bn-color-text);
+  }
+  [data-bn='table'] tbody tr:nth-child(even) {
+    background: rgb(255 255 255 / 0.02);
+  }
+  [data-bn='table'] tbody tr:hover {
+    background: var(--bn-color-surface-subtle);
+  }
+  [data-bn='table-empty'] {
+    text-align: center;
+    color: var(--bn-color-text-muted);
+    padding: var(--bn-space-8) !important;
+  }
 
-[data-bn="pipeline-card"][data-dragging] {
-  opacity: 0.5;
-  cursor: grabbing;
-}
+  /* === Pagination === */
+  [data-bn='pagination'] ul {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    gap: var(--bn-space-1);
+  }
+  [data-bn='pagination'] a,
+  [data-bn='pagination'] span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2rem;
+    height: 2rem;
+    padding: 0 var(--bn-space-2);
+    font-size: var(--bn-font-size-sm);
+    border-radius: var(--bn-radius-md);
+    text-decoration: none;
+    color: var(--bn-color-text);
+  }
+  [data-bn='pagination'] a:hover {
+    background: var(--bn-color-surface-muted);
+  }
+  [data-bn='pagination'] a:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+  [data-bn='pagination'] a[aria-current='page'] {
+    background: var(--bn-color-primary-600);
+    color: var(--bn-color-white);
+  }
+  [data-bn='pagination'] span[aria-disabled] {
+    opacity: 0.4;
+    cursor: default;
+  }
 
-[data-bn="pipeline-card-title"] {
-  font-weight: var(--bn-font-weight-medium);
-  font-size: var(--bn-font-size-sm);
-  color: var(--bn-color-text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
+  /* === Badge === */
+  [data-bn='badge'] {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--bn-space-1) var(--bn-space-2);
+    font-size: var(--bn-font-size-xs);
+    font-weight: var(--bn-font-weight-medium);
+    border-radius: var(--bn-radius-full);
+    line-height: 1;
+  }
+  [data-bn='badge'][data-variant='default'] {
+    background: var(--bn-color-border);
+    color: var(--bn-color-text);
+  }
+  [data-bn='badge'][data-variant='primary'] {
+    background: var(--bn-color-info-bg);
+    color: var(--bn-color-info-text);
+  }
+  [data-bn='badge'][data-variant='success'] {
+    background: var(--bn-color-success-badge-bg);
+    color: var(--bn-color-success-badge-text);
+  }
+  [data-bn='badge'][data-variant='warning'] {
+    background: var(--bn-color-warning-badge-bg);
+    color: var(--bn-color-warning-badge-text);
+  }
+  [data-bn='badge'][data-variant='error'] {
+    background: var(--bn-color-error-badge-bg);
+    color: var(--bn-color-error-badge-text);
+  }
 
-[data-bn="pipeline-card-subtitle"] {
-  font-size: var(--bn-font-size-xs);
-  color: var(--bn-color-text-muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
+  /* === Card === */
+  [data-bn='card'] {
+    background: var(--bn-color-surface);
+    border: 1px solid var(--bn-color-border);
+    border-radius: var(--bn-radius-lg);
+    overflow: hidden;
+  }
+  [data-bn='card-header'] {
+    padding: var(--bn-space-4) var(--bn-space-6);
+    border-bottom: 1px solid var(--bn-color-border);
+    font-weight: var(--bn-font-weight-semibold);
+  }
+  [data-bn='card-body'] {
+    padding: var(--bn-space-4) var(--bn-space-6);
+  }
+  [data-bn='card-footer'] {
+    padding: var(--bn-space-4) var(--bn-space-6);
+    border-top: 1px solid var(--bn-color-border);
+    background: var(--bn-color-surface-subtle);
+  }
 
-[data-bn="pipeline-card-description"] {
-  font-size: var(--bn-font-size-xs);
-  color: var(--bn-color-text-muted);
-  line-height: var(--bn-line-height-relaxed);
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
+  /* === Progress === */
+  [data-bn='progress'] {
+    width: 100%;
+    height: 0.5rem;
+    border-radius: var(--bn-radius-full);
+    appearance: none;
+    border: none;
+    background: var(--bn-color-surface-muted);
+  }
+  [data-bn='progress']::-webkit-progress-bar {
+    background: var(--bn-color-surface-muted);
+    border-radius: var(--bn-radius-full);
+  }
+  [data-bn='progress']::-webkit-progress-value {
+    background: var(--bn-color-accent-600);
+    border-radius: var(--bn-radius-full);
+  }
+  [data-bn='progress']::-moz-progress-bar {
+    background: var(--bn-color-accent-600);
+    border-radius: var(--bn-radius-full);
+  }
 
-[data-bn="pipeline-empty"] {
-  padding: var(--bn-space-4);
-  text-align: center;
-  color: var(--bn-color-text-muted);
-  font-size: var(--bn-font-size-sm);
-  opacity: 0.6;
-}
+  /* === Spinner === */
+  [data-bn='spinner'] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  [data-bn='spinner'] > span {
+    width: 1.25rem;
+    height: 1.25rem;
+    border: 2px solid var(--bn-color-border);
+    border-top-color: var(--bn-color-accent-600);
+    border-radius: var(--bn-radius-full);
+    animation: bn-spin 0.6s linear infinite;
+  }
+  [data-bn='spinner'][data-size='sm'] > span {
+    width: 1rem;
+    height: 1rem;
+  }
+  [data-bn='spinner'][data-size='lg'] > span {
+    width: 2rem;
+    height: 2rem;
+  }
+  @keyframes bn-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
 
+  /* === Skeleton === */
+  [data-bn='skeleton'] {
+    background: linear-gradient(
+      90deg,
+      var(--bn-color-surface-muted) 25%,
+      var(--bn-color-border) 50%,
+      var(--bn-color-surface-muted) 75%
+    );
+    background-size: 200% 100%;
+    animation: bn-shimmer 1.5s infinite;
+    border-radius: var(--bn-radius-md);
+  }
+  [data-bn='skeleton'][data-variant='circle'] {
+    border-radius: var(--bn-radius-full);
+  }
+  @keyframes bn-shimmer {
+    0% {
+      background-position: 200% 0;
+    }
+    100% {
+      background-position: -200% 0;
+    }
+  }
+
+  /* === Accordion === */
+  [data-bn='accordion'] {
+    display: flex;
+    flex-direction: column;
+  }
+  [data-bn='accordion-item'] {
+    border: var(--bn-border-width) solid var(--bn-color-border);
+    border-radius: var(--bn-radius-lg);
+    overflow: hidden;
+  }
+  [data-bn='accordion-item'] + [data-bn='accordion-item'] {
+    margin-top: calc(-1 * var(--bn-border-width));
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+  [data-bn='accordion-item']:first-child {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+  [data-bn='accordion-item']:only-child {
+    border-radius: var(--bn-radius-lg);
+  }
+  [data-bn='accordion-header'] {
+    display: flex;
+    align-items: center;
+    gap: var(--bn-space-2);
+    padding: var(--bn-space-component-y) var(--bn-space-component-x);
+    font-size: var(--bn-font-size-component);
+    font-weight: var(--bn-font-weight-medium);
+    background: var(--bn-color-surface);
+    cursor: pointer;
+    border: none;
+    width: 100%;
+    text-align: left;
+    color: var(--bn-color-text);
+    list-style: none;
+  }
+  [data-bn='accordion-header']::before {
+    content: '\25B8';
+    font-size: 0.75em;
+    color: var(--bn-color-accent-600);
+    transition: rotate var(--bn-transition-fast);
+    flex-shrink: 0;
+  }
+  [data-bn='accordion-header']::-webkit-details-marker {
+    display: none;
+  }
+  [data-bn='accordion-item'][open] > [data-bn='accordion-header']::before {
+    rotate: 90deg;
+  }
+  [data-bn='accordion-header']:hover {
+    background: var(--bn-color-surface-subtle);
+  }
+  [data-bn='accordion-header']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+    position: relative;
+    z-index: 1;
+  }
+  [data-bn='accordion-content'] {
+    padding: var(--bn-space-3) var(--bn-space-4);
+    font-size: var(--bn-font-size-sm);
+    color: var(--bn-color-text);
+    border-top: var(--bn-border-width) solid var(--bn-color-border);
+  }
+
+  /* === Avatar === */
+  [data-bn='avatar'] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: var(--bn-radius-full);
+    overflow: hidden;
+    background: var(--bn-color-border-strong);
+    color: var(--bn-color-text);
+    font-weight: var(--bn-font-weight-semibold);
+    font-size: var(--bn-font-size-sm);
+    flex-shrink: 0;
+  }
+  [data-bn='avatar'][data-size='sm'] {
+    width: 2rem;
+    height: 2rem;
+    font-size: var(--bn-font-size-xs);
+  }
+  [data-bn='avatar'][data-size='lg'] {
+    width: 3rem;
+    height: 3rem;
+    font-size: var(--bn-font-size-base);
+  }
+  [data-bn='avatar'][data-size='xl'] {
+    width: 4rem;
+    height: 4rem;
+    font-size: var(--bn-font-size-lg);
+  }
+  [data-bn='avatar'][data-shape='square'] {
+    border-radius: var(--bn-radius-lg);
+  }
+  [data-bn='avatar-img'] {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+  [data-bn='avatar-initials'] {
+    line-height: 1;
+    user-select: none;
+  }
+
+  /* === Breadcrumb === */
+  [data-bn='breadcrumb'] {
+    font-size: var(--bn-font-size-sm);
+  }
+  [data-bn='breadcrumb-list'] {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--bn-space-1);
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  [data-bn='breadcrumb-item'] {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--bn-space-1);
+  }
+  [data-bn='breadcrumb-item'] a {
+    color: var(--bn-color-text-link);
+    text-decoration: none;
+  }
+  [data-bn='breadcrumb-item'] a:hover {
+    color: var(--bn-color-text);
+    text-decoration: underline;
+  }
+  [data-bn='breadcrumb-item'] a:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+    border-radius: var(--bn-radius-sm);
+  }
+  [data-bn='breadcrumb-item'][aria-current] {
+    color: var(--bn-color-text);
+    font-weight: var(--bn-font-weight-semibold);
+  }
+  [data-bn='breadcrumb-separator'] {
+    color: var(--bn-color-text-subtle);
+    font-size: var(--bn-font-size-xs);
+    user-select: none;
+  }
+
+  /* === Combobox === */
+  [data-bn='combobox'] {
+    position: relative;
+  }
+  [data-bn='combobox-input'] {
+    padding: var(--bn-space-component-y) var(--bn-space-component-x);
+    font-family: var(--bn-font-family);
+    font-size: var(--bn-font-size-component);
+    color: var(--bn-color-text);
+    background: var(--bn-color-surface);
+    border: var(--bn-border-width) solid var(--bn-color-border);
+    border-radius: var(--bn-radius-md);
+    width: 100%;
+    transition: border-color var(--bn-transition-fast);
+  }
+  [data-bn='combobox-input']:focus {
+    border-color: var(--bn-color-border-focus);
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+  [data-bn='combobox-input'][aria-invalid='true'] {
+    border-color: var(--bn-color-error-500);
+  }
+  [data-bn='combobox-input']:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    background: var(--bn-color-surface-muted);
+  }
+
+  /* === Command Palette === */
+  [data-bn='command-palette'] {
+    border: none;
+    padding: 0;
+    border-radius: var(--bn-radius-xl);
+    background: var(--bn-color-surface);
+    box-shadow: var(--bn-shadow-lg);
+    max-width: 32rem;
+    width: 90vi;
+    max-height: min(24rem, 80vh);
+    overflow: hidden;
+    /* Reset zeroes margin globally; restore UA centering for modal dialogs. */
+    margin: auto;
+  }
+  [data-bn='command-palette'][open] {
+    display: flex;
+    flex-direction: column;
+  }
+  [data-bn='command-palette']::backdrop {
+    background: rgb(0 0 0 / 0.4);
+    backdrop-filter: blur(4px);
+  }
+  [data-bn='command-header'] {
+    padding: var(--bn-space-3) var(--bn-space-4);
+    border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+  }
+  [data-bn='command-input'] {
+    width: 100%;
+    padding: var(--bn-space-2) 0;
+    border: none;
+    background: transparent;
+    font-size: var(--bn-font-size-base);
+    color: var(--bn-color-text);
+    outline: none;
+  }
+  [data-bn='command-input']::placeholder {
+    color: var(--bn-color-text-subtle);
+  }
+  [data-bn='command-list'] {
+    overflow-y: auto;
+    flex: 1;
+    padding: var(--bn-space-2);
+  }
+  [data-bn='command-group'] {
+    margin-bottom: var(--bn-space-2);
+  }
+  [data-bn='command-group-label'] {
+    padding: var(--bn-space-1) var(--bn-space-2);
+    font-size: var(--bn-font-size-xs);
+    font-weight: var(--bn-font-weight-medium);
+    color: var(--bn-color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: var(--bn-letter-spacing-wide);
+  }
+  [data-bn='command-item'] {
+    display: flex;
+    align-items: center;
+    gap: var(--bn-space-3);
+    padding: var(--bn-space-2) var(--bn-space-3);
+    border-radius: var(--bn-radius-md);
+    cursor: pointer;
+    color: var(--bn-color-text);
+    font-size: var(--bn-font-size-sm);
+  }
+  [data-bn='command-item']:hover,
+  [data-bn='command-item'][aria-selected='true'] {
+    background: var(--bn-color-surface-muted);
+  }
+  [data-bn='command-item']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+  [data-bn='command-icon'] {
+    flex-shrink: 0;
+    width: 1rem;
+    height: 1rem;
+    color: var(--bn-color-text-muted);
+  }
+  [data-bn='command-label'] {
+    flex: 1;
+  }
+  [data-bn='command-shortcut'] {
+    font-family: var(--bn-font-mono);
+    font-size: var(--bn-font-size-xs);
+    color: var(--bn-color-text-subtle);
+  }
+  [data-bn='command-footer'] {
+    padding: var(--bn-space-2) var(--bn-space-4);
+    border-top: var(--bn-border-width) solid var(--bn-color-border);
+    font-size: var(--bn-font-size-xs);
+    color: var(--bn-color-text-muted);
+  }
+
+  /* === Data Grid === */
+  [data-bn='datagrid'] {
+    border: var(--bn-border-width) solid var(--bn-color-border);
+    border-radius: var(--bn-radius-lg);
+    overflow: hidden;
+  }
+  [data-bn='datagrid-scroll'] {
+    overflow-x: auto;
+  }
+  [data-bn='datagrid-table'] {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--bn-font-size-sm);
+  }
+  [data-bn='datagrid-th'] {
+    text-align: left;
+    padding: var(--bn-space-3) var(--bn-space-4);
+    font-weight: var(--bn-font-weight-medium);
+    color: var(--bn-color-text-muted);
+    border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+    background: var(--bn-color-surface-subtle);
+    position: sticky;
+    top: 0;
+    white-space: nowrap;
+    user-select: none;
+  }
+  [data-bn='datagrid-th'][data-sortable] {
+    cursor: pointer;
+  }
+  [data-bn='datagrid-th'][data-sortable]:hover {
+    color: var(--bn-color-text);
+  }
+  [data-bn='datagrid-th'][data-sortable]:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+  [data-bn='datagrid-th'][data-sorted]::after {
+    content: '';
+    display: inline-block;
+    width: 0;
+    height: 0;
+    margin-left: var(--bn-space-1);
+    vertical-align: middle;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+  }
+  [data-bn='datagrid-th'][data-sorted='asc']::after {
+    border-bottom: 4px solid currentColor;
+  }
+  [data-bn='datagrid-th'][data-sorted='desc']::after {
+    border-top: 4px solid currentColor;
+  }
+  [data-bn='datagrid-th-select'],
+  [data-bn='datagrid-td-select'] {
+    width: 2.5rem;
+    text-align: center;
+  }
+  [data-bn='datagrid'] input[type='checkbox'] {
+    appearance: none;
+    width: 1rem;
+    height: 1rem;
+    background: var(--bn-color-surface);
+    border: var(--bn-border-width) solid var(--bn-color-border-strong);
+    border-radius: var(--bn-radius-sm);
+    cursor: pointer;
+    position: relative;
+  }
+  [data-bn='datagrid'] input[type='checkbox']:checked {
+    background: var(--bn-color-accent-600);
+    border-color: var(--bn-color-accent-600);
+  }
+  [data-bn='datagrid'] input[type='checkbox']:checked::after {
+    content: '';
+    position: absolute;
+    top: 1px;
+    left: 3px;
+    width: 4px;
+    height: 7px;
+    border: solid var(--bn-color-white);
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+  }
+  [data-bn='datagrid'] input[type='checkbox']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+  [data-bn='datagrid-row']:hover {
+    background: var(--bn-color-surface-subtle);
+  }
+  [data-bn='datagrid-td'] {
+    padding: var(--bn-space-3) var(--bn-space-4);
+    border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+    color: var(--bn-color-text);
+  }
+  [data-bn='datagrid-empty'] {
+    text-align: center;
+    color: var(--bn-color-text-muted);
+    padding: var(--bn-space-8);
+  }
+  [data-bn='datagrid-footer'] {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--bn-space-3) var(--bn-space-4);
+    border-top: var(--bn-border-width) solid var(--bn-color-border);
+    background: var(--bn-color-surface-subtle);
+  }
+  [data-bn='datagrid-info'] {
+    font-size: var(--bn-font-size-xs);
+    color: var(--bn-color-text-muted);
+  }
+
+  /* === Dialog === */
+  [data-bn='dialog'] {
+    border: none;
+    padding: 0;
+    border-radius: var(--bn-radius-xl);
+    background: var(--bn-color-surface);
+    box-shadow: var(--bn-shadow-lg);
+    max-width: 28rem;
+    width: 90vi;
+    color: var(--bn-color-text);
+    /* Reset zeroes margin on every element; restore UA centering for modal dialogs. */
+    margin: auto;
+  }
+  [data-bn='dialog']::backdrop {
+    background: rgb(0 0 0 / 0.4);
+    backdrop-filter: blur(4px);
+  }
+  [data-bn='dialog'][data-size='sm'] {
+    max-width: 20rem;
+  }
+  [data-bn='dialog'][data-size='lg'] {
+    max-width: 40rem;
+  }
+  [data-bn='dialog-header'] {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--bn-space-4) var(--bn-space-6);
+    border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+  }
+  [data-bn='dialog-title'] {
+    font-size: var(--bn-font-size-lg);
+    font-weight: var(--bn-font-weight-semibold);
+  }
+  [data-bn='dialog-close'] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border: none;
+    background: transparent;
+    border-radius: var(--bn-radius-md);
+    cursor: pointer;
+    color: var(--bn-color-text-muted);
+    font-size: var(--bn-font-size-lg);
+  }
+  [data-bn='dialog-close']:hover {
+    background: var(--bn-color-surface-muted);
+    color: var(--bn-color-text);
+  }
+  [data-bn='dialog-close']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+  [data-bn='dialog-body'] {
+    padding: var(--bn-space-4) var(--bn-space-6);
+  }
+  [data-bn='dialog-footer'] {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--bn-space-2);
+    padding: var(--bn-space-4) var(--bn-space-6);
+    border-top: var(--bn-border-width) solid var(--bn-color-border);
+  }
+
+  /* === Drawer === */
+  [data-bn='drawer'] {
+    display: flex;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    z-index: var(--bn-z-modal);
+    background: var(--bn-color-surface);
+    box-shadow: var(--bn-shadow-lg);
+    flex-direction: column;
+    width: 20rem;
+    transform: translateX(100%);
+    transition: transform 300ms var(--bn-ease-out-expo);
+  }
+  [data-bn='drawer'][data-position='left'] {
+    right: auto;
+    left: 0;
+    transform: translateX(-100%);
+  }
+  [data-bn='drawer'][data-open] {
+    transform: translateX(0);
+  }
+  [data-bn='drawer'][data-size='sm'] {
+    width: 16rem;
+  }
+  [data-bn='drawer'][data-size='lg'] {
+    width: 28rem;
+  }
+  [data-bn='drawer-overlay'] {
+    position: fixed;
+    inset: 0;
+    z-index: calc(var(--bn-z-modal) - 1);
+    background: rgb(0 0 0 / 0.4);
+    backdrop-filter: blur(2px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 300ms var(--bn-ease-out-expo);
+  }
+  [data-bn='drawer-overlay'][data-open] {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  [data-bn='drawer-header'] {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--bn-space-4) var(--bn-space-6);
+    border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+  }
+  [data-bn='drawer-title'] {
+    font-size: var(--bn-font-size-lg);
+    font-weight: var(--bn-font-weight-semibold);
+  }
+  [data-bn='drawer-close'] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border: none;
+    background: transparent;
+    border-radius: var(--bn-radius-md);
+    cursor: pointer;
+    color: var(--bn-color-text-muted);
+  }
+  [data-bn='drawer-close']:hover {
+    background: var(--bn-color-surface-muted);
+    color: var(--bn-color-text);
+  }
+  [data-bn='drawer-close']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+  [data-bn='drawer-body'] {
+    padding: var(--bn-space-4) var(--bn-space-6);
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  /* === Dropdown Menu === */
+  [data-bn='dropdown'] {
+    position: relative;
+    display: inline-flex;
+  }
+  [data-bn='dropdown-trigger'] {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--bn-space-2);
+    padding: var(--bn-space-component-y) var(--bn-space-component-x);
+    font-family: var(--bn-font-family);
+    font-size: var(--bn-font-size-component);
+    font-weight: var(--bn-font-weight-medium);
+    background: var(--bn-color-surface);
+    color: var(--bn-color-text);
+    border: var(--bn-border-width) solid var(--bn-color-border);
+    border-radius: var(--bn-radius-md);
+    cursor: pointer;
+  }
+  [data-bn='dropdown-trigger']:hover {
+    background: var(--bn-color-surface-muted);
+  }
+  [data-bn='dropdown-trigger']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+  [data-bn='dropdown-menu'] {
+    /* Anchored via CSS vars set by showcase.js when the popover toggles. */
+    position: fixed;
+    inset: auto;
+    top: var(--bn-dropdown-top, 0);
+    left: var(--bn-dropdown-left, 0);
+    margin: 0;
+    z-index: var(--bn-z-dropdown);
+    min-width: 10rem;
+    padding: var(--bn-space-1);
+    background: var(--bn-color-surface);
+    border: var(--bn-border-width) solid var(--bn-color-border);
+    border-radius: var(--bn-radius-lg);
+    box-shadow: var(--bn-shadow-md);
+  }
+  [data-bn='dropdown-menu']:popover-open,
+  [data-bn='dropdown-menu'][data-open] {
+    display: flex;
+    flex-direction: column;
+  }
+  /* Fallback for browsers without the popover API */
+  [data-bn='dropdown-menu']:not([data-open]):not(:popover-open) {
+    display: none;
+  }
+  [data-bn='dropdown-item'] {
+    display: flex;
+    align-items: center;
+    gap: var(--bn-space-2);
+    padding: var(--bn-space-2) var(--bn-space-3);
+    font-size: var(--bn-font-size-sm);
+    color: var(--bn-color-text);
+    border: none;
+    background: transparent;
+    border-radius: var(--bn-radius-md);
+    cursor: pointer;
+    text-align: left;
+    width: 100%;
+  }
+  [data-bn='dropdown-item']:hover {
+    background: var(--bn-color-surface-muted);
+  }
+  [data-bn='dropdown-item']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+  [data-bn='dropdown-item'][aria-disabled='true'] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  [data-bn='dropdown-icon'] {
+    flex-shrink: 0;
+    width: 1rem;
+    height: 1rem;
+    color: var(--bn-color-text-muted);
+  }
+  [data-bn='dropdown-shortcut'] {
+    margin-left: auto;
+    font-family: var(--bn-font-mono);
+    font-size: var(--bn-font-size-xs);
+    color: var(--bn-color-text-subtle);
+  }
+  [data-bn='dropdown-separator'] {
+    height: var(--bn-border-width);
+    background: var(--bn-color-border);
+    margin: var(--bn-space-1) 0;
+  }
+
+  /* === Multiselect === */
+  [data-bn='multiselect'] {
+    position: relative;
+  }
+  [data-bn='multiselect'] select[hidden] {
+    display: none;
+  }
+  [data-bn='multiselect'][data-disabled] {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+  [data-bn='multiselect-container'] {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--bn-space-1);
+    padding: var(--bn-space-1) var(--bn-space-2);
+    min-height: 2.5rem;
+    background: var(--bn-color-surface);
+    border: var(--bn-border-width) solid var(--bn-color-border);
+    border-radius: var(--bn-radius-md);
+    cursor: text;
+    transition: border-color var(--bn-transition-fast);
+  }
+  [data-bn='multiselect-container']:focus-within {
+    border-color: var(--bn-color-border-focus);
+    box-shadow: var(--bn-focus-ring);
+  }
+  [data-bn='multiselect-tags'] {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--bn-space-1);
+  }
+  [data-bn='tag'] {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--bn-space-1);
+    padding: var(--bn-space-1) var(--bn-space-2);
+    font-size: var(--bn-font-size-xs);
+    font-weight: var(--bn-font-weight-medium);
+    background: var(--bn-color-surface-muted);
+    border-radius: var(--bn-radius-full);
+    color: var(--bn-color-text);
+    line-height: 1;
+  }
+  [data-bn='tag-remove'] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1rem;
+    height: 1rem;
+    border: none;
+    background: transparent;
+    border-radius: var(--bn-radius-full);
+    cursor: pointer;
+    color: var(--bn-color-text-muted);
+    font-size: var(--bn-font-size-xs);
+    line-height: 1;
+  }
+  [data-bn='tag-remove']:hover {
+    background: var(--bn-color-border);
+    color: var(--bn-color-text);
+  }
+  [data-bn='tag-remove']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+  [data-bn='multiselect-search'] {
+    border: none;
+    outline: none;
+    background: transparent;
+    font-size: var(--bn-font-size-component);
+    color: var(--bn-color-text);
+    flex: 1;
+    min-width: 4rem;
+    padding: var(--bn-space-1) 0;
+  }
+
+  /* === Tabs === */
+  [data-bn='tabs'] {
+    display: flex;
+    flex-direction: column;
+  }
+  [data-bn='tab-list'] {
+    display: flex;
+    gap: 0;
+    border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+  }
+  [data-bn='tab'] {
+    padding: var(--bn-space-2) var(--bn-space-4);
+    font-size: var(--bn-font-size-sm);
+    font-weight: var(--bn-font-weight-medium);
+    color: var(--bn-color-text-muted);
+    background: transparent;
+    border: none;
+    border-bottom: 3px solid transparent;
+    cursor: pointer;
+    margin-bottom: calc(-1 * var(--bn-border-width));
+    transition:
+      color var(--bn-transition-fast),
+      border-color var(--bn-transition-fast);
+  }
+  [data-bn='tab']:hover {
+    color: var(--bn-color-text);
+  }
+  [data-bn='tab'][aria-selected='true'] {
+    color: var(--bn-color-text);
+    border-bottom-color: var(--bn-color-accent-600);
+  }
+  [data-bn='tab']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+    position: relative;
+    z-index: 1;
+  }
+  [data-bn='tab']:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  [data-bn='tab-panel'] {
+    padding: var(--bn-space-4) 0;
+  }
+  [data-bn='tab-panel'][hidden] {
+    display: none;
+  }
+  /* Tabs: pills variant */
+  [data-bn='tabs'][data-variant='pills'] [data-bn='tab-list'] {
+    border-bottom: none;
+    gap: var(--bn-space-1);
+  }
+  [data-bn='tabs'][data-variant='pills'] [data-bn='tab'] {
+    border-bottom: none;
+    border-radius: var(--bn-radius-md);
+    margin-bottom: 0;
+  }
+  [data-bn='tabs'][data-variant='pills'] [data-bn='tab'][aria-selected='true'] {
+    background: var(--bn-color-surface-muted);
+    color: var(--bn-color-text);
+  }
+
+  /* === Toast (individual item) === */
+  [data-bn='toast'] {
+    pointer-events: auto;
+    display: flex;
+    align-items: flex-start;
+    gap: var(--bn-space-2);
+    padding: var(--bn-space-3) var(--bn-space-4);
+    background: var(--bn-color-surface);
+    border: var(--bn-border-width) solid var(--bn-color-border);
+    border-radius: var(--bn-radius-lg);
+    box-shadow: var(--bn-shadow-md);
+    font-size: var(--bn-font-size-sm);
+    color: var(--bn-color-text);
+    max-width: 24rem;
+  }
+  [data-bn='toast'][data-variant='success'] {
+    border-color: var(--bn-color-success-border);
+  }
+  [data-bn='toast'][data-variant='error'] {
+    border-color: var(--bn-color-error-border);
+  }
+  [data-bn='toast'][data-variant='warning'] {
+    border-color: var(--bn-color-warning-border);
+  }
+  [data-bn='toast'][data-variant='info'] {
+    border-color: var(--bn-color-info-border);
+  }
+
+  /* === Tooltip === */
+  [data-bn='tooltip'] {
+    position: fixed;
+    inset: auto;
+    top: var(--bn-tooltip-top, 0);
+    left: var(--bn-tooltip-left, 0);
+    margin: 0;
+    transform: translate(-50%, -100%);
+    z-index: var(--bn-z-dropdown);
+    max-width: 20rem;
+    padding: var(--bn-space-2) var(--bn-space-3);
+    background: var(--bn-color-surface-inverse);
+    color: var(--bn-color-text-inverse);
+    font-size: var(--bn-font-size-xs);
+    border-radius: var(--bn-radius-md);
+    pointer-events: none;
+    white-space: normal;
+    line-height: var(--bn-line-height-normal);
+  }
+  [data-bn='tooltip-trigger'] {
+    cursor: default;
+  }
+
+  /* === Tree === */
+  [data-bn='tree'] {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-size: var(--bn-font-size-sm);
+  }
+  [data-bn='tree-item'] {
+    display: flex;
+    flex-direction: column;
+  }
+  [data-bn='tree-item-content'] {
+    display: flex;
+    align-items: center;
+    gap: var(--bn-space-1);
+    padding: var(--bn-space-1) var(--bn-space-2);
+    border-radius: var(--bn-radius-md);
+    cursor: pointer;
+    color: var(--bn-color-text);
+  }
+  [data-bn='tree-item-content']:hover {
+    background: var(--bn-color-surface-subtle);
+  }
+  [data-bn='tree-item-content'][data-selected] {
+    background: var(--bn-color-primary-50);
+    color: var(--bn-color-primary-700);
+  }
+  [data-bn='tree-item-content']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+    position: relative;
+    z-index: 1;
+  }
+  [data-bn='tree-indent'] {
+    flex-shrink: 0;
+  }
+  [data-bn='tree-toggle'] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: var(--bn-color-text-muted);
+    border-radius: var(--bn-radius-sm);
+    flex-shrink: 0;
+  }
+  [data-bn='tree-toggle']:hover {
+    background: var(--bn-color-surface-muted);
+  }
+  [data-bn='tree-toggle']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+  [data-bn='tree-icon'] {
+    flex-shrink: 0;
+    width: 1rem;
+    height: 1rem;
+    color: var(--bn-color-text-muted);
+  }
+  [data-bn='tree-label'] {
+    flex: 1;
+  }
+  [data-bn='tree-children'] {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  /* Tree item indentation via data-level */
+  [data-bn='tree-item'][data-level='1'] [data-bn='tree-item-content'] {
+    padding-left: var(--bn-space-6);
+  }
+  [data-bn='tree-item'][data-level='2'] [data-bn='tree-item-content'] {
+    padding-left: var(--bn-space-10);
+  }
+  [data-bn='tree-item'][data-level='3'] [data-bn='tree-item-content'] {
+    padding-left: var(--bn-space-16);
+  }
+  /* Tree Grid */
+  [data-bn='treegrid'] {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--bn-font-size-sm);
+  }
+  [data-bn='treegrid-row'] {
+    cursor: pointer;
+  }
+  [data-bn='treegrid-row']:hover {
+    background: var(--bn-color-surface-subtle);
+  }
+  [data-bn='treegrid-row']:focus-visible {
+    box-shadow: var(--bn-focus-ring);
+    outline: none;
+  }
+
+  /* === Virtualizer === */
+  [data-bn='virtualizer'] {
+    overflow: auto;
+    border: var(--bn-border-width) solid var(--bn-color-border);
+    border-radius: var(--bn-radius-lg);
+  }
+  [data-bn='virtual-window'] {
+    position: relative;
+  }
+  [data-bn='virtual-item'] {
+    padding: var(--bn-space-3) var(--bn-space-4);
+    border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+    font-size: var(--bn-font-size-sm);
+  }
+  [data-bn='virtual-item']:last-child {
+    border-bottom: none;
+  }
+
+  /* === Calendar === */
+  [data-bn='calendar'] {
+    position: relative;
+    overflow: auto;
+    border: var(--bn-border-width) solid var(--bn-color-border);
+    border-radius: var(--bn-radius-md);
+    background: var(--bn-color-surface);
+  }
+  [data-bn='calendar-grid'] {
+    display: grid;
+    grid-template-columns: 4rem repeat(var(--bn-calendar-cols, 7), 1fr);
+    grid-template-rows: auto repeat(var(--bn-calendar-hours, 12), minmax(3.5rem, 1fr));
+    min-height: 0;
+  }
+  [data-bn='calendar-corner'] {
+    grid-column: 1;
+    grid-row: 1;
+    border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+    border-right: var(--bn-border-width) solid var(--bn-color-border);
+    background: var(--bn-color-surface-muted);
+  }
+  [data-bn='calendar-day-header'] {
+    grid-row: 1;
+    padding: var(--bn-space-2) var(--bn-space-3);
+    font-size: var(--bn-font-size-sm);
+    font-weight: var(--bn-font-weight-semibold);
+    text-align: center;
+    border-bottom: var(--bn-border-width) solid var(--bn-color-border);
+    border-right: var(--bn-border-width) solid var(--bn-color-border);
+    background: var(--bn-color-surface-muted);
+  }
+  [data-bn='calendar-day-header']:last-of-type {
+    border-right: none;
+  }
+  [data-bn='calendar-time-gutter'] {
+    grid-column: 1;
+    grid-row: 2 / -1;
+    position: relative;
+    border-right: var(--bn-border-width) solid var(--bn-color-border);
+  }
+  [data-bn='calendar-time-label'] {
+    position: absolute;
+    right: var(--bn-space-2);
+    font-size: var(--bn-font-size-xs);
+    color: var(--bn-color-text-muted);
+    line-height: 1;
+    transform: translateY(-50%);
+  }
+  [data-bn='calendar-day-column'] {
+    position: relative;
+    display: grid;
+    grid-row: 2 / -1;
+    grid-template-rows: subgrid;
+    border-right: var(--bn-border-width) solid var(--bn-color-border);
+  }
+  [data-bn='calendar-day-column']:last-of-type {
+    border-right: none;
+  }
+  [data-bn='calendar-slot'] {
+    border-bottom: var(--bn-border-width) solid var(--bn-color-border-light, var(--bn-color-border));
+    transition: background-color var(--bn-transition-fast);
+  }
+  [data-bn='calendar-slot'][data-drop-target] {
+    background: var(--bn-color-primary-50, hsl(210 100% 95%));
+  }
+  [data-bn='calendar-event'] {
+    position: absolute;
+    inset-inline: var(--bn-space-1);
+    display: flex;
+    flex-direction: column;
+    gap: var(--bn-space-half, 0.125rem);
+    padding: var(--bn-space-1) var(--bn-space-2);
+    background: var(--bn-calendar-event-color, var(--bn-color-primary-100));
+    border-left: 3px solid var(--bn-calendar-event-color, var(--bn-color-primary-600));
+    border-radius: var(--bn-radius-sm);
+    font-size: var(--bn-font-size-xs);
+    cursor: grab;
+    overflow: hidden;
+    z-index: 1;
+  }
+  [data-bn='calendar-event'][data-dragging] {
+    opacity: 0.5;
+    cursor: grabbing;
+  }
+  [data-bn='calendar-event'][data-status='scheduled'] {
+    --bn-calendar-event-color: var(--bn-color-primary-600);
+    background: var(--bn-color-primary-50);
+  }
+  [data-bn='calendar-event'][data-status='in_progress'] {
+    --bn-calendar-event-color: var(--bn-color-warning-500, hsl(38 90% 50%));
+    background: var(--bn-color-warning-50, hsl(38 90% 95%));
+  }
+  [data-bn='calendar-event'][data-status='completed'] {
+    --bn-calendar-event-color: var(--bn-color-success-500, hsl(145 55% 40%));
+    background: var(--bn-color-success-50, hsl(145 55% 95%));
+  }
+  [data-bn='calendar-event-title'] {
+    font-weight: var(--bn-font-weight-semibold);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  [data-bn='calendar-event-assignee'] {
+    color: var(--bn-color-text-muted);
+  }
+  [data-bn='calendar-event-time'] {
+    color: var(--bn-color-text-muted);
+  }
+
+  /* Pipeline block (draggable card for sidebar dispatch) */
+  [data-bn='pipeline-block'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--bn-space-1);
+    padding: var(--bn-space-2) var(--bn-space-3);
+    background: var(--bn-color-surface);
+    border: var(--bn-border-width) solid var(--bn-color-border);
+    border-radius: var(--bn-radius-md);
+    cursor: grab;
+    transition:
+      box-shadow var(--bn-transition-fast),
+      border-color var(--bn-transition-fast);
+  }
+  [data-bn='pipeline-block']:hover {
+    border-color: var(--bn-color-primary-300);
+    box-shadow: var(--bn-shadow-sm);
+  }
+  [data-bn='pipeline-block'][data-dragging] {
+    opacity: 0.5;
+    cursor: grabbing;
+  }
+  [data-bn='pipeline-block-title'] {
+    font-weight: var(--bn-font-weight-medium);
+    font-size: var(--bn-font-size-sm);
+  }
+  [data-bn='pipeline-block-subtitle'] {
+    font-size: var(--bn-font-size-xs);
+    color: var(--bn-color-text-muted);
+  }
+
+  [data-bn='calendar-empty'] {
+    padding: var(--bn-space-8);
+    text-align: center;
+    color: var(--bn-color-text-muted);
+    font-size: var(--bn-font-size-sm);
+  }
+
+  /* Pipeline / Kanban component */
+  [data-bn='pipeline'] {
+    display: grid;
+    grid-auto-flow: column;
+    gap: var(--bn-space-4);
+    overflow-x: auto;
+    padding: var(--bn-space-3);
+    background: var(--bn-color-surface-muted);
+    border-radius: var(--bn-radius-md);
+    min-height: 20rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [data-bn='pipeline'] [data-bn='pipeline-card'] {
+      transition: none;
+    }
+  }
+
+  [data-bn='pipeline-column'] {
+    flex: 0 0 min(100%, 20rem);
+    display: flex;
+    flex-direction: column;
+    gap: var(--bn-space-2);
+    min-height: 0;
+  }
+
+  [data-bn='pipeline-column-header'] {
+    font-weight: var(--bn-font-weight-semibold);
+    font-size: var(--bn-font-size-sm);
+    color: var(--bn-color-text);
+    padding: var(--bn-space-2) 0;
+    border-bottom: 2px solid var(--bn-color-border);
+  }
+
+  [data-bn='pipeline-column-cards'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--bn-space-2);
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+    padding: var(--bn-space-1);
+    border-radius: var(--bn-radius-md);
+    transition: background-color var(--bn-transition-fast);
+  }
+
+  [data-bn='pipeline-column-cards'][data-drop-target] {
+    background-color: var(--bn-color-primary-50, hsl(210 100% 95%));
+    border: 2px dashed var(--bn-color-primary-200, hsl(210 100% 85%));
+  }
+
+  [data-bn='pipeline-card'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--bn-space-1);
+    padding: var(--bn-space-2);
+    background: var(--bn-color-surface);
+    border: 1px solid var(--bn-color-border);
+    border-radius: var(--bn-radius-md);
+    cursor: grab;
+    transition:
+      box-shadow var(--bn-transition-fast),
+      transform var(--bn-transition-fast);
+    user-select: none;
+  }
+
+  [data-bn='pipeline-card']:hover {
+    box-shadow: var(--bn-shadow-md);
+    transform: translateY(-2px);
+  }
+
+  [data-bn='pipeline-card'][data-dragging] {
+    opacity: 0.5;
+    cursor: grabbing;
+  }
+
+  [data-bn='pipeline-card-title'] {
+    font-weight: var(--bn-font-weight-medium);
+    font-size: var(--bn-font-size-sm);
+    color: var(--bn-color-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  [data-bn='pipeline-card-subtitle'] {
+    font-size: var(--bn-font-size-xs);
+    color: var(--bn-color-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  [data-bn='pipeline-card-description'] {
+    font-size: var(--bn-font-size-xs);
+    color: var(--bn-color-text-muted);
+    line-height: var(--bn-line-height-relaxed);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  [data-bn='pipeline-empty'] {
+    padding: var(--bn-space-4);
+    text-align: center;
+    color: var(--bn-color-text-muted);
+    font-size: var(--bn-font-size-sm);
+    opacity: 0.6;
+  }
 } /* end @layer components */

--- a/packages/components/src/components.css
+++ b/packages/components/src/components.css
@@ -478,6 +478,8 @@
   width: 90vi;
   max-height: min(24rem, 80vh);
   overflow: hidden;
+  /* Reset zeroes margin globally; restore UA centering for modal dialogs. */
+  margin: auto;
 }
 [data-bn="command-palette"][open] {
   display: flex;
@@ -647,6 +649,8 @@
   max-width: 28rem;
   width: 90vi;
   color: var(--bn-color-text);
+  /* Reset zeroes margin on every element; restore UA centering for modal dialogs. */
+  margin: auto;
 }
 [data-bn="dialog"]::backdrop {
   background: rgb(0 0 0 / 0.4);
@@ -760,7 +764,12 @@
 [data-bn="dropdown-trigger"]:hover { background: var(--bn-color-surface-muted); }
 [data-bn="dropdown-trigger"]:focus-visible { box-shadow: var(--bn-focus-ring); outline: none; }
 [data-bn="dropdown-menu"] {
-  position: absolute;
+  /* Anchored via CSS vars set by showcase.js when the popover toggles. */
+  position: fixed;
+  inset: auto;
+  top: var(--bn-dropdown-top, 0);
+  left: var(--bn-dropdown-left, 0);
+  margin: 0;
   z-index: var(--bn-z-dropdown);
   min-width: 10rem;
   padding: var(--bn-space-1);
@@ -769,9 +778,14 @@
   border-radius: var(--bn-radius-lg);
   box-shadow: var(--bn-shadow-md);
 }
-[data-bn="dropdown-menu"]:popover-open {
+[data-bn="dropdown-menu"]:popover-open,
+[data-bn="dropdown-menu"][data-open] {
   display: flex;
   flex-direction: column;
+}
+/* Fallback for browsers without the popover API */
+[data-bn="dropdown-menu"]:not([data-open]):not(:popover-open) {
+  display: none;
 }
 [data-bn="dropdown-item"] {
   display: flex;
@@ -930,7 +944,12 @@
 
 /* === Tooltip === */
 [data-bn="tooltip"] {
-  position: absolute;
+  position: fixed;
+  inset: auto;
+  top: var(--bn-tooltip-top, 0);
+  left: var(--bn-tooltip-left, 0);
+  margin: 0;
+  transform: translate(-50%, -100%);
   z-index: var(--bn-z-dropdown);
   max-width: 20rem;
   padding: var(--bn-space-2) var(--bn-space-3);

--- a/packages/components/src/dialog.js
+++ b/packages/components/src/dialog.js
@@ -16,7 +16,7 @@ export function renderDialog(options = {}) {
 
   const openAttr = open ? ' open' : '';
   const closeBtn = closable
-    ? `<button data-bn="dialog-close" aria-label="Close" type="button">&times;</button>`
+    ? `<button data-bn="dialog-close" data-bn-action="close-dialog" aria-label="Close" type="button">&times;</button>`
     : '';
 
   return `<dialog data-bn="dialog" data-size="${size}" id="${id}"${openAttr} ${attrs}>

--- a/packages/components/src/drawer.js
+++ b/packages/components/src/drawer.js
@@ -17,7 +17,9 @@ export function renderDrawer(options = {}) {
   const closeBtn = closable
     ? `<button data-bn="drawer-close" data-bn-action="close-drawer" aria-label="Close" type="button">&times;</button>`
     : '';
-  const overlayHtml = overlay ? `<div data-bn="drawer-overlay"${open ? '' : ' hidden'}></div>` : '';
+  const overlayHtml = overlay
+    ? `<div data-bn="drawer-overlay"${open ? ' data-open' : ''}></div>`
+    : '';
 
   return `${overlayHtml}<aside data-bn="drawer" data-position="${position}" data-size="${size}" id="${id}"${open ? ' data-open' : ''} role="dialog" aria-modal="true" ${attrs}>
   <div data-bn="drawer-header">

--- a/packages/components/src/drawer.js
+++ b/packages/components/src/drawer.js
@@ -15,7 +15,7 @@ export function renderDrawer(options = {}) {
   } = options;
 
   const closeBtn = closable
-    ? `<button data-bn="drawer-close" aria-label="Close" type="button">&times;</button>`
+    ? `<button data-bn="drawer-close" data-bn-action="close-drawer" aria-label="Close" type="button">&times;</button>`
     : '';
   const overlayHtml = overlay ? `<div data-bn="drawer-overlay"${open ? '' : ' hidden'}></div>` : '';
 

--- a/packages/components/src/multiselect.js
+++ b/packages/components/src/multiselect.js
@@ -20,7 +20,7 @@ export function renderMultiselect(options = {}) {
     .map(val => {
       const item = items.find(i => (typeof i === 'string' ? i : i.value) === val);
       const text = item ? (typeof item === 'string' ? item : item.label) : val;
-      return `<span data-bn="tag" data-value="${val}">${text}<button type="button" data-bn="tag-remove" aria-label="Remove ${text}">&times;</button></span>`;
+      return `<span data-bn="tag" data-value="${val}">${text}<button type="button" data-bn="tag-remove" data-bn-action="remove-tag" aria-label="Remove ${text}">&times;</button></span>`;
     })
     .join('');
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -34,5 +34,8 @@
     "reactive",
     "ssr",
     "zero-dependencies"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,7 +14,7 @@
   },
   "types": "./types/render.d.ts",
   "dependencies": {
-    "@basenative/runtime": "^0.4.0",
+    "@basenative/runtime": "workspace:^0.4.0",
     "node-html-parser": "^7.0.1"
   },
   "files": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basenative/server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Server-side rendering with streaming support for BaseNative templates",
   "type": "module",
   "exports": {
@@ -14,7 +14,7 @@
   },
   "types": "./types/render.d.ts",
   "dependencies": {
-    "@basenative/runtime": "workspace:*",
+    "@basenative/runtime": "^0.4.0",
     "node-html-parser": "^7.0.1"
   },
   "files": [
@@ -38,5 +38,8 @@
     "ssr",
     "streaming",
     "server-rendering"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,8 +346,8 @@ importers:
   packages/server:
     dependencies:
       '@basenative/runtime':
-        specifier: workspace:*
-        version: link:../runtime
+        specifier: ^0.4.0
+        version: 0.4.1
       node-html-parser:
         specifier: ^7.0.1
         version: 7.1.0
@@ -406,6 +406,9 @@ packages:
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
+
+  '@basenative/runtime@0.4.1':
+    resolution: {integrity: sha512-L61KyHhPt8sCg7OwsIwGK3nq+O4g/I8Xp7zOcZje1daR1iqQZnyx4de0SOpevBE5ajdPyjPsoK6ktugVLxiI6Q==, tarball: https://npm.pkg.github.com/download/@basenative/runtime/0.4.1/19e9d0d995086d338355d53742576572ab1ede3b}
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -2535,6 +2538,8 @@ packages:
 snapshots:
 
   '@babel/runtime@7.29.2': {}
+
+  '@basenative/runtime@0.4.1': {}
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,8 +346,8 @@ importers:
   packages/server:
     dependencies:
       '@basenative/runtime':
-        specifier: ^0.4.0
-        version: 0.4.1
+        specifier: workspace:^0.4.0
+        version: link:../runtime
       node-html-parser:
         specifier: ^7.0.1
         version: 7.1.0
@@ -406,9 +406,6 @@ packages:
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
-
-  '@basenative/runtime@0.4.1':
-    resolution: {integrity: sha512-L61KyHhPt8sCg7OwsIwGK3nq+O4g/I8Xp7zOcZje1daR1iqQZnyx4de0SOpevBE5ajdPyjPsoK6ktugVLxiI6Q==, tarball: https://npm.pkg.github.com/download/@basenative/runtime/0.4.1/19e9d0d995086d338355d53742576572ab1ede3b}
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -2538,8 +2535,6 @@ packages:
 snapshots:
 
   '@babel/runtime@7.29.2': {}
-
-  '@basenative/runtime@0.4.1': {}
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:


### PR DESCRIPTION
## Summary

Audit of `basenative.com/showcase` surfaced seven broken or visually-off interactive components. This PR fixes all of them, plus extracts the inline `<script type="module">` block in `views/showcase.html` into a proper `public/showcase.js` that uses `data-bn-action` delegation (no inline handlers).

### Root causes

- **Drawer / command palette didn't open.** Inline `onclick="openDrawer()"` and `onclick="…showModal()"` referenced functions declared inside a `<script type="module">` block — those never reach `window` scope.
- **Dialog & command palette landed top-left.** The components reset (`* { margin: 0 }` in `reset.css`) overrides the UA stylesheet's `margin: auto` that normally centers modal `<dialog>` elements. Adding `margin: auto` back on `[data-bn="dialog"]` and `[data-bn="command-palette"]` (in `@layer components`, which beats the reset layer) restores centering.
- **Dropdown menu & tooltip popovers floated to top-left.** `position: absolute` with no offsets and a popover top-layer rendering put them at `0,0` of the popover containing block. They are now `position: fixed` with `top`/`left` driven by CSS custom properties that `showcase.js` sets from the trigger's `getBoundingClientRect()` on toggle/hover.
- **Tooltip never showed.** `popovertargetaction="toggle"` only toggles on click; tooltips need hover/focus wiring. Added `mouseenter`/`mouseleave`/`focus`/`blur` handlers in `showcase.js`.
- **Alert × and multiselect tag × didn't fire.** The renderers now emit `data-bn-action="dismiss-alert"` / `data-bn-action="remove-tag"` and `showcase.js` handles them through a single delegated click listener. The tag-remove handler also deselects the matching `<option>` in the hidden `<select>` so form submission stays correct.

### Files

- `examples/express/public/showcase.js` *(new)* — consolidates all client behaviour behind a `data-bn-action` delegation pattern.
- `examples/express/views/showcase.html` — replaces inline `onclick=` with `data-bn-action` / `data-bn-target`; drops the inline `<script type="module">` block.
- `examples/express/server.js` — injects `<script type="module" src="/showcase.js"></script>` only on the showcase route.
- `packages/components/src/{alert,multiselect,dialog,drawer,command-palette}.js` — emit the matching `data-bn-action` attribute on dismiss/close/remove buttons.
- `packages/components/src/components.css` — `margin: auto` on dialog & command-palette; CSS-var-driven positioning on dropdown-menu & tooltip.

### Test plan

- [x] Run `examples/express` server, navigate to `/showcase`.
- [x] Click × on the error alert → alert is removed from DOM.
- [x] Click × on the "CSS" tag in Multiselect → tag removed and hidden `<select>`'s "CSS" option is deselected.
- [x] Open dialog → centered horizontally and vertically.
- [x] Open drawer → slides in from right; close button & overlay click both close it.
- [x] Open dropdown → menu anchored below the "Actions" trigger button.
- [x] Hover "Hover me" → tooltip appears above; mouse leave hides it.
- [x] Open command palette → centered modal with focused search input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)