### PR TITLE
feat(showcase,components): interactive demos, source viewers, search filters

### DIFF
--- a/examples/express/public/showcase.js
+++ b/examples/express/public/showcase.js
@@ -19,6 +19,13 @@ ready(() => {
   wireVirtualList();
   wireCounter();
   wireClock();
+  wireLiveCounter();
+  wireLiveValidate();
+  wireLiveProgress();
+  wireThemePicker();
+  wireSourceCopy();
+  wireShowcaseFilter();
+  wireShowcaseToc();
 });
 
 function wireTabs() {
@@ -332,7 +339,7 @@ function wireToastButtons(toaster) {
 }
 
 function wireCounter() {
-  const root = document.querySelector('[data-showcase-counter]');
+  const root = document.querySelector('[data-bn-counter-readout]');
   if (!root) return;
 
   const count = signal(0);
@@ -343,18 +350,19 @@ function wireCounter() {
   effect(() => {
     const n = count();
     if (valueEl) valueEl.textContent = String(n);
-    if (doubledEl) doubledEl.textContent = `doubled: ${n * 2}`;
+    if (doubledEl) doubledEl.textContent = String(n * 2);
     if (parityEl) {
-      parityEl.textContent = n % 2 === 0 ? 'even' : 'odd';
-      parityEl.dataset.parity = n % 2 === 0 ? 'even' : 'odd';
+      const p = n % 2 === 0 ? 'even' : 'odd';
+      parityEl.textContent = p;
+      parityEl.dataset.parity = p;
     }
   });
 
-  root
-    .querySelector('[data-bn-action="counter-inc"]')
+  document
+    .querySelector('[data-bn-action="cc-inc"]')
     ?.addEventListener('click', () => count.set((c) => c + 1));
-  root
-    .querySelector('[data-bn-action="counter-dec"]')
+  document
+    .querySelector('[data-bn-action="cc-dec"]')
     ?.addEventListener('click', () => count.set((c) => c - 1));
 }
 
@@ -366,6 +374,182 @@ function wireClock() {
     el.textContent = time().toLocaleTimeString();
   });
   setInterval(() => time.set(new Date()), 1000);
+}
+
+function wireLiveCounter() {
+  const out = document.querySelector('[data-bn-live-counter]');
+  if (!out) return;
+  const count = signal(0);
+  effect(() => {
+    out.textContent = String(count());
+  });
+  document
+    .querySelector('[data-bn-action="counter-inc"]')
+    ?.addEventListener('click', () => count.set((c) => c + 1));
+  document
+    .querySelector('[data-bn-action="counter-dec"]')
+    ?.addEventListener('click', () => count.set((c) => c - 1));
+  document
+    .querySelector('[data-bn-action="counter-reset"]')
+    ?.addEventListener('click', () => count.set(0));
+}
+
+function wireLiveValidate() {
+  const feedback = document.querySelector('[data-bn-live-validate-feedback]');
+  if (!feedback) return;
+  const input = document.querySelector('input[name="live-username"]');
+  if (!input) return;
+  input.setAttribute('minlength', '3');
+  input.setAttribute('maxlength', '20');
+  const min = 3;
+  const max = 20;
+  const value = signal(input.value);
+  effect(() => {
+    const v = value();
+    if (v.length === 0) {
+      feedback.textContent = '';
+      input.removeAttribute('aria-invalid');
+      feedback.removeAttribute('data-bn-state');
+      return;
+    }
+    if (v.length < min) {
+      feedback.textContent = `Need at least ${min} characters (have ${v.length}).`;
+      input.setAttribute('aria-invalid', 'true');
+      feedback.setAttribute('data-bn-state', 'error');
+    } else if (v.length > max) {
+      feedback.textContent = `Too long — max ${max}.`;
+      input.setAttribute('aria-invalid', 'true');
+      feedback.setAttribute('data-bn-state', 'error');
+    } else {
+      feedback.textContent = `Looks good (${v.length}/${max}).`;
+      input.setAttribute('aria-invalid', 'false');
+      feedback.setAttribute('data-bn-state', 'ok');
+    }
+  });
+  input.addEventListener('input', () => value.set(input.value));
+}
+
+function wireLiveProgress() {
+  const toggle = document.querySelector('[data-bn-action="progress-toggle"]');
+  const bar = toggle
+    ?.closest('[data-bn-showcase-demo]')
+    ?.querySelector('progress[data-bn="progress"]');
+  if (!bar) return;
+  const v = signal(0);
+  const running = signal(true);
+  effect(() => {
+    bar.value = v();
+  });
+  let id = null;
+  const start = () => {
+    if (id) return;
+    id = setInterval(() => v.set((p) => (p + 5) % 105), 200);
+  };
+  const stop = () => {
+    if (!id) return;
+    clearInterval(id);
+    id = null;
+  };
+  effect(() => {
+    if (running()) start();
+    else stop();
+  });
+  document.querySelector('[data-bn-action="progress-toggle"]')?.addEventListener('click', () => {
+    running.set((r) => !r);
+  });
+  document.querySelector('[data-bn-action="progress-reset"]')?.addEventListener('click', () => {
+    v.set(0);
+  });
+}
+
+function wireThemePicker() {
+  const root = document.documentElement;
+  const original = getComputedStyle(root).getPropertyValue('--accent').trim();
+  for (const btn of document.querySelectorAll('[data-bn-action="theme"]')) {
+    btn.addEventListener('click', () => {
+      const accent = btn.getAttribute('data-bn-accent');
+      if (accent) root.style.setProperty('--accent', accent);
+      else root.style.setProperty('--accent', original);
+    });
+  }
+}
+
+function wireSourceCopy() {
+  for (const btn of document.querySelectorAll('[data-bn-action="copy-code"]')) {
+    btn.addEventListener('click', async () => {
+      const pre = btn.parentElement?.querySelector('pre code');
+      if (!pre) return;
+      try {
+        await navigator.clipboard.writeText(pre.textContent || '');
+        const prev = btn.textContent;
+        btn.textContent = 'Copied ✓';
+        btn.setAttribute('data-bn-copied', '');
+        setTimeout(() => {
+          btn.textContent = prev;
+          btn.removeAttribute('data-bn-copied');
+        }, 1400);
+      } catch {
+        btn.textContent = 'Copy failed';
+      }
+    });
+  }
+}
+
+function wireShowcaseFilter() {
+  const input = document.querySelector('[data-bn-showcase-q]');
+  const clear = document.querySelector('[data-bn-showcase-clear]');
+  if (!input) return;
+  const sections = [...document.querySelectorAll('[data-bn-showcase-section]')];
+  const tocLinks = [...document.querySelectorAll('[data-bn-showcase-toc-link]')];
+  const root = document.documentElement;
+  const apply = () => {
+    const q = input.value.trim().toLowerCase();
+    let visible = 0;
+    for (const sec of sections) {
+      const title = (sec.getAttribute('data-bn-title') || '').toLowerCase();
+      const cat = (sec.getAttribute('data-bn-category') || '').toLowerCase();
+      const captions = [...sec.querySelectorAll('figcaption')]
+        .map((f) => f.textContent.toLowerCase())
+        .join(' ');
+      const match = !q || title.includes(q) || cat.includes(q) || captions.includes(q);
+      sec.toggleAttribute('hidden', !match);
+      if (match) visible++;
+    }
+    for (const link of tocLinks) {
+      const id = link.getAttribute('data-bn-target');
+      const target = id && document.getElementById(id);
+      link.toggleAttribute('hidden', !target || target.hasAttribute('hidden'));
+    }
+    root.toggleAttribute('data-bn-showcase-empty', visible === 0);
+  };
+  input.addEventListener('input', apply);
+  clear?.addEventListener('click', () => {
+    input.value = '';
+    apply();
+    input.focus();
+  });
+}
+
+function wireShowcaseToc() {
+  const links = document.querySelectorAll('[data-bn-showcase-toc-link]');
+  if (links.length === 0) return;
+  const sections = [...document.querySelectorAll('[data-bn-showcase-section]')];
+  const observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          const id = entry.target.id;
+          for (const link of links) {
+            if (link.getAttribute('data-bn-target') === id)
+              link.setAttribute('aria-current', 'true');
+            else link.removeAttribute('aria-current');
+          }
+        }
+      }
+    },
+    { rootMargin: '-30% 0px -60% 0px' },
+  );
+  for (const sec of sections) observer.observe(sec);
 }
 
 function wireVirtualList() {

--- a/examples/express/public/styles.css
+++ b/examples/express/public/styles.css
@@ -3099,3 +3099,427 @@
     display: inline-flex;
   }
 }
