### PR TITLE
chore: remove 36 duplicate AI tool skill folders

### DIFF
--- a/.adal/skills/link-workspace-packages
+++ b/.adal/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.adal/skills/monitor-ci
+++ b/.adal/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.adal/skills/nx-generate
+++ b/.adal/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.adal/skills/nx-import
+++ b/.adal/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.adal/skills/nx-plugins
+++ b/.adal/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.adal/skills/nx-run-tasks
+++ b/.adal/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.adal/skills/nx-workspace
+++ b/.adal/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.aider-desk/skills/link-workspace-packages
+++ b/.aider-desk/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.aider-desk/skills/monitor-ci
+++ b/.aider-desk/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.aider-desk/skills/nx-generate
+++ b/.aider-desk/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.aider-desk/skills/nx-import
+++ b/.aider-desk/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.aider-desk/skills/nx-plugins
+++ b/.aider-desk/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.aider-desk/skills/nx-run-tasks
+++ b/.aider-desk/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.aider-desk/skills/nx-workspace
+++ b/.aider-desk/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.augment/skills/link-workspace-packages
+++ b/.augment/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.augment/skills/monitor-ci
+++ b/.augment/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.augment/skills/nx-generate
+++ b/.augment/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.augment/skills/nx-import
+++ b/.augment/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.augment/skills/nx-plugins
+++ b/.augment/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.augment/skills/nx-run-tasks
+++ b/.augment/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.augment/skills/nx-workspace
+++ b/.augment/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.bob/skills/link-workspace-packages
+++ b/.bob/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.bob/skills/monitor-ci
+++ b/.bob/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.bob/skills/nx-generate
+++ b/.bob/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.bob/skills/nx-import
+++ b/.bob/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.bob/skills/nx-plugins
+++ b/.bob/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.bob/skills/nx-run-tasks
+++ b/.bob/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.bob/skills/nx-workspace
+++ b/.bob/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.codeartsdoer/skills/link-workspace-packages
+++ b/.codeartsdoer/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.codeartsdoer/skills/monitor-ci
+++ b/.codeartsdoer/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.codeartsdoer/skills/nx-generate
+++ b/.codeartsdoer/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.codeartsdoer/skills/nx-import
+++ b/.codeartsdoer/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.codeartsdoer/skills/nx-plugins
+++ b/.codeartsdoer/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.codeartsdoer/skills/nx-run-tasks
+++ b/.codeartsdoer/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.codeartsdoer/skills/nx-workspace
+++ b/.codeartsdoer/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.codebuddy/skills/link-workspace-packages
+++ b/.codebuddy/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.codebuddy/skills/monitor-ci
+++ b/.codebuddy/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.codebuddy/skills/nx-generate
+++ b/.codebuddy/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.codebuddy/skills/nx-import
+++ b/.codebuddy/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.codebuddy/skills/nx-plugins
+++ b/.codebuddy/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.codebuddy/skills/nx-run-tasks
+++ b/.codebuddy/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.codebuddy/skills/nx-workspace
+++ b/.codebuddy/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.codemaker/skills/link-workspace-packages
+++ b/.codemaker/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.codemaker/skills/monitor-ci
+++ b/.codemaker/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.codemaker/skills/nx-generate
+++ b/.codemaker/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.codemaker/skills/nx-import
+++ b/.codemaker/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.codemaker/skills/nx-plugins
+++ b/.codemaker/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.codemaker/skills/nx-run-tasks
+++ b/.codemaker/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.codemaker/skills/nx-workspace
+++ b/.codemaker/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.codestudio/skills/link-workspace-packages
+++ b/.codestudio/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.codestudio/skills/monitor-ci
+++ b/.codestudio/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.codestudio/skills/nx-generate
+++ b/.codestudio/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.codestudio/skills/nx-import
+++ b/.codestudio/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.codestudio/skills/nx-plugins
+++ b/.codestudio/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.codestudio/skills/nx-run-tasks
+++ b/.codestudio/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.codestudio/skills/nx-workspace
+++ b/.codestudio/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.commandcode/skills/link-workspace-packages
+++ b/.commandcode/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.commandcode/skills/monitor-ci
+++ b/.commandcode/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.commandcode/skills/nx-generate
+++ b/.commandcode/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.commandcode/skills/nx-import
+++ b/.commandcode/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.commandcode/skills/nx-plugins
+++ b/.commandcode/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.commandcode/skills/nx-run-tasks
+++ b/.commandcode/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.commandcode/skills/nx-workspace
+++ b/.commandcode/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.continue/skills/link-workspace-packages
+++ b/.continue/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.continue/skills/monitor-ci
+++ b/.continue/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.continue/skills/nx-generate
+++ b/.continue/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.continue/skills/nx-import
+++ b/.continue/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.continue/skills/nx-plugins
+++ b/.continue/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.continue/skills/nx-run-tasks
+++ b/.continue/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.continue/skills/nx-workspace
+++ b/.continue/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.cortex/skills/link-workspace-packages
+++ b/.cortex/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.cortex/skills/monitor-ci
+++ b/.cortex/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.cortex/skills/nx-generate
+++ b/.cortex/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.cortex/skills/nx-import
+++ b/.cortex/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.cortex/skills/nx-plugins
+++ b/.cortex/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.cortex/skills/nx-run-tasks
+++ b/.cortex/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.cortex/skills/nx-workspace
+++ b/.cortex/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.crush/skills/link-workspace-packages
+++ b/.crush/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.crush/skills/monitor-ci
+++ b/.crush/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.crush/skills/nx-generate
+++ b/.crush/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.crush/skills/nx-import
+++ b/.crush/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.crush/skills/nx-plugins
+++ b/.crush/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.crush/skills/nx-run-tasks
+++ b/.crush/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.crush/skills/nx-workspace
+++ b/.crush/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.devin/skills/link-workspace-packages
+++ b/.devin/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.devin/skills/monitor-ci
+++ b/.devin/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.devin/skills/nx-generate
+++ b/.devin/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.devin/skills/nx-import
+++ b/.devin/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.devin/skills/nx-plugins
+++ b/.devin/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.devin/skills/nx-run-tasks
+++ b/.devin/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.devin/skills/nx-workspace
+++ b/.devin/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.factory/skills/link-workspace-packages
+++ b/.factory/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.factory/skills/monitor-ci
+++ b/.factory/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.factory/skills/nx-generate
+++ b/.factory/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.factory/skills/nx-import
+++ b/.factory/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.factory/skills/nx-plugins
+++ b/.factory/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.factory/skills/nx-run-tasks
+++ b/.factory/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.factory/skills/nx-workspace
+++ b/.factory/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.forge/skills/link-workspace-packages
+++ b/.forge/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.forge/skills/monitor-ci
+++ b/.forge/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.forge/skills/nx-generate
+++ b/.forge/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.forge/skills/nx-import
+++ b/.forge/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.forge/skills/nx-plugins
+++ b/.forge/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.forge/skills/nx-run-tasks
+++ b/.forge/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.forge/skills/nx-workspace
+++ b/.forge/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.goose/skills/link-workspace-packages
+++ b/.goose/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.goose/skills/monitor-ci
+++ b/.goose/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.goose/skills/nx-generate
+++ b/.goose/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.goose/skills/nx-import
+++ b/.goose/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.goose/skills/nx-plugins
+++ b/.goose/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.goose/skills/nx-run-tasks
+++ b/.goose/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.goose/skills/nx-workspace
+++ b/.goose/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.iflow/skills/link-workspace-packages
+++ b/.iflow/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.iflow/skills/monitor-ci
+++ b/.iflow/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.iflow/skills/nx-generate
+++ b/.iflow/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.iflow/skills/nx-import
+++ b/.iflow/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.iflow/skills/nx-plugins
+++ b/.iflow/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.iflow/skills/nx-run-tasks
+++ b/.iflow/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.iflow/skills/nx-workspace
+++ b/.iflow/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.junie/skills/link-workspace-packages
+++ b/.junie/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.junie/skills/monitor-ci
+++ b/.junie/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.junie/skills/nx-generate
+++ b/.junie/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.junie/skills/nx-import
+++ b/.junie/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.junie/skills/nx-plugins
+++ b/.junie/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.junie/skills/nx-run-tasks
+++ b/.junie/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.junie/skills/nx-workspace
+++ b/.junie/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.kilocode/skills/link-workspace-packages
+++ b/.kilocode/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.kilocode/skills/monitor-ci
+++ b/.kilocode/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.kilocode/skills/nx-generate
+++ b/.kilocode/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.kilocode/skills/nx-import
+++ b/.kilocode/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.kilocode/skills/nx-plugins
+++ b/.kilocode/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.kilocode/skills/nx-run-tasks
+++ b/.kilocode/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.kilocode/skills/nx-workspace
+++ b/.kilocode/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.kiro/skills/link-workspace-packages
+++ b/.kiro/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.kiro/skills/monitor-ci
+++ b/.kiro/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.kiro/skills/nx-generate
+++ b/.kiro/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.kiro/skills/nx-import
+++ b/.kiro/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.kiro/skills/nx-plugins
+++ b/.kiro/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.kiro/skills/nx-run-tasks
+++ b/.kiro/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.kiro/skills/nx-workspace
+++ b/.kiro/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.kode/skills/link-workspace-packages
+++ b/.kode/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.kode/skills/monitor-ci
+++ b/.kode/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.kode/skills/nx-generate
+++ b/.kode/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.kode/skills/nx-import
+++ b/.kode/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.kode/skills/nx-plugins
+++ b/.kode/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.kode/skills/nx-run-tasks
+++ b/.kode/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.kode/skills/nx-workspace
+++ b/.kode/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.mcpjam/skills/link-workspace-packages
+++ b/.mcpjam/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.mcpjam/skills/monitor-ci
+++ b/.mcpjam/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.mcpjam/skills/nx-generate
+++ b/.mcpjam/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.mcpjam/skills/nx-import
+++ b/.mcpjam/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.mcpjam/skills/nx-plugins
+++ b/.mcpjam/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.mcpjam/skills/nx-run-tasks
+++ b/.mcpjam/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.mcpjam/skills/nx-workspace
+++ b/.mcpjam/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.mux/skills/link-workspace-packages
+++ b/.mux/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.mux/skills/monitor-ci
+++ b/.mux/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.mux/skills/nx-generate
+++ b/.mux/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.mux/skills/nx-import
+++ b/.mux/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.mux/skills/nx-plugins
+++ b/.mux/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.mux/skills/nx-run-tasks
+++ b/.mux/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.mux/skills/nx-workspace
+++ b/.mux/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.neovate/skills/link-workspace-packages
+++ b/.neovate/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.neovate/skills/monitor-ci
+++ b/.neovate/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.neovate/skills/nx-generate
+++ b/.neovate/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.neovate/skills/nx-import
+++ b/.neovate/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.neovate/skills/nx-plugins
+++ b/.neovate/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.neovate/skills/nx-run-tasks
+++ b/.neovate/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.neovate/skills/nx-workspace
+++ b/.neovate/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.openhands/skills/link-workspace-packages
+++ b/.openhands/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.openhands/skills/monitor-ci
+++ b/.openhands/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.openhands/skills/nx-generate
+++ b/.openhands/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.openhands/skills/nx-import
+++ b/.openhands/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.openhands/skills/nx-plugins
+++ b/.openhands/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.openhands/skills/nx-run-tasks
+++ b/.openhands/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.openhands/skills/nx-workspace
+++ b/.openhands/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.pi/skills/link-workspace-packages
+++ b/.pi/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.pi/skills/monitor-ci
+++ b/.pi/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.pi/skills/nx-generate
+++ b/.pi/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.pi/skills/nx-import
+++ b/.pi/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.pi/skills/nx-plugins
+++ b/.pi/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.pi/skills/nx-run-tasks
+++ b/.pi/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.pi/skills/nx-workspace
+++ b/.pi/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.pochi/skills/link-workspace-packages
+++ b/.pochi/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.pochi/skills/monitor-ci
+++ b/.pochi/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.pochi/skills/nx-generate
+++ b/.pochi/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.pochi/skills/nx-import
+++ b/.pochi/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.pochi/skills/nx-plugins
+++ b/.pochi/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.pochi/skills/nx-run-tasks
+++ b/.pochi/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.pochi/skills/nx-workspace
+++ b/.pochi/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.qoder/skills/link-workspace-packages
+++ b/.qoder/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.qoder/skills/monitor-ci
+++ b/.qoder/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.qoder/skills/nx-generate
+++ b/.qoder/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.qoder/skills/nx-import
+++ b/.qoder/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.qoder/skills/nx-plugins
+++ b/.qoder/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.qoder/skills/nx-run-tasks
+++ b/.qoder/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.qoder/skills/nx-workspace
+++ b/.qoder/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.qwen/skills/link-workspace-packages
+++ b/.qwen/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.qwen/skills/monitor-ci
+++ b/.qwen/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.qwen/skills/nx-generate
+++ b/.qwen/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.qwen/skills/nx-import
+++ b/.qwen/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.qwen/skills/nx-plugins
+++ b/.qwen/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.qwen/skills/nx-run-tasks
+++ b/.qwen/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.qwen/skills/nx-workspace
+++ b/.qwen/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.roo/skills/link-workspace-packages
+++ b/.roo/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.roo/skills/monitor-ci
+++ b/.roo/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.roo/skills/nx-generate
+++ b/.roo/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.roo/skills/nx-import
+++ b/.roo/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.roo/skills/nx-plugins
+++ b/.roo/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.roo/skills/nx-run-tasks
+++ b/.roo/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.roo/skills/nx-workspace
+++ b/.roo/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.rovodev/skills/link-workspace-packages
+++ b/.rovodev/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.rovodev/skills/monitor-ci
+++ b/.rovodev/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.rovodev/skills/nx-generate
+++ b/.rovodev/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.rovodev/skills/nx-import
+++ b/.rovodev/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.rovodev/skills/nx-plugins
+++ b/.rovodev/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.rovodev/skills/nx-run-tasks
+++ b/.rovodev/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.rovodev/skills/nx-workspace
+++ b/.rovodev/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.trae/skills/link-workspace-packages
+++ b/.trae/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.trae/skills/monitor-ci
+++ b/.trae/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.trae/skills/nx-generate
+++ b/.trae/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.trae/skills/nx-import
+++ b/.trae/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.trae/skills/nx-plugins
+++ b/.trae/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.trae/skills/nx-run-tasks
+++ b/.trae/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.trae/skills/nx-workspace
+++ b/.trae/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.vibe/skills/link-workspace-packages
+++ b/.vibe/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.vibe/skills/monitor-ci
+++ b/.vibe/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.vibe/skills/nx-generate
+++ b/.vibe/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.vibe/skills/nx-import
+++ b/.vibe/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.vibe/skills/nx-plugins
+++ b/.vibe/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.vibe/skills/nx-run-tasks
+++ b/.vibe/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.vibe/skills/nx-workspace
+++ b/.vibe/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.windsurf/skills/link-workspace-packages
+++ b/.windsurf/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.windsurf/skills/monitor-ci
+++ b/.windsurf/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.windsurf/skills/nx-generate
+++ b/.windsurf/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.windsurf/skills/nx-import
+++ b/.windsurf/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.windsurf/skills/nx-plugins
+++ b/.windsurf/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.windsurf/skills/nx-run-tasks
+++ b/.windsurf/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.windsurf/skills/nx-workspace
+++ b/.windsurf/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/.zencoder/skills/link-workspace-packages
+++ b/.zencoder/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../../.agents/skills/link-workspace-packages

