### PR TITLE
fix(showcase,components): polish audit fixes (avatars, layout grid, calendar, kanban, datagrid)

### DIFF
--- a/examples/express/public/avatar-eve.svg
+++ b/examples/express/public/avatar-eve.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Eve Martinez">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7c3aed"/>
+      <stop offset="100%" stop-color="#2563eb"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" fill="url(#bg)"/>
+  <circle cx="32" cy="26" r="11" fill="#fef3c7"/>
+  <path d="M10 60c0-12 9.85-20 22-20s22 8 22 20z" fill="#fef3c7"/>
+  <path d="M21 22 q11 -14 22 0 q-3 -3 -7 -2 q-4 -7 -10 -3 q-4 0 -5 5z" fill="#1e1b4b"/>
+</svg>

--- a/examples/express/public/styles.css
+++ b/examples/express/public/styles.css
@@ -552,8 +552,8 @@
     border-inline-start-color: var(--accent);
   }
 
-  /* -- Status badges -- */
-  [data-status] {
+  /* -- Status badges (scoped to <mark> so component data-status is unaffected) -- */
+  mark[data-status] {
     display: inline-block;
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
@@ -563,23 +563,23 @@
     font-weight: var(--font-weight-semibold);
     white-space: nowrap;
   }
-  [data-status='active'],
-  [data-status='done'] {
+  mark[data-status='active'],
+  mark[data-status='done'] {
     background: var(--status-active-bg);
     color: var(--success);
   }
-  [data-status='idle'],
-  [data-status='dom'],
-  [data-status='binding'] {
+  mark[data-status='idle'],
+  mark[data-status='dom'],
+  mark[data-status='binding'] {
     background: var(--status-idle-bg);
     color: var(--accent);
   }
-  [data-status='error'] {
+  mark[data-status='error'] {
     background: var(--status-error-bg);
     color: var(--danger);
   }
-  [data-status='pending'],
-  [data-status='server'] {
+  mark[data-status='pending'],
+  mark[data-status='server'] {
     background: var(--status-pending-bg);
     color: var(--text-2);
   }

--- a/examples/express/showcase-data.js
+++ b/examples/express/showcase-data.js
@@ -332,6 +332,7 @@ export function getShowcaseContext() {
       renderAvatar({ name: 'Bob Smith' }),
       renderAvatar({ name: 'Carol Davis', size: 'lg' }),
       renderAvatar({ name: 'Dan Lee', size: 'xl' }),
+      renderAvatar({ name: 'Eve Martinez', src: '/avatar-eve.svg', size: 'lg' }),
     ].join('\n'),
 
     inputDefault: renderInput({

--- a/packages/components/src/calendar.js
+++ b/packages/components/src/calendar.js
@@ -83,7 +83,7 @@ export function renderCalendar(options = {}) {
   for (let h = hourStart; h < hourEnd; h++) {
     const label = h <= 12 ? `${h}am` : `${h - 12}pm`;
     timeLabels.push(
-      `<div data-bn="calendar-time-label" data-hour="${h}" style="grid-row: ${h - hourStart + 2}">${h === 12 ? '12pm' : label}</div>`
+      `<div data-bn="calendar-time-label" data-hour="${h}" style="grid-row: ${h - hourStart + 1}">${h === 12 ? '12pm' : label}</div>`
     );
   }
 
@@ -99,7 +99,7 @@ export function renderCalendar(options = {}) {
       const statusAttr = ev.status ? ` data-status="${ev.status}"` : '';
       const colorStyle = ev.color ? ` --bn-calendar-event-color: ${ev.color};` : '';
 
-      return `<div data-bn="calendar-event" draggable="true" data-event-id="${ev.id}"${statusAttr} style="grid-row: ${topRow} / span ${Math.ceil(span)};${colorStyle}">
+      return `<div data-bn="calendar-event" draggable="true" data-event-id="${ev.id}"${statusAttr} title="${ev.title}" style="grid-row: ${topRow} / span ${Math.ceil(span)};${colorStyle}">
   <span data-bn="calendar-event-title">${ev.title}</span>
   ${ev.assignee ? `<span data-bn="calendar-event-assignee">${ev.assignee}</span>` : ''}
   <span data-bn="calendar-event-time">${new Date(ev.start).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })} – ${new Date(ev.end).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}</span>
@@ -179,7 +179,7 @@ export function renderPipeline(options = {}) {
     const colCards = cards.filter(c => c.columnId === col.id);
     const cardsHtml = colCards.map(card => {
       const statusAttr = card.status ? ` data-status="${card.status}"` : '';
-      return `<article data-bn="pipeline-card" data-card-id="${card.id}" draggable="true"${statusAttr}>
+      return `<article data-bn="pipeline-card" data-card-id="${card.id}" draggable="true"${statusAttr} title="${card.title}">
   <div data-bn="pipeline-card-title">${card.title}</div>
   ${card.subtitle ? `<div data-bn="pipeline-card-subtitle">${card.subtitle}</div>` : ''}
   ${card.description ? `<div data-bn="pipeline-card-description">${card.description}</div>` : ''}

--- a/packages/components/src/components.css
+++ b/packages/components/src/components.css
@@ -588,6 +588,9 @@
   appearance: none;
   width: 1rem;
   height: 1rem;
+  min-inline-size: 1rem;
+  min-block-size: 1rem;
+  flex: none;
   background: var(--bn-color-surface);
   border: var(--bn-border-width) solid var(--bn-color-border-strong);
   border-radius: var(--bn-radius-sm);
@@ -1046,16 +1049,17 @@
 [data-bn="calendar-time-gutter"] {
   grid-column: 1;
   grid-row: 2 / -1;
-  position: relative;
+  display: grid;
+  grid-template-rows: subgrid;
   border-right: var(--bn-border-width) solid var(--bn-color-border);
 }
 [data-bn="calendar-time-label"] {
-  position: absolute;
-  right: var(--bn-space-2);
+  align-self: start;
+  justify-self: end;
+  padding: var(--bn-space-1) var(--bn-space-2) 0 0;
   font-size: var(--bn-font-size-xs);
   color: var(--bn-color-text-muted);
   line-height: 1;
-  transform: translateY(-50%);
 }
 [data-bn="calendar-day-column"] {
   position: relative;
@@ -1083,6 +1087,7 @@
   border-left: 3px solid var(--bn-calendar-event-color, var(--bn-color-primary-600));
   border-radius: var(--bn-radius-sm);
   font-size: var(--bn-font-size-xs);
+  color: var(--bn-color-gray-900);
   cursor: grab;
   overflow: hidden;
   z-index: 1;
@@ -1102,15 +1107,13 @@
 }
 [data-bn="calendar-event-title"] {
   font-weight: var(--bn-font-weight-semibold);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: var(--bn-line-height-tight);
 }
-[data-bn="calendar-event-assignee"] {
-  color: var(--bn-color-text-muted);
-}
+[data-bn="calendar-event-assignee"],
 [data-bn="calendar-event-time"] {
-  color: var(--bn-color-text-muted);
+  color: var(--bn-color-gray-700, hsl(220 10% 30%));
 }
 
 /* Pipeline block (draggable card for sidebar dispatch) */
@@ -1224,17 +1227,16 @@
   font-weight: var(--bn-font-weight-medium);
   font-size: var(--bn-font-size-sm);
   color: var(--bn-color-text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: var(--bn-line-height-snug, 1.35);
 }
 
 [data-bn="pipeline-card-subtitle"] {
   font-size: var(--bn-font-size-xs);
   color: var(--bn-color-text-muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 [data-bn="pipeline-card-description"] {
@@ -1253,6 +1255,36 @@
   color: var(--bn-color-text-muted);
   font-size: var(--bn-font-size-sm);
   opacity: 0.6;
+}
+
+/* === Layout Grid (visual builder primitive) === */
+[data-bn="layout-grid"] {
+  min-height: 8rem;
+  padding: var(--bn-space-2);
+  background: var(--bn-color-surface-muted);
+  border: 1px dashed var(--bn-color-border);
+  border-radius: var(--bn-radius-md);
+}
+[data-bn="layout-cell"] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--bn-space-3);
+  background: var(--bn-color-surface);
+  border: 1px solid var(--bn-color-border);
+  border-radius: var(--bn-radius-sm);
+  font-size: var(--bn-font-size-sm);
+  color: var(--bn-color-text-muted);
+  transition: border-color var(--bn-transition-fast), box-shadow var(--bn-transition-fast);
+}
+[data-bn="layout-cell"]:hover {
+  border-color: var(--bn-color-primary-300, var(--bn-color-border-strong));
+}
+[data-bn="layout-cell"][draggable="true"] { cursor: grab; }
+[data-bn="layout-cell"][draggable="true"]:active { cursor: grabbing; opacity: 0.7; }
+[data-bn="layout-cell"].drop-target {
+  border-color: var(--bn-color-primary-500);
+  box-shadow: inset 0 0 0 2px var(--bn-color-primary-500);
 }
 
 } /* end @layer components */

--- a/packages/components/src/datagrid.js
+++ b/packages/components/src/datagrid.js
@@ -41,7 +41,7 @@ export function renderDataGrid(options = {}) {
       return `<td data-bn="datagrid-td" data-key="${col.key}"${editable}>${value}</td>`;
     }).join('');
     const selectCell = selectable
-      ? `<td data-bn="datagrid-td-select"><input type="checkbox" ${selectedSet.has(rowId) ? 'checked ' : ''}aria-label="Select row ${rowId}" data-row-id="${rowId}"></td>`
+      ? `<td data-bn="datagrid-td-select"><input type="checkbox" ${selectedSet.has(rowId) ? 'checked ' : ''}aria-label="Select row ${rowId}" data-bn="datagrid-row-select" data-row-id="${rowId}"></td>`
       : '';
     return `<tr data-bn="datagrid-row" data-row-id="${rowId}">${selectCell}${cells}</tr>`;
   }).join('');

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -117,6 +117,7 @@ cpSync(join(express, 'public', 'theme.css'), join(dist, 'theme.css'));
 cpSync(join(express, 'public', 'basenative.js'), join(dist, 'basenative.js'));
 cpSync(join(express, 'public', 'showcase.js'), join(dist, 'showcase.js'));
 cpSync(join(express, 'public', 'favicon.svg'), join(dist, 'favicon.svg'));
+cpSync(join(express, 'public', 'avatar-eve.svg'), join(dist, 'avatar-eve.svg'));
 
 // Copy component CSS (served as /bn-css/ in Express, must exist in dist)
 const bnCssDir = join(dist, 'bn-css');


### PR DESCRIPTION
## Summary

Polish bugs surfaced by an audit of `/showcase` on the deployed site.

- **Avatars** — added an image-backed avatar (`/avatar-eve.svg`) so the section demos `src=` rendering, not just initials fallbacks.
- **Layout grid** — added `[data-bn="layout-grid"]` / `[data-bn="layout-cell"]` styles in `components.css` (`layoutGridStyles()` was never imported), so Header / Sidebar / Main / Aside / Footer render as visually distinct cells.
- **Calendar time labels** — gutter is now `display:grid; grid-template-rows: subgrid` instead of `position: relative` with absolute-positioned labels (which all stacked at the top). All 10 hour labels (8am–5pm) are visible.
- **Calendar event titles** — wrap instead of ellipsing; chip text uses `gray-900` / `gray-700` so light pastel status backgrounds stay readable on the dark site. `title="..."` added for hover tooltip.
- **Pipeline (kanban) cards** — title and subtitle wrap; `title="..."` on the article.
- **Site `[data-status]` rule** — scoped to `mark[data-status]`. The unscoped rule was forcing badge styles (inline-block, padding, nowrap) onto every component using `data-status` for state — this is what was breaking the kanban titles.
- **Datagrid row checkboxes** — added `data-bn="datagrid-row-select"` on the row `<input>` so the site-level `input[type=checkbox]:not([data-bn])` 2.75rem touch-target min-size no longer applies. Row checkboxes are now compact like the header one.

## Test plan

- [x] `node --test` in `packages/components` (136/136 pass)
- [x] Visually verified each section in the Express preview at desktop + tablet widths
- [x] Verified computed styles via DOM inspection: calendar event title color = `rgb(24,24,27)` on `rgb(253,244,231)` bg; datagrid checkbox = 16×16

🤖 Generated with [Claude Code](https://claude.com/claude-code)