### PR TITLE
feat(components): drawer slide-in animation + overlay fade

### DIFF
--- a/examples/express/public/showcase.js
+++ b/examples/express/public/showcase.js
@@ -88,12 +88,12 @@ function wireDrawer() {
 
     const open = () => {
       drawer.setAttribute('data-open', '');
-      overlay?.removeAttribute('hidden');
+      overlay?.setAttribute('data-open', '');
       drawer.querySelector('[data-bn="drawer-close"], button')?.focus();
     };
     const close = () => {
       drawer.removeAttribute('data-open');
-      overlay?.setAttribute('hidden', '');
+      overlay?.removeAttribute('data-open');
       trigger.focus();
     };
 

--- a/packages/components/src/components.css
+++ b/packages/components/src/components.css
@@ -694,7 +694,7 @@
 
 /* === Drawer === */
 [data-bn="drawer"] {
-  display: none;
+  display: flex;
   position: fixed;
   top: 0;
   bottom: 0;
@@ -704,9 +704,15 @@
   box-shadow: var(--bn-shadow-lg);
   flex-direction: column;
   width: 20rem;
+  transform: translateX(100%);
+  transition: transform 300ms var(--bn-ease-out-expo);
 }
-[data-bn="drawer"][data-position="left"] { right: auto; left: 0; }
-[data-bn="drawer"][data-open] { display: flex; }
+[data-bn="drawer"][data-position="left"] {
+  right: auto;
+  left: 0;
+  transform: translateX(-100%);
+}
+[data-bn="drawer"][data-open] { transform: translateX(0); }
 [data-bn="drawer"][data-size="sm"] { width: 16rem; }
 [data-bn="drawer"][data-size="lg"] { width: 28rem; }
 [data-bn="drawer-overlay"] {
@@ -715,8 +721,14 @@
   z-index: calc(var(--bn-z-modal) - 1);
   background: rgb(0 0 0 / 0.4);
   backdrop-filter: blur(2px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 300ms var(--bn-ease-out-expo);
 }
-[data-bn="drawer-overlay"][hidden] { display: none; }
+[data-bn="drawer-overlay"][data-open] {
+  opacity: 1;
+  pointer-events: auto;
+}
 [data-bn="drawer-header"] {
   display: flex;
   align-items: center;

--- a/packages/components/src/drawer.js
+++ b/packages/components/src/drawer.js
@@ -17,7 +17,7 @@ export function renderDrawer(options = {}) {
   const closeBtn = closable
     ? `<button data-bn="drawer-close" aria-label="Close" type="button">&times;</button>`
     : '';
-  const overlayHtml = overlay ? `<div data-bn="drawer-overlay"${open ? '' : ' hidden'}></div>` : '';
+  const overlayHtml = overlay ? `<div data-bn="drawer-overlay"${open ? ' data-open' : ''}></div>` : '';
 
   return `${overlayHtml}<aside data-bn="drawer" data-position="${position}" data-size="${size}" id="${id}"${open ? ' data-open' : ''} role="dialog" aria-modal="true" ${attrs}>
   <div data-bn="drawer-header">


### PR DESCRIPTION
## Summary

Replaces the drawer's hard `display: none → flex` pop with a real slide-in animation matching the reference UI kit:

- Drawer slides from its position-edge with `transform: translateX(±100%) → 0`, eased with the system's `--bn-ease-out-expo` curve.
- Overlay fades via `opacity: 0 → 1` plus a `pointer-events` toggle.
- Drawer always renders `display: flex`; the closed state is the off-axis transform, so the open transition is a slide rather than a sudden mount.

## Changes

- **`packages/components/src/components.css`** — drawer + overlay rules updated. (The CSS formatter ran across the whole file; only the drawer/overlay block is a semantic change, the rest is whitespace/indentation normalization.)
- **`packages/components/src/drawer.js`** — overlay closed-state attribute switched from `hidden` to absence-of-`data-open` so opacity can transition.
- **`examples/express/public/showcase.js`** — `wireDrawer` now toggles `[data-open]` on the overlay instead of `[hidden]`.

## Test plan

- [x] Run `examples/express` server, navigate to `/showcase`.
- [x] Click "Open drawer" → drawer slides in from right; backdrop fades in.
- [x] Click overlay → drawer slides out; backdrop fades.
- [x] Click drawer × → same.
- [x] Press Escape while drawer is open → same.
- [x] Verified `getComputedStyle(drawer).transform === "matrix(1, 0, 0, 1, 320, 0)"` in closed state and identity in open state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)