+
+/* ============================================================================
+ * Showcase + components — modern CSS layer
+ * Uses @scope, :has(), container queries, color-mix(), nesting
+ * ============================================================================ */
+
+@layer states {
+  /* -- Showcase: search bar + empty state ----------------------------------- */
+  [data-bn-showcase-search] {
+    display: grid;
+    gap: var(--space-sm);
+    margin-block-end: var(--space-lg);
+    padding: var(--space-md);
+    background: color-mix(in srgb, var(--surface-1) 92%, transparent);
+    border: var(--border-width) solid var(--border);
+    border-radius: var(--radius-md);
+    backdrop-filter: blur(8px);
+    position: sticky;
+    inset-block-start: var(--space-sm);
+    z-index: 6;
+
+    & input[type='search'] {
+      inline-size: 100%;
+      padding: var(--space-sm) var(--space-md);
+      background: var(--surface-0);
+      color: var(--text-0);
+      border: var(--border-width) solid var(--border);
+      border-radius: var(--radius-sm);
+      font-family: var(--font-family);
+      font-size: var(--font-size-sm);
+      transition:
+        border-color var(--duration-fast),
+        box-shadow var(--duration-fast);
+
+      &::placeholder {
+        color: var(--text-2);
+      }
+
+      &:focus-visible {
+        outline: none;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
+      }
+    }
+
+    & [data-bn-showcase-empty] {
+      display: none;
+      color: var(--text-1);
+      font-size: var(--font-size-sm);
+      margin: 0;
+
+      & button {
+        background: none;
+        border: none;
+        color: var(--accent);
+        font-family: inherit;
+        font-size: inherit;
+        cursor: pointer;
+        text-decoration: underline;
+        padding: 0;
+      }
+    }
+  }
+  :root[data-bn-showcase-empty] [data-bn-showcase-empty] {
+    display: block;
+  }
+
+  /* Dim TOC link for hidden sections via :has() — pure CSS */
+  [data-bn-showcase-toc] a[hidden] {
+    display: none;
+  }
+
+  /* -- Showcase: section + figure -------------------------------------------- */
+  [data-bn-showcase-section][hidden] {
+    display: none;
+  }
+
+  [data-bn-showcase-demo] {
+    container-type: inline-size;
+
+    & > [data-bn-showcase-stage] {
+      display: block;
+      padding: var(--space-xl);
+      background: var(--surface-inset);
+      min-block-size: 6rem;
+    }
+
+    &[data-bn-layout='row'] > [data-bn-showcase-stage] {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-md);
+      align-items: center;
+    }
+
+    &[data-bn-layout='stack'] > [data-bn-showcase-stage] {
+      display: grid;
+      gap: var(--space-md);
+    }
+
+    &[data-bn-layout='form'] > [data-bn-showcase-stage] {
+      display: grid;
+      gap: var(--space-lg);
+      max-inline-size: 36rem;
+    }
+
+    &[data-bn-layout='card'] > [data-bn-showcase-stage] {
+      max-inline-size: 28rem;
+    }
+  }
+
+  /* Source viewer: native <details> with copy button */
+  [data-bn-showcase-source],
+  [data-bn-component-source] {
+    border-block-start: var(--border-width) solid var(--border);
+    background: var(--surface-2);
+    margin: 0;
+    padding: 0;
+
+    & > summary {
+      list-style: none;
+      cursor: pointer;
+      padding: var(--space-sm) var(--space-md);
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-xs);
+      color: var(--text-2);
+      letter-spacing: var(--letter-spacing-wider);
+      text-transform: uppercase;
+      display: flex;
+      align-items: center;
+      gap: var(--space-xs);
+      user-select: none;
+
+      &::-webkit-details-marker {
+        display: none;
+      }
+
+      & > span:first-child {
+        display: inline-block;
+        transition: transform var(--duration-fast) var(--ease-out-expo);
+      }
+    }
+
+    &[open] > summary > span:first-child {
+      transform: rotate(180deg);
+    }
+
+    & > pre {
+      margin: 0;
+      padding: var(--space-md) var(--space-lg);
+      background: var(--surface-inset);
+      color: var(--text-0);
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-sm);
+      line-height: var(--line-height-code);
+      overflow-x: auto;
+    }
+
+    & > [data-bn-action='copy-code'] {
+      margin: var(--space-sm) var(--space-md) var(--space-md);
+      cursor: pointer;
+    }
+
+    & > [data-bn-action='copy-code'][data-bn-copied] {
+      background: color-mix(in srgb, var(--success) 25%, transparent);
+      border-color: var(--success);
+      color: var(--success);
+    }
+  }
+
+  /* -- Live demo styles ------------------------------------------------------ */
+  [data-bn-live-counter] {
+    display: inline-block;
+    font-family: var(--font-family);
+    font-stretch: var(--font-serif);
+    font-size: var(--font-size-3xl, 2.5rem);
+    color: var(--accent);
+    min-inline-size: 4ch;
+    text-align: center;
+    padding: var(--space-xs) var(--space-md);
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+    border-radius: var(--radius-md);
+  }
+
+  [data-bn-live-validate-feedback] {
+    display: block;
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--text-2);
+    margin-block-start: var(--space-xs);
+
+    &[data-bn-state='ok'] {
+      color: var(--success);
+    }
+
+    &[data-bn-state='error'] {
+      color: var(--danger);
+    }
+
+    &:empty {
+      display: none;
+    }
+  }
+
+  [data-bn-clock] {
+    display: inline-block;
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    font-size: var(--font-size-2xl);
+    color: var(--accent);
+    padding: var(--space-sm) var(--space-md);
+    background: var(--surface-2);
+    border: var(--border-width) solid var(--border);
+    border-radius: var(--radius-md);
+    font-variant-numeric: tabular-nums;
+  }
+
+  [data-bn-clock-note] {
+    margin-block-start: var(--space-sm);
+    color: var(--text-2);
+    font-size: var(--font-size-xs);
+    max-inline-size: 32rem;
+  }
+
+  [data-bn-theme-preview] {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    align-items: center;
+    padding: var(--space-md);
+    border: var(--border-width) dashed var(--border);
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--accent) 4%, transparent);
+    transition: background var(--duration-med);
+  }
+
+  /* Computed counter readout — definition list */
+  [data-bn-counter-readout] {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    column-gap: var(--space-md);
+    row-gap: var(--space-xs);
+    padding: var(--space-md);
+    background: var(--surface-2);
+    border-radius: var(--radius-md);
+    max-inline-size: 24rem;
+
+    & dt {
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-xs);
+      color: var(--text-2);
+      letter-spacing: var(--letter-spacing-wider);
+      text-transform: uppercase;
+      align-self: center;
+    }
+
+    & dd {
+      margin: 0;
+      font-family: var(--font-family);
+      font-stretch: var(--font-serif);
+      font-size: var(--font-size-lg);
+      color: var(--text-0);
+
+      &[data-parity='odd'] {
+        color: var(--accent);
+      }
+
+      &[data-parity='even'] {
+        color: var(--success);
+      }
+    }
+  }
+
+  /* -- Components page: search + tag filter --------------------------------- */
+  [data-bn-component-search] {
+    display: grid;
+    gap: var(--space-sm);
+    margin-block-end: var(--space-xl);
+    padding: var(--space-md);
+    background: color-mix(in srgb, var(--surface-1) 92%, transparent);
+    border: var(--border-width) solid var(--border);
+    border-radius: var(--radius-md);
+    backdrop-filter: blur(8px);
+    position: sticky;
+    inset-block-start: var(--space-sm);
+    z-index: 6;
+
+    & input[type='search'] {
+      inline-size: 100%;
+      padding: var(--space-sm) var(--space-md);
+      background: var(--surface-0);
+      color: var(--text-0);
+      border: var(--border-width) solid var(--border);
+      border-radius: var(--radius-sm);
+      font-family: var(--font-family);
+      font-size: var(--font-size-sm);
+
+      &::placeholder {
+        color: var(--text-2);
+      }
+
+      &:focus-visible {
+        outline: none;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
+      }
+    }
+
+    & [data-bn-component-empty] {
+      display: none;
+      color: var(--text-1);
+      font-size: var(--font-size-sm);
+      margin: 0;
+
+      & button {
+        background: none;
+        border: none;
+        color: var(--accent);
+        font-family: inherit;
+        font-size: inherit;
+        cursor: pointer;
+        text-decoration: underline;
+        padding: 0;
+      }
+    }
+  }
+  :root[data-bn-no-results] [data-bn-component-empty] {
+    display: block;
+  }
+
+  [data-bn-component-filters] {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+
+    & button {
+      background: var(--surface-2);
+      border: var(--border-width) solid var(--border);
+      color: var(--text-1);
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-xs);
+      letter-spacing: var(--letter-spacing-wider);
+      text-transform: uppercase;
+      padding: var(--space-xs) var(--space-md);
+      border-radius: var(--radius-sm);
+      cursor: pointer;
+      transition:
+        background var(--duration-fast),
+        color var(--duration-fast),
+        border-color var(--duration-fast);
+
+      &:hover {
+        background: var(--surface-3);
+        color: var(--accent);
+      }
+
+      &[aria-pressed='true'] {
+        background: color-mix(in srgb, var(--accent) 18%, transparent);
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+    }
+  }
+
+  [data-bn-component-card-host][hidden],
+  [data-bn-component-category][hidden] {
+    display: none;
+  }
+
+  /* Hide a category whose cards are all filtered out — :has() */
+  [data-bn-component-category]:not(:has([data-bn-component-card-host]:not([hidden]))) {
+    display: none;
+  }
+
+  /* -- Component detail: related components --------------------------------- */
+  [data-bn-component-related] {
+    margin-block: var(--space-2xl) var(--space-xl);
+    padding-block-start: var(--space-xl);
+    border-block-start: var(--border-width) solid var(--border);
+
+    & > h3 {
+      font-family: var(--font-family);
+      font-stretch: var(--font-serif);
+      font-size: var(--font-size-xl);
+      font-weight: var(--font-weight-normal);
+      margin-block-end: var(--space-lg);
+
+      & em {
+        font-style: normal;
+        color: var(--accent);
+      }
+    }
+  }
+
+  /* -- Container queries: showcase grid adaptation -------------------------- */
+  @container (min-width: 36rem) {
+    [data-bn-showcase-demo][data-bn-layout='form'] > [data-bn-showcase-stage] {
+      grid-template-columns: 1fr 1fr;
+      gap: var(--space-xl);
+    }
+  }
+}
+
+@layer states {
+  /* -- @scope: keep showcase TOC styles from leaking ------------------------ */
+  @scope ([data-bn-showcase-toc]) {
+    :scope a:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+  }
+
+  /* -- @scope: per-section card host styling -------------------------------- */
+  @scope ([data-bn-component-grid]) {
+    :scope > li:has(a:focus-visible) {
+      transform: translateY(-2px);
+    }
+  }
+}
+

