### PR TITLE
fix(builder): repair drag-and-drop and add click-to-add fallback

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -8,6 +8,13 @@
       "port": 3000
     },
     {
+      "name": "Builder Express",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["examples/express/server.js"],
+      "port": 3019,
+      "autoPort": true
+    },
+    {
       "name": "Static Dev Server",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["dev:static"],

--- a/packages/builder/src/builder-element.js
+++ b/packages/builder/src/builder-element.js
@@ -89,6 +89,13 @@ export class BnBuilder extends HTMLElement {
         this.dispatchEvent(new CustomEvent('bn-builder-export', { detail: { code }, bubbles: true }));
       }
     });
+    this.addEventListener('bn-palette-add', (e) => {
+      const type = e.detail?.type;
+      if (!type || !this.state || !this.palette) return;
+      const def = this.palette.get(type);
+      if (!def) return;
+      this.state.addNode(null, { type, props: { ...def.defaults } });
+    });
   }
 }
 

--- a/packages/builder/src/canvas-element.js
+++ b/packages/builder/src/canvas-element.js
@@ -127,8 +127,20 @@ export class BnBuilderCanvas extends HTMLElement {
     });
 
     this._root.addEventListener('dragover', (e) => {
+      const types = e.dataTransfer.types;
+      const isPaletteDrag =
+        types && (types.contains
+          ? types.contains('application/x-bn-component-type')
+          : Array.from(types).includes('application/x-bn-component-type'));
+      if (!isPaletteDrag) {
+        const isNodeDrag =
+          types && (types.contains
+            ? types.contains('application/x-bn-node-id')
+            : Array.from(types).includes('application/x-bn-node-id'));
+        if (!isNodeDrag) return;
+      }
       e.preventDefault();
-      e.dataTransfer.dropEffect = 'move';
+      e.dataTransfer.dropEffect = isPaletteDrag ? 'copy' : 'move';
     });
 
     this._root.addEventListener('drop', (e) => {

--- a/packages/builder/src/palette-element.js
+++ b/packages/builder/src/palette-element.js
@@ -48,11 +48,22 @@ export class BnBuilderPalette extends HTMLElement {
   }
 
   _wire() {
+    if (this._wired) return;
+    this._wired = true;
     this.addEventListener('dragstart', (e) => {
       const btn = e.target.closest('[data-bn-palette-type]');
       if (!btn) return;
       e.dataTransfer.setData('application/x-bn-component-type', btn.dataset.bnPaletteType);
       e.dataTransfer.effectAllowed = 'copy';
+    });
+    this.addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-bn-palette-type]');
+      if (!btn) return;
+      e.preventDefault();
+      this.dispatchEvent(new CustomEvent('bn-palette-add', {
+        detail: { type: btn.dataset.bnPaletteType },
+        bubbles: true,
+      }));
     });
   }
 }


### PR DESCRIPTION
## Summary

The /builder page on basenative.com renders the palette, canvas, and inspector, but drag-and-drop does nothing — components dragged from the palette never land on the canvas. Click-to-add was also unimplemented, so there was no working path to add a component.

**Root cause** — incompatible drag effects between palette and canvas:

- Palette \`dragstart\` set \`dataTransfer.effectAllowed = 'copy'\`
- Canvas \`dragover\` unconditionally set \`dataTransfer.dropEffect = 'move'\`

Per the HTML drag-and-drop spec, when \`dropEffect\` is incompatible with \`effectAllowed\`, the drop is "not permitted" — browsers show the not-allowed cursor and the \`drop\` event either does not fire on the target or fires with \`dropEffect='none'\`, in which case the canvas never reaches \`state.addNode\`. No console error, no visual feedback — exactly the symptom reported.

## Fix

- \`canvas-element.js\` — \`dragover\` now inspects \`dataTransfer.types\` and picks the matching \`dropEffect\`: \`copy\` for palette items (\`application/x-bn-component-type\`), \`move\` for internal node reorders (\`application/x-bn-node-id\`). Unrelated drags no longer call \`preventDefault\`, so the canvas doesn't hijack drops it has no business with.
- \`palette-element.js\` — clicks on a palette item now dispatch a bubbling \`bn-palette-add\` CustomEvent.
- \`builder-element.js\` — listens for \`bn-palette-add\` and appends a new root node using the palette's defaults. This also makes the builder usable on touch devices, where HTML5 drag-and-drop is unavailable natively.
- \`.claude/launch.json\` — adds a "Builder Express" launch config on port 3019 with \`autoPort: true\` for local preview without colliding with the existing showcase server.

## Test plan

- [x] All 74 existing \`@basenative/builder\` package tests pass (\`cd packages/builder && node --test\`).
- [x] Verified click-to-add live: clicking Heading / Text / Button palette items appends each to the canvas and the tree view, with the palette \`defaults\` applied (e.g. heading text "Heading", button text "Click me").
- [x] Verified drop logic via synthesized DragEvent flow on the running preview: \`dragover\` only \`preventDefault\`s for palette / node MIME types, \`dropEffect\` matches \`effectAllowed\`, drop adds the correct node.
- [ ] Manual real-browser drag verification on the deployed preview before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)