--- a/.zencoder/skills/monitor-ci
+++ b/.zencoder/skills/monitor-ci
@@ -1,1 +1,0 @@
-../../.agents/skills/monitor-ci

--- a/.zencoder/skills/nx-generate
+++ b/.zencoder/skills/nx-generate
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-generate

--- a/.zencoder/skills/nx-import
+++ b/.zencoder/skills/nx-import
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-import

--- a/.zencoder/skills/nx-plugins
+++ b/.zencoder/skills/nx-plugins
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-plugins

--- a/.zencoder/skills/nx-run-tasks
+++ b/.zencoder/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-run-tasks

--- a/.zencoder/skills/nx-workspace
+++ b/.zencoder/skills/nx-workspace
@@ -1,1 +1,0 @@
-../../.agents/skills/nx-workspace

--- a/skills/link-workspace-packages
+++ b/skills/link-workspace-packages
@@ -1,1 +1,0 @@
-../.agents/skills/link-workspace-packages

--- a/skills/monitor-ci
+++ b/skills/monitor-ci
@@ -1,1 +1,0 @@
-../.agents/skills/monitor-ci

--- a/skills/nx-generate
+++ b/skills/nx-generate
@@ -1,1 +1,0 @@
-../.agents/skills/nx-generate

--- a/skills/nx-import
+++ b/skills/nx-import
@@ -1,1 +1,0 @@
-../.agents/skills/nx-import

--- a/skills/nx-plugins
+++ b/skills/nx-plugins
@@ -1,1 +1,0 @@
-../.agents/skills/nx-plugins

--- a/skills/nx-run-tasks
+++ b/skills/nx-run-tasks
@@ -1,1 +1,0 @@
-../.agents/skills/nx-run-tasks

--- a/skills/nx-workspace
+++ b/skills/nx-workspace
@@ -1,1 +1,0 @@
-../.agents/skills/nx-workspace


### PR DESCRIPTION
## Summary
- Removed 36 duplicate AI-tool skill folders that mirrored `.claude/skills/` (`.adal`, `.aider-desk`, `.augment`, ..., `.zencoder` — full list in commit).
- Removed the dangling root `./skills/` symlink directory (it pointed into `.agents/`, which no longer exists).
- Preserved `.claude/skills/`, `.github/`, and `.changeset/` (legitimate changesets config).

## Test plan
- [x] `git status` clean after commit
- [ ] CI green