--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -158,12 +158,16 @@ app.get('/components/:slug', (req, res) => {
   const idx = flatComponents.findIndex((c) => c.slug === component.slug);
   const prev = idx > 0 ? flatComponents[idx - 1] : null;
   const next = idx < flatComponents.length - 1 ? flatComponents[idx + 1] : null;
+  const related = flatComponents
+    .filter((c) => c.categoryId === component.categoryId && c.slug !== component.slug)
+    .slice(0, 6);
 
   const ctx = {
     component,
     examples: demo?.examples ?? [],
     prev,
     next,
+    related,
     breadcrumb: renderBreadcrumb({
       items: [
         { label: 'Home', href: '/' },

--- a/examples/express/showcase-data.js
+++ b/examples/express/showcase-data.js
@@ -240,7 +240,7 @@ const PACKAGE_GROUPS = [
 ];
 
 function renderPackageCards() {
-  const groupHtml = PACKAGE_GROUPS.map((group) => {
+  return PACKAGE_GROUPS.map((group) => {
     const cards = PACKAGES.filter((p) => p.tag === group.tag)
       .map(
         (p) => `<li data-bn-package-card data-tag="${p.tag}">
@@ -254,7 +254,6 @@ function renderPackageCards() {
   <ul data-bn-package-list>${cards}</ul>
 </li>`;
   }).join('');
-  return groupHtml;
 }
 
 function calendarStartOfWeek() {
@@ -309,336 +308,738 @@ function calendarEvents(startDate) {
   ];
 }
 
-export function getShowcaseContext() {
+const trim = (s) => s.replace(/^\n/, '').replace(/\n$/, '');
+
+/**
+ * Build a single showcase section.
+ * Each section has { id, title, description, demos: [{ caption, html, code }] }.
+ * Sections drive both the TOC and the page body.
+ */
+export function getShowcaseSections() {
   const startDate = calendarStartOfWeek();
 
+  return [
+    {
+      id: 'sec-buttons',
+      category: 'inputs',
+      title: 'Buttons',
+      description:
+        'Real button elements. Variants, disabled state, and a hydrated counter to prove the click handler is native.',
+      demos: [
+        {
+          caption: 'Variants',
+          layout: 'row',
+          html: [
+            renderButton('Primary', { variant: 'primary' }),
+            renderButton('Secondary', { variant: 'secondary' }),
+            renderButton('Destructive', { variant: 'destructive' }),
+            renderButton('Ghost', { variant: 'ghost' }),
+            renderButton('Disabled', { variant: 'primary', disabled: true }),
+          ].join('\n'),
+          code: trim(`
+renderButton('Primary',     { variant: 'primary' })
+renderButton('Secondary',   { variant: 'secondary' })
+renderButton('Destructive', { variant: 'destructive' })
+renderButton('Ghost',       { variant: 'ghost' })
+renderButton('Disabled',    { variant: 'primary', disabled: true })`),
+        },
+        {
+          caption: 'Live counter (signal + effect)',
+          layout: 'stack',
+          html: `
+<output data-bn-live-counter aria-live="polite">0</output>
+<nav data-bn-demo-row aria-label="Counter controls">
+  ${renderButton('−', { variant: 'secondary', attrs: 'data-bn-action="counter-dec" aria-label="Decrement"' })}
+  ${renderButton('+', { variant: 'primary', attrs: 'data-bn-action="counter-inc" aria-label="Increment"' })}
+  ${renderButton('Reset', { variant: 'ghost', attrs: 'data-bn-action="counter-reset"' })}
+</nav>`,
+          code: trim(`
+const count = signal(0);
+effect(() => out.textContent = count());
+inc.onclick   = () => count.set(c => c + 1);
+dec.onclick   = () => count.set(c => c - 1);
+reset.onclick = () => count.set(0);`),
+        },
+      ],
+    },
+    {
+      id: 'sec-badges',
+      category: 'feedback',
+      title: 'Badges & avatars',
+      description:
+        'Compact status pills and an initials-fallback avatar that reads from the name attribute. Both are built on a single span element.',
+      demos: [
+        {
+          caption: 'Badge variants',
+          layout: 'row',
+          html: [
+            renderBadge('Default', { variant: 'default' }),
+            renderBadge('Primary', { variant: 'primary' }),
+            renderBadge('Success', { variant: 'success' }),
+            renderBadge('Warning', { variant: 'warning' }),
+            renderBadge('Error', { variant: 'error' }),
+          ].join(' '),
+          code: trim(`
+renderBadge('Active',  { variant: 'success' })
+renderBadge('Warning', { variant: 'warning' })`),
+        },
+        {
+          caption: 'Avatar sizes',
+          layout: 'row',
+          html: [
+            renderAvatar({ name: 'Alice Johnson', size: 'sm' }),
+            renderAvatar({ name: 'Bob Smith' }),
+            renderAvatar({ name: 'Carol Davis', size: 'lg' }),
+            renderAvatar({ name: 'Dan Lee', size: 'xl' }),
+          ].join(' '),
+          code: trim(`renderAvatar({ name: 'Alice Johnson', size: 'lg' })`),
+        },
+      ],
+    },
+    {
+      id: 'sec-form',
+      category: 'inputs',
+      title: 'Form controls',
+      description:
+        'Native form fields with label / help / error wiring, plus a live-validating input that toggles aria-invalid based on signal state.',
+      demos: [
+        {
+          caption: 'Inputs (default + error)',
+          layout: 'form',
+          html: [
+            renderInput({
+              name: 'email',
+              label: 'Email',
+              type: 'email',
+              placeholder: 'you@example.com',
+              helpText: 'We will not share your email.',
+            }),
+            renderInput({
+              name: 'username',
+              label: 'Username',
+              value: 'ab',
+              error: 'Must be at least 3 characters',
+            }),
+          ].join('\n'),
+          code: trim(`
+renderInput({ name: 'email',    label: 'Email',    type: 'email', helpText: '...' })
+renderInput({ name: 'username', label: 'Username', value: 'ab',   error: '...' })`),
+        },
+        {
+          caption: 'Live validation',
+          layout: 'form',
+          html: `
+${renderInput({ name: 'live-username', label: 'Username (live-validated)', placeholder: 'pick a handle', attrs: 'data-bn-live-validate minlength="3" maxlength="20"' })}
+<output data-bn-live-validate-feedback role="status" aria-live="polite"></output>`,
+          code: trim(`
+const value = signal('');
+const valid = computed(() => value().length >= 3);
+effect(() => input.setAttribute('aria-invalid', String(!valid())));`),
+        },
+        {
+          caption: 'Textarea, select, combobox, multiselect',
+          layout: 'form',
+          html: [
+            renderTextarea({
+              name: 'bio',
+              label: 'Bio',
+              placeholder: 'Tell us about yourself...',
+              rows: 3,
+            }),
+            renderSelect({
+              name: 'role',
+              label: 'Role',
+              items: ['Admin', 'Editor', 'Viewer'],
+              placeholder: 'Choose a role',
+            }),
+            renderCombobox({
+              name: 'framework',
+              label: 'Framework',
+              items: ['Angular', 'React', 'Vue', 'Svelte', 'Solid'],
+              placeholder: 'Search frameworks...',
+            }),
+            renderMultiselect({
+              name: 'tags',
+              label: 'Tags',
+              items: ['JavaScript', 'TypeScript', 'CSS', 'HTML', 'Node.js'],
+              selected: ['JavaScript', 'CSS'],
+            }),
+          ].join('\n'),
+          code: trim(`
+renderTextarea({ name: 'bio',       rows: 3 })
+renderSelect({   name: 'role',      items: [...] })
+renderCombobox({ name: 'framework', items: [...] })
+renderMultiselect({ name: 'tags',   items: [...], selected: [...] })`),
+        },
+        {
+          caption: 'Checkbox, radio group, toggle',
+          layout: 'form',
+          html: [
+            renderCheckbox({ name: 'terms', label: 'I agree to the terms and conditions' }),
+            renderRadioGroup({
+              name: 'plan',
+              label: 'Plan',
+              items: ['Free', 'Pro', 'Enterprise'],
+              selected: 'Pro',
+            }),
+            renderToggle({ name: 'notifications', label: 'Email notifications', checked: true }),
+          ].join('\n'),
+          code: trim(`
+renderCheckbox({   name: 'terms',         label: '...' })
+renderRadioGroup({ name: 'plan',          items: [...], selected: 'Pro' })
+renderToggle({     name: 'notifications', checked: true })`),
+        },
+      ],
+    },
+    {
+      id: 'sec-feedback',
+      category: 'feedback',
+      title: 'Feedback',
+      description:
+        'Inline alerts, native progress, CSS spinners, skeletons, and an animated progress bar that ticks via setInterval bound to a signal.',
+      demos: [
+        {
+          caption: 'Alerts',
+          layout: 'stack',
+          html: [
+            renderAlert('This is an informational message.', { variant: 'info' }),
+            renderAlert('Operation completed successfully.', { variant: 'success' }),
+            renderAlert('Proceed with caution.', { variant: 'warning' }),
+            renderAlert('Something went wrong.', { variant: 'error', dismissible: true }),
+          ].join('\n'),
+          code: trim(`
+renderAlert('Saved.',   { variant: 'success' })
+renderAlert('Heads up.',{ variant: 'warning' })
+renderAlert('Failed.',  { variant: 'error', dismissible: true })`),
+        },
+        {
+          caption: 'Live progress (signal-driven)',
+          layout: 'stack',
+          html: `
+${renderProgress({ value: 0, max: 100, label: 'Uploading…', attrs: 'data-bn-live-progress' })}
+<nav data-bn-demo-row aria-label="Progress controls">
+  ${renderButton('Pause / play', { variant: 'secondary', attrs: 'data-bn-action="progress-toggle"' })}
+  ${renderButton('Reset', { variant: 'ghost', attrs: 'data-bn-action="progress-reset"' })}
+</nav>`,
+          code: trim(`
+const v = signal(0);
+effect(() => bar.value = v());
+setInterval(() => v.set(p => (p + 5) % 105), 200);`),
+        },
+        {
+          caption: 'Spinners',
+          layout: 'row',
+          html: [
+            renderSpinner({ size: 'sm', label: 'Loading' }),
+            renderSpinner({ label: 'Loading' }),
+            renderSpinner({ size: 'lg', label: 'Loading' }),
+          ].join('\n'),
+          code: trim(`renderSpinner({ size: 'lg', label: 'Loading' })`),
+        },
+        {
+          caption: 'Skeleton',
+          layout: 'stack',
+          html: renderSkeleton({ width: '100%', height: '1rem', count: 3 }),
+          code: trim(`renderSkeleton({ width: '100%', height: '1rem', count: 3 })`),
+        },
+      ],
+    },
+    {
+      id: 'sec-layout',
+      category: 'layout',
+      title: 'Cards & layout',
+      description:
+        'Article-shaped cards, accordions built on the native details element, and ARIA tablists with arrow-key navigation.',
+      demos: [
+        {
+          caption: 'Card',
+          layout: 'card',
+          html: renderCard({
+            header: 'Card Title',
+            body: '<p>Card body content with descriptive text about the feature or item being presented.</p>',
+            footer: 'Updated 2 hours ago',
+          }),
+          code: trim(`renderCard({ header, body, footer })`),
+        },
+        {
+          caption: 'Accordion (native <details>)',
+          layout: 'form',
+          html: renderAccordion({
+            items: [
+              {
+                title: 'What is BaseNative?',
+                content:
+                  'A signal-based runtime over native HTML — ~120 lines for the core primitives.',
+              },
+              {
+                title: 'How does SSR work?',
+                content:
+                  'The server renderer evaluates @if, @for, @switch directives at request time and emits clean HTML with hydration markers.',
+              },
+              {
+                title: 'What about hydration?',
+                content:
+                  'hydrate() walks the DOM, binds reactive expressions, and attaches event handlers without reconstructing the tree.',
+              },
+            ],
+          }),
+          code: trim(`renderAccordion({ items: [{ title, content }, ...] })`),
+        },
+        {
+          caption: 'Tabs (arrow-key navigation)',
+          layout: 'plain',
+          html: renderTabs({
+            tabs: [
+              {
+                id: 'overview',
+                label: 'Overview',
+                content:
+                  '<p>BaseNative brings Angular-inspired control flow to native template elements.</p>',
+              },
+              {
+                id: 'features',
+                label: 'Features',
+                content:
+                  '<p>Signals, computed values, effects, SSR, hydration, and template directives.</p>',
+              },
+              {
+                id: 'api',
+                label: 'API',
+                content:
+                  '<p><code>signal()</code>, <code>computed()</code>, <code>effect()</code>, <code>hydrate()</code>, <code>render()</code>.</p>',
+              },
+            ],
+          }),
+          code: trim(`renderTabs({ tabs: [{ id, label, content }, ...] })`),
+        },
+      ],
+    },
+    {
+      id: 'sec-nav',
+      category: 'navigation',
+      title: 'Navigation',
+      description:
+        'Wayfinding primitives wrapped in a semantic nav element with proper aria-label and aria-current wiring.',
+      demos: [
+        {
+          caption: 'Breadcrumb',
+          layout: 'plain',
+          html: renderBreadcrumb({
+            items: [
+              { label: 'Home', href: '/' },
+              { label: 'Components', href: '/components' },
+              { label: 'Showcase' },
+            ],
+          }),
+          code: trim(`renderBreadcrumb({ items: [{ label, href }, ...] })`),
+        },
+        {
+          caption: 'Pagination',
+          layout: 'plain',
+          html: renderPagination({ currentPage: 3, totalPages: 10, baseUrl: '/showcase' }),
+          code: trim(`renderPagination({ currentPage: 3, totalPages: 10, baseUrl: '/items' })`),
+        },
+      ],
+    },
+    {
+      id: 'sec-data',
+      category: 'data',
+      title: 'Data display',
+      description:
+        'From a basic table to a sortable data grid, an aria-tree, and a windowed virtual list of 200 rows.',
+      demos: [
+        {
+          caption: 'Table',
+          layout: 'plain',
+          html: renderTable({
+            columns: [
+              { key: 'name', label: 'Name' },
+              { key: 'role', label: 'Role' },
+              { key: 'status', label: 'Status' },
+            ],
+            rows: [
+              { name: 'Alice Johnson', role: 'Admin', status: 'Active' },
+              { name: 'Bob Smith', role: 'Editor', status: 'Active' },
+              { name: 'Carol Davis', role: 'Viewer', status: 'Inactive' },
+            ],
+            caption: 'Team members',
+          }),
+          code: trim(`renderTable({ columns: [...], rows: [...], caption: 'Team members' })`),
+        },
+        {
+          caption: 'Data grid (sortable + selectable)',
+          layout: 'plain',
+          html: renderDataGrid({
+            columns: [
+              { key: 'task', label: 'Task', sortable: true },
+              { key: 'assignee', label: 'Assignee', sortable: true },
+              { key: 'priority', label: 'Priority' },
+              { key: 'status', label: 'Status' },
+            ],
+            rows: [
+              {
+                id: 1,
+                task: 'Design token system',
+                assignee: 'Alice',
+                priority: 'High',
+                status: 'Done',
+              },
+              {
+                id: 2,
+                task: 'Signal reactivity',
+                assignee: 'Bob',
+                priority: 'High',
+                status: 'Done',
+              },
+              {
+                id: 3,
+                task: 'Server rendering',
+                assignee: 'Carol',
+                priority: 'Medium',
+                status: 'Active',
+              },
+              {
+                id: 4,
+                task: 'Client hydration',
+                assignee: 'Dan',
+                priority: 'Medium',
+                status: 'Pending',
+              },
+              {
+                id: 5,
+                task: 'Component library',
+                assignee: 'Alice',
+                priority: 'Low',
+                status: 'Active',
+              },
+            ],
+            sortBy: 'task',
+            sortDir: 'asc',
+            selectable: true,
+            caption: 'Project tasks',
+          }),
+          code: trim(
+            `renderDataGrid({ columns, rows, sortBy: 'task', sortDir: 'asc', selectable: true })`,
+          ),
+        },
+        {
+          caption: 'Tree',
+          layout: 'card',
+          html: renderTree({
+            items: [
+              {
+                id: '1',
+                label: 'src',
+                icon: '\u{1F4C1}',
+                children: [
+                  {
+                    id: '1-1',
+                    label: 'runtime',
+                    icon: '\u{1F4C1}',
+                    children: [
+                      { id: '1-1-1', label: 'signals.js', icon: '\u{1F4C4}' },
+                      { id: '1-1-2', label: 'hydrate.js', icon: '\u{1F4C4}' },
+                      { id: '1-1-3', label: 'bind.js', icon: '\u{1F4C4}' },
+                    ],
+                  },
+                  {
+                    id: '1-2',
+                    label: 'server',
+                    icon: '\u{1F4C1}',
+                    children: [{ id: '1-2-1', label: 'render.js', icon: '\u{1F4C4}' }],
+                  },
+                ],
+              },
+              {
+                id: '2',
+                label: 'examples',
+                icon: '\u{1F4C1}',
+                children: [
+                  { id: '2-1', label: 'express', icon: '\u{1F4C1}' },
+                  { id: '2-2', label: 'enterprise', icon: '\u{1F4C1}' },
+                ],
+              },
+            ],
+            expanded: new Set(['1', '1-1']),
+            selected: '1-1-1',
+          }),
+          code: trim(
+            `renderTree({ items: [...], expanded: new Set(['1', '1-1']), selected: '1-1-1' })`,
+          ),
+        },
+        {
+          caption: 'Virtual list (200 rows, windowed)',
+          layout: 'form',
+          html: renderVirtualList({
+            items: Array.from(
+              { length: 200 },
+              (_, i) => `Row ${i + 1} — generated server-side, scrolled client-side`,
+            ),
+            itemHeight: 44,
+            containerHeight: 240,
+          }),
+          code: trim(`renderVirtualList({ items: [...], itemHeight: 44, containerHeight: 240 })`),
+        },
+      ],
+    },
+    {
+      id: 'sec-overlays',
+      category: 'overlays',
+      title: 'Overlays',
+      description:
+        'Native dialog, drawer that slides in, popover-anchored menus and tooltips, and a Cmd+K command palette.',
+      demos: [
+        {
+          caption: 'Dialog (native showModal)',
+          layout: 'plain',
+          html: `
+${renderButton('Open dialog', { variant: 'secondary', attrs: 'data-bn-action="open-dialog" data-bn-target="demo-dialog"' })}
+${renderDialog({
+  title: 'Confirm action',
+  content: '<p>Are you sure you want to proceed? This cannot be undone.</p>',
+  footer:
+    renderButton('Cancel', { variant: 'secondary' }) +
+    ' ' +
+    renderButton('Confirm', { variant: 'primary' }),
+  id: 'demo-dialog',
+})}`,
+          code: trim(`
+const d = renderDialog({ title, content, footer, id: 'my-dialog' });
+document.getElementById('my-dialog').showModal();`),
+        },
+        {
+          caption: 'Drawer (slide-in)',
+          layout: 'plain',
+          html: `
+${renderButton('Open drawer', { variant: 'secondary', attrs: 'data-bn-action="open-drawer" data-bn-target="demo-drawer"' })}
+${renderDrawer({
+  title: 'Settings',
+  content: '<p>Drawer body content goes here. This slides in from the edge of the viewport.</p>',
+  position: 'right',
+  id: 'demo-drawer',
+})}`,
+          code: trim(`renderDrawer({ title, content, position: 'right' })`),
+        },
+        {
+          caption: 'Dropdown menu (Popover API)',
+          layout: 'plain',
+          html: renderDropdownMenu({
+            trigger: 'Actions',
+            items: [
+              { label: 'Edit', action: 'edit', icon: '\u{270F}\u{FE0F}' },
+              { label: 'Duplicate', action: 'duplicate', icon: '\u{1F4CB}' },
+              { separator: true },
+              { label: 'Delete', action: 'delete', icon: '\u{1F5D1}\u{FE0F}' },
+            ],
+          }),
+          code: trim(
+            `renderDropdownMenu({ trigger: 'Actions', items: [{ label, action, icon }, ...] })`,
+          ),
+        },
+        {
+          caption: 'Tooltip',
+          layout: 'plain',
+          html: renderTooltip({
+            trigger: renderButton('Hover or focus', { variant: 'secondary' }),
+            content: 'This is a tooltip with helpful context. Triggers on hover or focus.',
+            position: 'top',
+          }),
+          code: trim(`renderTooltip({ trigger, content, position: 'top' })`),
+        },
+        {
+          caption: 'Command palette',
+          layout: 'plain',
+          html: `
+${renderButton('Open command palette', { variant: 'secondary', attrs: 'data-bn-action="open-command-palette" data-bn-target="demo-cmd"' })}
+<kbd>Ctrl</kbd> + <kbd>K</kbd>
+${renderCommandPalette({
+  commands: [
+    { label: 'Go to Home', action: 'home', group: 'Navigation', icon: '\u{1F3E0}' },
+    { label: 'Go to Tasks', action: 'tasks', group: 'Navigation', icon: '\u{2705}' },
+    {
+      label: 'New Task',
+      action: 'new-task',
+      group: 'Actions',
+      icon: '\u{2795}',
+      shortcut: 'Ctrl+N',
+    },
+    { label: 'Search', action: 'search', group: 'Actions', icon: '\u{1F50D}', shortcut: 'Ctrl+K' },
+  ],
+  id: 'demo-cmd',
+})}`,
+          code: trim(
+            `renderCommandPalette({ commands: [{ label, action, group, shortcut }, ...] })`,
+          ),
+        },
+        {
+          caption: 'Toasts (live region)',
+          layout: 'stack',
+          html: `
+<nav data-bn-demo-row aria-label="Toast triggers">
+  ${renderButton('Info', { variant: 'secondary', attrs: 'data-bn-action="toast" data-bn-message="For your information." data-bn-variant="info"' })}
+  ${renderButton('Success', { variant: 'primary', attrs: 'data-bn-action="toast" data-bn-message="All good — saved." data-bn-variant="success"' })}
+  ${renderButton('Error', { variant: 'destructive', attrs: 'data-bn-action="toast" data-bn-message="Something went sideways." data-bn-variant="error"' })}
+</nav>`,
+          code: trim(`
+import { showToast } from '@basenative/components';
+showToast({ message: 'Saved.', variant: 'success' });`),
+        },
+      ],
+    },
+    {
+      id: 'sec-blocks',
+      category: 'data',
+      title: 'Block components',
+      description:
+        'Higher-order layouts: a layout grid, a week calendar, and a pipeline board — all server-rendered, all on native primitives.',
+      demos: [
+        {
+          caption: 'Layout grid (6-col)',
+          layout: 'plain',
+          html: renderLayoutGrid({
+            id: 'showcase-layout-grid',
+            columns: 6,
+            gap: '0.75rem',
+            cells: [
+              { id: 'g1', label: 'Header', colSpan: 6 },
+              { id: 'g2', label: 'Sidebar', colSpan: 2, rowSpan: 2 },
+              { id: 'g3', label: 'Main content', colSpan: 4 },
+              { id: 'g4', label: 'Aside', colSpan: 4 },
+              { id: 'g5', label: 'Footer', colSpan: 6 },
+            ],
+          }),
+          code: trim(
+            `renderLayoutGrid({ columns: 6, cells: [{ id, label, colSpan, rowSpan }, ...] })`,
+          ),
+        },
+        {
+          caption: 'Week calendar',
+          layout: 'plain',
+          html: renderCalendar({
+            startDate,
+            events: calendarEvents(startDate),
+            hours: { start: 8, end: 18 },
+          }),
+          code: trim(`renderCalendar({ startDate, events: [...], hours: { start: 8, end: 18 } })`),
+        },
+        {
+          caption: 'Pipeline board',
+          layout: 'plain',
+          html: renderPipeline({
+            columns: [
+              { id: 'todo', title: 'Todo' },
+              { id: 'doing', title: 'In progress' },
+              { id: 'done', title: 'Done' },
+            ],
+            cards: [
+              {
+                id: 'c1',
+                columnId: 'todo',
+                title: 'Wire showcase hydration',
+                subtitle: 'web',
+                status: 'scheduled',
+              },
+              { id: 'c2', columnId: 'todo', title: 'Audit page navigation', subtitle: 'web' },
+              {
+                id: 'c3',
+                columnId: 'doing',
+                title: 'Render every package',
+                subtitle: 'docs',
+                description: 'Cards for all 30+ @basenative/* packages.',
+              },
+              {
+                id: 'c4',
+                columnId: 'done',
+                title: 'Fix Open dialog handler',
+                subtitle: 'overlay',
+                status: 'completed',
+              },
+              {
+                id: 'c5',
+                columnId: 'done',
+                title: 'Tooltip hover',
+                subtitle: 'overlay',
+                status: 'completed',
+              },
+            ],
+          }),
+          code: trim(
+            `renderPipeline({ columns: [...], cards: [{ id, columnId, title, ... }, ...] })`,
+          ),
+        },
+      ],
+    },
+    {
+      id: 'sec-live',
+      category: 'live',
+      title: 'Live runtime',
+      description:
+        'Pure-runtime demos that prove signals + effects work without virtual DOM, without rebuilds, without classes.',
+      demos: [
+        {
+          caption: 'Live clock (signal + setInterval)',
+          layout: 'stack',
+          html: `
+<time data-bn-clock aria-live="polite">--:--:--</time>
+<p data-bn-clock-note>Updates every second. The &lt;time&gt; element is server-rendered with a placeholder; hydration takes over on the client.</p>`,
+          code: trim(`
+const time = signal(new Date());
+effect(() => el.textContent = time().toLocaleTimeString());
+setInterval(() => time.set(new Date()), 1000);`),
+        },
+        {
+          caption: 'Theme picker (CSS custom property swap)',
+          layout: 'stack',
+          html: `
+<nav data-bn-demo-row aria-label="Pick an accent">
+  ${renderButton('Amber', { variant: 'secondary', attrs: 'data-bn-action="theme" data-bn-accent="#e8a44a"' })}
+  ${renderButton('Mint', { variant: 'secondary', attrs: 'data-bn-action="theme" data-bn-accent="#7fd1a8"' })}
+  ${renderButton('Sky', { variant: 'secondary', attrs: 'data-bn-action="theme" data-bn-accent="#82aaff"' })}
+  ${renderButton('Rose', { variant: 'secondary', attrs: 'data-bn-action="theme" data-bn-accent="#f07178"' })}
+  ${renderButton('Reset', { variant: 'ghost', attrs: 'data-bn-action="theme" data-bn-accent=""' })}
+</nav>
+<output data-bn-theme-preview>
+  ${renderBadge('Live preview', { variant: 'primary' })}
+  ${renderButton('Buttons re-tint', { variant: 'primary' })}
+  ${renderButton('Outlines re-tint', { variant: 'secondary' })}
+</output>`,
+          code: trim(`
+btn.onclick = (e) => {
+  document.documentElement.style
+    .setProperty('--accent', e.target.dataset.bnAccent);
+};`),
+        },
+        {
+          caption: 'Computed signals (counter → doubled / parity)',
+          layout: 'stack',
+          html: `
+<dl data-bn-counter-readout>
+  <dt>Value</dt>     <dd data-bn-counter-value>0</dd>
+  <dt>Doubled</dt>   <dd data-bn-counter-doubled>0</dd>
+  <dt>Parity</dt>    <dd data-bn-counter-parity data-parity="even">even</dd>
+</dl>
+<nav data-bn-demo-row aria-label="Computed counter controls">
+  ${renderButton('−', { variant: 'secondary', attrs: 'data-bn-action="cc-dec" aria-label="Decrement"' })}
+  ${renderButton('+', { variant: 'primary', attrs: 'data-bn-action="cc-inc" aria-label="Increment"' })}
+</nav>`,
+          code: trim(`
+const n       = signal(0);
+const doubled = computed(() => n() * 2);
+const parity  = computed(() => n() % 2 === 0 ? 'even' : 'odd');
+effect(() => { value.textContent = n();
+               doubledEl.textContent = doubled();
+               parityEl.textContent = parity(); });`),
+        },
+      ],
+    },
+  ];
+}
+
+export function getShowcaseContext() {
+  const sections = getShowcaseSections();
   return {
-    buttons: [
-      renderButton('Primary', { variant: 'primary' }),
-      renderButton('Secondary', { variant: 'secondary' }),
-      renderButton('Destructive', { variant: 'destructive' }),
-      renderButton('Ghost', { variant: 'ghost' }),
-      renderButton('Disabled', { variant: 'primary', disabled: true }),
-    ].join('\n'),
-    badges: [
-      renderBadge('Default', { variant: 'default' }),
-      renderBadge('Primary', { variant: 'primary' }),
-      renderBadge('Success', { variant: 'success' }),
-      renderBadge('Warning', { variant: 'warning' }),
-      renderBadge('Error', { variant: 'error' }),
-    ].join('\n'),
-    avatars: [
-      renderAvatar({ name: 'Alice Johnson', size: 'sm' }),
-      renderAvatar({ name: 'Bob Smith' }),
-      renderAvatar({ name: 'Carol Davis', size: 'lg' }),
-      renderAvatar({ name: 'Dan Lee', size: 'xl' }),
-      renderAvatar({ name: 'Eve Martinez', src: '/avatar-eve.svg', size: 'lg' }),
-    ].join('\n'),
-
-    inputDefault: renderInput({
-      name: 'email',
-      label: 'Email',
-      type: 'email',
-      placeholder: 'you@example.com',
-      helpText: 'We will not share your email.',
-    }),
-    inputError: renderInput({
-      name: 'username',
-      label: 'Username',
-      value: 'ab',
-      error: 'Must be at least 3 characters',
-    }),
-    textarea: renderTextarea({
-      name: 'bio',
-      label: 'Bio',
-      placeholder: 'Tell us about yourself...',
-      rows: 3,
-    }),
-    select: renderSelect({
-      name: 'role',
-      label: 'Role',
-      items: ['Admin', 'Editor', 'Viewer'],
-      placeholder: 'Choose a role',
-    }),
-    combobox: renderCombobox({
-      name: 'framework',
-      label: 'Framework',
-      items: ['Angular', 'React', 'Vue', 'Svelte', 'Solid'],
-      placeholder: 'Search frameworks...',
-    }),
-    multiselect: renderMultiselect({
-      name: 'tags',
-      label: 'Tags',
-      items: ['JavaScript', 'TypeScript', 'CSS', 'HTML', 'Node.js'],
-      selected: ['JavaScript', 'CSS'],
-    }),
-    checkbox: renderCheckbox({ name: 'terms', label: 'I agree to the terms and conditions' }),
-    radioGroup: renderRadioGroup({
-      name: 'plan',
-      label: 'Plan',
-      items: ['Free', 'Pro', 'Enterprise'],
-      selected: 'Pro',
-    }),
-    toggle: renderToggle({ name: 'notifications', label: 'Email notifications', checked: true }),
-
-    alertInfo: renderAlert('This is an informational message.', { variant: 'info' }),
-    alertSuccess: renderAlert('Operation completed successfully.', { variant: 'success' }),
-    alertWarning: renderAlert('Proceed with caution.', { variant: 'warning' }),
-    alertError: renderAlert('Something went wrong.', { variant: 'error', dismissible: true }),
-    progress: renderProgress({ value: 65, max: 100, label: 'Upload progress' }),
-    spinner: renderSpinner({ label: 'Loading' }),
-    spinnerLg: renderSpinner({ size: 'lg', label: 'Loading' }),
-    skeleton: renderSkeleton({ width: '100%', height: '1rem', count: 3 }),
-
-    card: renderCard({
-      header: 'Card Title',
-      body: '<p>Card body content with descriptive text about the feature or item being presented.</p>',
-      footer: 'Updated 2 hours ago',
-    }),
-    accordion: renderAccordion({
-      items: [
-        {
-          title: 'What is BaseNative?',
-          content:
-            'A lightweight signals-based runtime for native template elements with ~120 lines of client code.',
-        },
-        {
-          title: 'How does SSR work?',
-          content:
-            'The server renderer evaluates @if, @for, @switch directives at request time and returns clean HTML.',
-        },
-        {
-          title: 'What about hydration?',
-          content:
-            'The client hydrate() function walks the DOM tree, binds reactive expressions, and attaches event handlers.',
-        },
-      ],
-    }),
-    tabs: renderTabs({
-      tabs: [
-        {
-          id: 'overview',
-          label: 'Overview',
-          content:
-            '<p>BaseNative brings Angular-inspired control flow to native template elements.</p>',
-        },
-        {
-          id: 'features',
-          label: 'Features',
-          content:
-            '<p>Signals, computed values, effects, SSR, hydration, and template directives.</p>',
-        },
-        {
-          id: 'api',
-          label: 'API',
-          content:
-            '<p><code>signal()</code>, <code>computed()</code>, <code>effect()</code>, <code>hydrate()</code>, <code>render()</code>.</p>',
-        },
-      ],
-    }),
-    layoutGrid: renderLayoutGrid({
-      id: 'showcase-layout-grid',
-      columns: 6,
-      gap: '0.75rem',
-      cells: [
-        { id: 'g1', label: 'Header', colSpan: 6 },
-        { id: 'g2', label: 'Sidebar', colSpan: 2, rowSpan: 2 },
-        { id: 'g3', label: 'Main content', colSpan: 4 },
-        { id: 'g4', label: 'Aside', colSpan: 4 },
-        { id: 'g5', label: 'Footer', colSpan: 6 },
-      ],
-    }),
-
-    breadcrumb: renderBreadcrumb({
-      items: [
-        { label: 'Home', href: '/' },
-        { label: 'Components', href: '/components' },
-        { label: 'Showcase' },
-      ],
-    }),
-    pagination: renderPagination({ currentPage: 3, totalPages: 10, baseUrl: '/showcase' }),
-
-    table: renderTable({
-      columns: [
-        { key: 'name', label: 'Name' },
-        { key: 'role', label: 'Role' },
-        { key: 'status', label: 'Status' },
-      ],
-      rows: [
-        { name: 'Alice Johnson', role: 'Admin', status: 'Active' },
-        { name: 'Bob Smith', role: 'Editor', status: 'Active' },
-        { name: 'Carol Davis', role: 'Viewer', status: 'Inactive' },
-      ],
-      caption: 'Team members',
-    }),
-    datagrid: renderDataGrid({
-      columns: [
-        { key: 'task', label: 'Task', sortable: true },
-        { key: 'assignee', label: 'Assignee', sortable: true },
-        { key: 'priority', label: 'Priority' },
-        { key: 'status', label: 'Status' },
-      ],
-      rows: [
-        { id: 1, task: 'Design token system', assignee: 'Alice', priority: 'High', status: 'Done' },
-        { id: 2, task: 'Signal reactivity', assignee: 'Bob', priority: 'High', status: 'Done' },
-        {
-          id: 3,
-          task: 'Server rendering',
-          assignee: 'Carol',
-          priority: 'Medium',
-          status: 'Active',
-        },
-        { id: 4, task: 'Client hydration', assignee: 'Dan', priority: 'Medium', status: 'Pending' },
-        { id: 5, task: 'Component library', assignee: 'Alice', priority: 'Low', status: 'Active' },
-      ],
-      sortBy: 'task',
-      sortDir: 'asc',
-      selectable: true,
-      caption: 'Project tasks',
-    }),
-    tree: renderTree({
-      items: [
-        {
-          id: '1',
-          label: 'src',
-          icon: '\u{1F4C1}',
-          children: [
-            {
-              id: '1-1',
-              label: 'runtime',
-              icon: '\u{1F4C1}',
-              children: [
-                { id: '1-1-1', label: 'signals.js', icon: '\u{1F4C4}' },
-                { id: '1-1-2', label: 'hydrate.js', icon: '\u{1F4C4}' },
-                { id: '1-1-3', label: 'bind.js', icon: '\u{1F4C4}' },
-              ],
-            },
-            {
-              id: '1-2',
-              label: 'server',
-              icon: '\u{1F4C1}',
-              children: [{ id: '1-2-1', label: 'render.js', icon: '\u{1F4C4}' }],
-            },
-          ],
-        },
-        {
-          id: '2',
-          label: 'examples',
-          icon: '\u{1F4C1}',
-          children: [
-            { id: '2-1', label: 'express', icon: '\u{1F4C1}' },
-            { id: '2-2', label: 'enterprise', icon: '\u{1F4C1}' },
-          ],
-        },
-      ],
-      expanded: new Set(['1', '1-1']),
-      selected: '1-1-1',
-    }),
-    virtualList: renderVirtualList({
-      items: Array.from(
-        { length: 200 },
-        (_, i) => `Row ${i + 1} — generated server-side, scrolled client-side`,
-      ),
-      itemHeight: 44,
-      containerHeight: 240,
-    }),
-    calendar: renderCalendar({
-      startDate,
-      events: calendarEvents(startDate),
-      hours: { start: 8, end: 18 },
-    }),
-    pipeline: renderPipeline({
-      columns: [
-        { id: 'todo', title: 'Todo' },
-        { id: 'doing', title: 'In progress' },
-        { id: 'done', title: 'Done' },
-      ],
-      cards: [
-        {
-          id: 'c1',
-          columnId: 'todo',
-          title: 'Wire showcase hydration',
-          subtitle: 'web',
-          status: 'scheduled',
-        },
-        { id: 'c2', columnId: 'todo', title: 'Audit page navigation', subtitle: 'web' },
-        {
-          id: 'c3',
-          columnId: 'doing',
-          title: 'Render every package',
-          subtitle: 'docs',
-          description: 'Cards for all 30+ @basenative/* packages.',
-        },
-        {
-          id: 'c4',
-          columnId: 'done',
-          title: 'Fix Open dialog handler',
-          subtitle: 'overlay',
-          status: 'completed',
-        },
-        {
-          id: 'c5',
-          columnId: 'done',
-          title: 'Tooltip hover',
-          subtitle: 'overlay',
-          status: 'completed',
-        },
-      ],
-    }),
-
-    dialog: renderDialog({
-      title: 'Confirm Action',
-      content: '<p>Are you sure you want to proceed? This action cannot be undone.</p>',
-      footer:
-        renderButton('Cancel', { variant: 'secondary' }) +
-        renderButton('Confirm', { variant: 'primary' }),
-      id: 'demo-dialog',
-    }),
-    drawer: renderDrawer({
-      title: 'Settings',
-      content:
-        '<p>Drawer body content goes here. This slides in from the edge of the viewport.</p>',
-      position: 'right',
-      id: 'demo-drawer',
-    }),
-    dropdown: renderDropdownMenu({
-      trigger: 'Actions',
-      items: [
-        { label: 'Edit', action: 'edit', icon: '\u{270F}\u{FE0F}' },
-        { label: 'Duplicate', action: 'duplicate', icon: '\u{1F4CB}' },
-        { separator: true },
-        { label: 'Delete', action: 'delete', icon: '\u{1F5D1}\u{FE0F}' },
-      ],
-    }),
-    tooltip: renderTooltip({
-      trigger: 'Hover me',
-      content: 'This is a tooltip with helpful context. Triggers on hover or focus.',
-      position: 'top',
-    }),
-    commandPalette: renderCommandPalette({
-      commands: [
-        { label: 'Go to Home', action: 'home', group: 'Navigation', icon: '\u{1F3E0}' },
-        { label: 'Go to Tasks', action: 'tasks', group: 'Navigation', icon: '\u{2705}' },
-        {
-          label: 'New Task',
-          action: 'new-task',
-          group: 'Actions',
-          icon: '\u{2795}',
-          shortcut: 'Ctrl+N',
-        },
-        {
-          label: 'Search',
-          action: 'search',
-          group: 'Actions',
-          icon: '\u{1F50D}',
-          shortcut: 'Ctrl+K',
-        },
-      ],
-      id: 'demo-cmd',
-    }),
-
+    sections,
     toastContainer: renderToastContainer('top-right'),
-
     packageCount: PACKAGES.length,
     packageCards: renderPackageCards(),
   };

--- a/examples/express/views/component.html
+++ b/examples/express/views/component.html
@@ -23,10 +23,40 @@
       </figure>
 
       <details data-bn-component-source>
-        <summary>View source</summary>
+        <summary>
+          <span aria-hidden="true">⌄</span>
+          <span>View source</span>
+        </summary>
         <pre><code>{{ example.code }}</code></pre>
+        <button
+          type="button"
+          data-bn-action="copy-code"
+          data-bn-cta="secondary"
+          aria-label="Copy code to clipboard"
+        >
+          Copy code
+        </button>
       </details>
     </section>
+  </template>
+
+  <template @if="related.length">
+    <aside data-bn-component-related aria-label="Related components">
+      <h3>More in <em>{{ component.categoryTitle }}</em></h3>
+      <ul role="list" data-bn-component-grid>
+        <template @for="r of related; track r.slug">
+          <li>
+            <a href="/components/{{ r.slug }}" data-bn-component-card>
+              <header>
+                <h3>{{ r.title }}</h3>
+                <code data-bn-component-tag>&lt;{{ r.tag }}&gt;</code>
+              </header>
+              <p>{{ r.summary }}</p>
+            </a>
+          </li>
+        </template>
+      </ul>
+    </aside>
   </template>
 
   <nav data-bn-component-pager aria-label="Component pagination">
@@ -49,3 +79,21 @@
     </template>
   </nav>
 </article>
+
+<script type="module">
+  for (const btn of document.querySelectorAll('[data-bn-action="copy-code"]')) {
+    btn.addEventListener('click', async () => {
+      const pre = btn.parentElement?.querySelector('pre code');
+      if (!pre) return;
+      try {
+        await navigator.clipboard.writeText(pre.textContent || '');
+        const prev = btn.textContent;
+        btn.textContent = 'Copied ✓';
+        btn.setAttribute('data-bn-copied', '');
+        setTimeout(() => { btn.textContent = prev; btn.removeAttribute('data-bn-copied'); }, 1400);
+      } catch {
+        btn.textContent = 'Copy failed';
+      }
+    });
+  }
+</script>

--- a/examples/express/views/components.html
+++ b/examples/express/views/components.html
@@ -12,6 +12,27 @@
   </nav>
 </section>
 
+<search data-bn-component-search role="search" aria-label="Filter components">
+  <label for="components-q" data-bn-visually-hidden>Search components</label>
+  <input
+    id="components-q"
+    type="search"
+    data-bn-component-q
+    placeholder="Search components (e.g. button, dialog, tree…)"
+    autocomplete="off"
+    spellcheck="false"
+  />
+  <nav data-bn-component-filters aria-label="Filter by category">
+    <button type="button" data-bn-component-filter="all" aria-pressed="true">All</button>
+    <template @for="cat of categories; track cat.id">
+      <button type="button" data-bn-component-filter="{{ cat.id }}" aria-pressed="false">{{ cat.title }}</button>
+    </template>
+  </nav>
+  <p data-bn-component-empty role="status" aria-live="polite">
+    No components match. <button type="button" data-bn-component-reset>Reset filters</button>
+  </p>
+</search>
+
 <nav data-bn-component-toc aria-label="Component categories">
   <template @for="cat of categories; track cat.id">
     <a href="#cat-{{ cat.id }}">{{ cat.title }}</a>
@@ -19,7 +40,7 @@
 </nav>
 
 <template @for="cat of categories; track cat.id">
-  <section data-bn-component-category id="cat-{{ cat.id }}">
+  <section data-bn-component-category id="cat-{{ cat.id }}" data-bn-category="{{ cat.id }}">
     <header data-bn-component-category-head>
       <h2>{{ cat.title }}</h2>
       <p>{{ cat.summary }}</p>
@@ -27,7 +48,11 @@
 
     <ul role="list" data-bn-component-grid>
       <template @for="comp of cat.components; track comp.slug">
-        <li>
+        <li
+          data-bn-component-card-host
+          data-bn-slug="{{ comp.slug }}"
+          data-bn-search="{{ comp.slug }} {{ comp.title }} {{ comp.tag }} {{ comp.summary }}"
+        >
           <a href="/components/{{ comp.slug }}" data-bn-component-card>
             <header>
               <h3>{{ comp.title }}</h3>
@@ -66,3 +91,51 @@
     </li>
   </ol>
 </section>
+
+<script type="module">
+  const ROOT = document.documentElement;
+  const input = document.querySelector('[data-bn-component-q]');
+  const cards = document.querySelectorAll('[data-bn-component-card-host]');
+  const cats = document.querySelectorAll('[data-bn-component-category]');
+  const filterBtns = document.querySelectorAll('[data-bn-component-filter]');
+  const reset = document.querySelector('[data-bn-component-reset]');
+
+  let activeCat = 'all';
+  let activeQ = '';
+
+  const apply = () => {
+    const q = activeQ.trim().toLowerCase();
+    let visibleTotal = 0;
+    for (const card of cards) {
+      const haystack = (card.getAttribute('data-bn-search') || '').toLowerCase();
+      const inCat = activeCat === 'all' || card.closest('[data-bn-category]')?.dataset.bnCategory === activeCat;
+      const matchQ = !q || haystack.includes(q);
+      const visible = inCat && matchQ;
+      card.toggleAttribute('hidden', !visible);
+      if (visible) visibleTotal++;
+    }
+    for (const cat of cats) {
+      const visible = cat.querySelectorAll('[data-bn-component-card-host]:not([hidden])').length > 0;
+      cat.toggleAttribute('hidden', !visible);
+    }
+    ROOT.toggleAttribute('data-bn-no-results', visibleTotal === 0);
+  };
+
+  input?.addEventListener('input', () => { activeQ = input.value; apply(); });
+  for (const btn of filterBtns) {
+    btn.addEventListener('click', () => {
+      for (const b of filterBtns) b.setAttribute('aria-pressed', 'false');
+      btn.setAttribute('aria-pressed', 'true');
+      activeCat = btn.getAttribute('data-bn-component-filter') || 'all';
+      apply();
+    });
+  }
+  reset?.addEventListener('click', () => {
+    if (input) input.value = '';
+    activeQ = '';
+    activeCat = 'all';
+    for (const b of filterBtns) b.setAttribute('aria-pressed', String(b.getAttribute('data-bn-component-filter') === 'all'));
+    apply();
+    input?.focus();
+  });
+</script>

--- a/examples/express/views/showcase.html
+++ b/examples/express/views/showcase.html
@@ -3,9 +3,9 @@
     <p data-bn-eyebrow>Live gallery</p>
     <h2>Component <em>showcase</em></h2>
     <p data-bn-lede>
-      Every component, server-rendered and interactive. Each section below is a real
-      <code>render*()</code> call from <code>@basenative/components</code> — there are no mockups,
-      no static screenshots, and no virtual DOM.
+      Every component, server-rendered and interactive. Each demo is a real
+      <code>render*()</code> call from <code>@basenative/components</code> — no mockups,
+      no screenshots, no virtual DOM.
     </p>
     <nav data-bn-showcase-actions aria-label="Quick links">
       <a href="/components" data-bn-cta="primary">Browse the catalog →</a>
@@ -13,317 +13,69 @@
     </nav>
   </header>
 
+  <search data-bn-showcase-search role="search" aria-label="Filter showcase sections">
+    <label for="showcase-q" data-bn-visually-hidden>Filter sections by name</label>
+    <input
+      id="showcase-q"
+      type="search"
+      data-bn-showcase-q
+      placeholder="Filter by name (e.g. dialog, table, signal…)"
+      autocomplete="off"
+      spellcheck="false"
+    />
+    <p data-bn-showcase-empty role="status" aria-live="polite">
+      No sections match your filter. <button type="button" data-bn-showcase-clear>Clear</button>
+    </p>
+  </search>
+
   <aside data-bn-showcase-toc aria-label="Showcase sections">
     <h3>Sections</h3>
     <nav>
       <ol>
-        <li><a href="#sec-buttons">Buttons</a></li>
-        <li><a href="#sec-badges">Badges &amp; avatars</a></li>
-        <li><a href="#sec-form">Form controls</a></li>
-        <li><a href="#sec-feedback">Feedback</a></li>
-        <li><a href="#sec-layout">Cards &amp; layout</a></li>
-        <li><a href="#sec-nav">Navigation</a></li>
-        <li><a href="#sec-data">Data display</a></li>
-        <li><a href="#sec-overlays">Overlays</a></li>
+        <template @for="s of sections; track s.id">
+          <li><a href="#{{ s.id }}" data-bn-showcase-toc-link data-bn-target="{{ s.id }}">{{ s.title }}</a></li>
+        </template>
       </ol>
     </nav>
   </aside>
 
-  <section id="sec-buttons" data-bn-showcase-section>
-    <header>
-      <h2>Buttons</h2>
-      <p>
-        Primary, secondary, destructive, ghost, and disabled — all on a real
-        <code>&lt;button&gt;</code>.
-      </p>
-    </header>
-    <figure data-bn-showcase-demo>
-      <figcaption>Variants</figcaption>
-      <output data-bn-showcase-row>{{ buttons }}</output>
-    </figure>
-  </section>
+  <template @for="s of sections; track s.id">
+    <section
+      data-bn-showcase-section
+      id="{{ s.id }}"
+      data-bn-category="{{ s.category }}"
+      data-bn-title="{{ s.title }}"
+    >
+      <header>
+        <h2>{{ s.title }}</h2>
+        <p>{{ s.description }}</p>
+      </header>
 
-  <section id="sec-badges" data-bn-showcase-section>
-    <header>
-      <h2>Badges &amp; avatars</h2>
-      <p>Compact status pills and initials-fallback avatars.</p>
-    </header>
-    <figure data-bn-showcase-demo>
-      <figcaption>Badge variants</figcaption>
-      <output data-bn-showcase-row>{{ badges }}</output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Avatar sizes</figcaption>
-      <output data-bn-showcase-row>{{ avatars }}</output>
-    </figure>
-  </section>
-
-  <section id="sec-form" data-bn-showcase-section>
-    <header>
-      <h2>Form controls</h2>
-      <p>Field semantics, label/help/error wiring, native validation hooks.</p>
-    </header>
-    <figure data-bn-showcase-demo>
-      <figcaption>Inputs</figcaption>
-      <output data-bn-showcase-form> {{ inputDefault }} {{ inputError }} </output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Textarea, select, combobox, multiselect</figcaption>
-      <output data-bn-showcase-form>
-        {{ textarea }} {{ select }} {{ combobox }} {{ multiselect }}
-      </output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Checkbox, radio group, toggle</figcaption>
-      <output data-bn-showcase-form> {{ checkbox }} {{ radioGroup }} {{ toggle }} </output>
-    </figure>
-  </section>
-
-  <section id="sec-feedback" data-bn-showcase-section>
-    <header>
-      <h2>Feedback</h2>
-      <p>Inline alerts, progress, spinners, skeletons, and toasts.</p>
-    </header>
-    <figure data-bn-showcase-demo>
-      <figcaption>Alerts</figcaption>
-      <output data-bn-showcase-stack>
-        {{ alertInfo }} {{ alertSuccess }} {{ alertWarning }} {{ alertError }}
-      </output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Progress</figcaption>
-      <output>{{ progress }}</output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Spinners</figcaption>
-      <output data-bn-showcase-row> {{ spinner }} {{ spinnerLg }} </output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Skeleton</figcaption>
-      <output>{{ skeleton }}</output>
-    </figure>
-  </section>
-
-  <section id="sec-layout" data-bn-showcase-section>
-    <header>
-      <h2>Cards &amp; layout</h2>
-      <p>Article-shaped cards, native disclosure for accordions, ARIA tablists.</p>
-    </header>
-    <figure data-bn-showcase-demo>
-      <figcaption>Card</figcaption>
-      <output data-bn-showcase-card>{{ card }}</output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Accordion (native &lt;details&gt;)</figcaption>
-      <output data-bn-showcase-form>{{ accordion }}</output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Tabs</figcaption>
-      <output>{{ tabs }}</output>
-    </figure>
-  </section>
-
-  <section id="sec-nav" data-bn-showcase-section>
-    <header>
-      <h2>Navigation</h2>
-      <p>
-        Breadcrumbs and pagination — both wrapped in a <code>&lt;nav&gt;</code> with proper ARIA
-        labels.
-      </p>
-    </header>
-    <figure data-bn-showcase-demo>
-      <figcaption>Breadcrumb</figcaption>
-      <output>{{ breadcrumb }}</output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Pagination</figcaption>
-      <output>{{ pagination }}</output>
-    </figure>
-  </section>
-
-  <section id="sec-data" data-bn-showcase-section>
-    <header>
-      <h2>Data display</h2>
-      <p>From a basic table to a sortable data grid, a tree, and a virtualized list.</p>
-    </header>
-    <figure data-bn-showcase-demo>
-      <figcaption>Table</figcaption>
-      <output>{{ table }}</output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Data grid</figcaption>
-      <output>{{ datagrid }}</output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Tree</figcaption>
-      <output data-bn-showcase-card>{{ tree }}</output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Virtual list</figcaption>
-      <output data-bn-showcase-form>{{ virtualList }}</output>
-    </figure>
-  </section>
-
-  <section id="sec-overlays" data-bn-showcase-section>
-    <header>
-      <h2>Overlays</h2>
-      <p>Native <code>&lt;dialog&gt;</code>, side drawers, popover-anchored menus and tooltips.</p>
-    </header>
-    <figure data-bn-showcase-demo>
-      <figcaption>Dialog</figcaption>
-      <output>
-        <button
-          type="button"
-          data-bn="button"
-          data-variant="secondary"
-          onclick="document.getElementById('demo-dialog').showModal()"
-        >
-          Open dialog
-        </button>
-        {{ dialog }}
-      </output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Drawer</figcaption>
-      <output>
-        <button
-          type="button"
-          data-bn="button"
-          data-variant="secondary"
-          data-bn-showcase-open-drawer
-        >
-          Open drawer
-        </button>
-        {{ drawer }}
-      </output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Dropdown menu</figcaption>
-      <output>{{ dropdown }}</output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Tooltip</figcaption>
-      <output>{{ tooltip }}</output>
-    </figure>
-    <figure data-bn-showcase-demo>
-      <figcaption>Command palette</figcaption>
-      <output>
-        <button
-          type="button"
-          data-bn="button"
-          data-variant="secondary"
-          onclick="document.getElementById('demo-cmd').showModal()"
-        >
-          Open command palette
-        </button>
-        <kbd>Ctrl</kbd> + <kbd>K</kbd>
-        {{ commandPalette }}
-      </output>
-    </figure>
-  </section>
+      <template @for="d of s.demos; track d.caption">
+        <figure data-bn-showcase-demo data-bn-layout="{{ d.layout }}">
+          <figcaption>{{ d.caption }}</figcaption>
+          <output data-bn-showcase-stage>{{ d.html }}</output>
+          <details data-bn-showcase-source>
+            <summary>
+              <span aria-hidden="true">⌄</span>
+              <span>View source</span>
+            </summary>
+            <pre><code>{{ d.code }}</code></pre>
+            <button
+              type="button"
+              data-bn-action="copy-code"
+              data-bn-cta="secondary"
+              aria-label="Copy code to clipboard"
+            >
+              Copy code
+            </button>
+          </details>
+        </figure>
+      </template>
+    </section>
+  </template>
 </article>
 
 {{ toastContainer }}
 
-<script type="module">
-  // Tabs interactivity
-  document.querySelectorAll('[data-bn="tab"]').forEach((tab) => {
-    tab.addEventListener('click', () => {
-      const tabs = tab.closest('[data-bn="tabs"]');
-      tabs
-        .querySelectorAll('[data-bn="tab"]')
-        .forEach((t) => t.setAttribute('aria-selected', 'false'));
-      tabs.querySelectorAll('[data-bn="tab-panel"]').forEach((p) => (p.hidden = true));
-      tab.setAttribute('aria-selected', 'true');
-      const panel = tabs.querySelector('#' + tab.getAttribute('aria-controls'));
-      if (panel) panel.hidden = false;
-    });
-  });
-
-  // Dialog close buttons
-  document.querySelectorAll('[data-bn="dialog-close"]').forEach((btn) => {
-    btn.addEventListener('click', () => btn.closest('[data-bn="dialog"]')?.close());
-  });
-
-  // Drawer
-  const drawer = document.getElementById('demo-drawer');
-  const drawerOverlay = document.querySelector('[data-bn="drawer-overlay"]');
-  document.querySelector('[data-bn-showcase-open-drawer]')?.addEventListener('click', () => {
-    drawer?.setAttribute('data-open', '');
-    drawerOverlay?.removeAttribute('hidden');
-  });
-  const closeDrawer = () => {
-    drawer?.removeAttribute('data-open');
-    drawerOverlay?.setAttribute('hidden', '');
-  };
-  document.querySelector('[data-bn="drawer-close"]')?.addEventListener('click', closeDrawer);
-  drawerOverlay?.addEventListener('click', closeDrawer);
-
-  // Alert dismiss
-  document.querySelectorAll('[data-bn="alert-dismiss"]').forEach((btn) => {
-    btn.addEventListener('click', () => btn.closest('[data-bn="alert"]')?.remove());
-  });
-
-  // Tooltip — popovertarget only fires on <button>/<input>, so wire span triggers manually
-  document.querySelectorAll('[data-bn="tooltip-trigger"]').forEach((trigger) => {
-    const id = trigger.getAttribute('popovertarget');
-    const tip = id && document.getElementById(id);
-    if (!tip) return;
-    trigger.tabIndex = 0;
-    const place = () => {
-      const t = trigger.getBoundingClientRect();
-      const tw = tip.offsetWidth || 200;
-      const th = tip.offsetHeight || 40;
-      tip.style.left = Math.max(8, t.left + t.width / 2 - tw / 2) + 'px';
-      tip.style.top = Math.max(8, t.top - th - 8) + 'px';
-    };
-    const show = () => {
-      try {
-        tip.showPopover();
-        place();
-        requestAnimationFrame(place);
-      } catch {}
-    };
-    const hide = () => {
-      try {
-        tip.hidePopover();
-      } catch {}
-    };
-    trigger.addEventListener('pointerenter', show);
-    trigger.addEventListener('pointerleave', hide);
-    trigger.addEventListener('focus', show);
-    trigger.addEventListener('blur', hide);
-  });
-
-  // Dropdown menu — anchor the popover to its trigger after open
-  document.querySelectorAll('[data-bn="dropdown-trigger"]').forEach((trigger) => {
-    const id = trigger.getAttribute('popovertarget');
-    const menu = id && document.getElementById(id);
-    if (!menu) return;
-    menu.addEventListener('toggle', (e) => {
-      if (e.newState !== 'open') return;
-      const t = trigger.getBoundingClientRect();
-      menu.style.left = t.left + 'px';
-      menu.style.top = t.bottom + 4 + 'px';
-    });
-  });
-
-  // Highlight current section in TOC as user scrolls
-  const tocLinks = document.querySelectorAll('[data-bn-showcase-toc] a');
-  const sections = Array.from(document.querySelectorAll('[data-bn-showcase-section]'));
-  const observer = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          const id = entry.target.id;
-          tocLinks.forEach((a) => {
-            if (a.getAttribute('href') === '#' + id) a.setAttribute('aria-current', 'true');
-            else a.removeAttribute('aria-current');
-          });
-        }
-      });
-    },
-    { rootMargin: '-30% 0px -60% 0px' },
-  );
-  sections.forEach((s) => observer.observe(s));
-</script>
+<script type="module" src="/showcase.js"></script>


### PR DESCRIPTION
## Summary
Significant UX overhaul of the **/showcase**, **/components**, and **/components/:slug** pages on basenative.com. Demonstrates BaseNative's semantic-HTML philosophy by example — every selector is element + `data-bn-*`, zero classes, every section is built on the right primitive.

### Showcase (/showcase)
- **Data-driven sections** — each demo declares `{ caption, html, code, layout }` in `examples/express/showcase-data.js`. New `getShowcaseSections()` exports a single source of truth that drives both the TOC and the page body.
- **Source viewer per demo** — every `<figure>` ships with a `<details data-bn-showcase-source>` and a Copy-code button. Click a chevron, see the `render*()` call, hit copy.
- **New interactive demos** — live counter (signal + effect), live form validation (signal + computed + aria-invalid wiring), animated progress with pause/play/reset, theme picker that swaps `--accent` across the document, computed-signal readout (value / doubled / parity), and a live `<time>` clock.
- **Sticky filter bar** (`<search role="search">`) narrows sections by name. Empty state surfaces via `:root[data-bn-showcase-empty]` — pure CSS.
- **Sticky TOC** with intersection-observer-driven `aria-current`.

### Components catalog (/components)
- **Sticky `<search>` bar** with category filter chips (`aria-pressed` states).
- **Live JS-driven filtering** — hides cards via `[hidden]`, auto-hides empty categories via `:has()`.
- **Empty state** with reset button surfaces via `:root[data-bn-no-results]`.

### Component detail (/components/:slug)
- **Source viewer** styled with ▾ chevron animation + Copy code button.
- **Related components grid** — siblings in the same category (max 6).
- Server passes `related` into the per-component context.

### Modern CSS used
- `@scope` blocks for showcase TOC + component grid focus state
- `:has()` for empty-state visibility and category auto-hiding
- `color-mix()` for translucent surfaces and active filter pills
- Container queries for adaptive demo grid layout
- CSS nesting throughout new rule blocks

Semantic markup end-to-end: `section / article / figure / figcaption / details / summary / nav / search / output / time / dl-dt-dd`.

## Test plan
- [x] `cd packages/components && node --test` — 136/136 pass
- [x] `/showcase` renders all 10 sections with 33 demos and source viewers
- [x] Live counter increments via signal + effect
- [x] Live form validation toggles `aria-invalid` based on length
- [x] Theme picker swaps `--accent` (verified `#7fd1a8`)
- [x] Sticky filter narrows sections (typed `progress` → 1 section visible)
- [x] `/components` filter chips set `aria-pressed=true`, narrow to 5 overlay components
- [x] `/components` search "dialog" → 2 results (dialog + command-palette)
- [x] `/components/dialog` shows breadcrumb, copy button, related (Drawer/Dropdown/Tooltip/Toast), prev/next pager
- [x] `curl` smoke test: `/`, `/components`, `/components/button`, `/showcase` all 200
- [x] No console errors in any of the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)