### PR TITLE
fix(ci,lint): repair lint gate + clear 47 real ESLint errors

### DIFF
--- a/examples/configurator/project.json
+++ b/examples/configurator/project.json
@@ -3,11 +3,16 @@
   "targets": {
     "serve": {
       "cache": false,
-      "command": "npx serve ."
+      "command": "npx serve .",
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "test": {
       "command": "node --test passive-house-engine.test.js",
-      "options": { "cwd": "{projectRoot}" }
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/examples/enterprise/project.json
+++ b/examples/enterprise/project.json
@@ -2,7 +2,10 @@
   "name": "basenative-enterprise-example",
   "targets": {
     "serve": {
-      "command": "node server.js"
+      "command": "node server.js",
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/examples/static/project.json
+++ b/examples/static/project.json
@@ -3,7 +3,10 @@
   "targets": {
     "serve": {
       "cache": false,
-      "command": "npx serve ."
+      "command": "npx serve .",
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/admin/project.json
+++ b/packages/admin/project.json
@@ -4,12 +4,23 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js", "{projectRoot}/test/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js",
+        "{projectRoot}/test/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/auth-webauthn/project.json
+++ b/packages/auth-webauthn/project.json
@@ -4,12 +4,23 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js", "{projectRoot}/test/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js",
+        "{projectRoot}/test/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/auth/project.json
+++ b/packages/auth/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/auth/src/providers/credentials.js
+++ b/packages/auth/src/providers/credentials.js
@@ -27,7 +27,7 @@ export function credentialsProvider(options) {
       if (!valid) return { success: false, error: 'Invalid credentials' };
 
       // Return user without password hash
-      const { passwordHash, password_hash, ...safeUser } = user;
+      const { passwordHash: _passwordHash, password_hash: _password_hash, ...safeUser } = user;
       return { success: true, user: safeUser };
     },
 

--- a/packages/auth/src/session.js
+++ b/packages/auth/src/session.js
@@ -1,4 +1,4 @@
-import { randomBytes, createHash } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
 
 /**
  * Session manager with pluggable storage.

--- a/packages/builder/project.json
+++ b/packages/builder/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/claude-config/project.json
+++ b/packages/claude-config/project.json
@@ -4,12 +4,24 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js", "{projectRoot}/test/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js",
+        "{projectRoot}/test/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src",
-      "inputs": ["{projectRoot}/src/**/*.js", "{projectRoot}/bin/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js",
+        "{projectRoot}/bin/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/combobox/project.json
+++ b/packages/combobox/project.json
@@ -4,12 +4,23 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js", "{projectRoot}/test/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js",
+        "{projectRoot}/test/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/combobox/src/combobox.js
+++ b/packages/combobox/src/combobox.js
@@ -108,9 +108,6 @@ export function renderCombobox(options = {}) {
     : ` aria-describedby="${liveId}"`;
   const opts = (options.options || []).map(normalizeOption).filter(Boolean);
   const allowCreate = options.allowCreate === true;
-  const createLabelText = options.createLabel
-    ? options.createLabel(value)
-    : defaultCreateLabel(value);
 
   // Pre-render the option list so that JS-disabled clients still see
   // selectable choices via a fallback <datalist>. The visible listbox

--- a/packages/components/project.json
+++ b/packages/components/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/components/src/accordion.js
+++ b/packages/components/src/accordion.js
@@ -12,7 +12,7 @@ export function renderAccordion(options = {}) {
   const exclusiveName = multiple ? '' : ` name="${id}"`;
 
   const sectionsHtml = items
-    .map((item, i) => {
+    .map((item, _i) => {
       const open = item.open ? ' open' : '';
       return `<details data-bn="accordion-item"${exclusiveName}${open}>
   <summary data-bn="accordion-header">${item.title}</summary>

--- a/packages/components/src/calendar-state.js
+++ b/packages/components/src/calendar-state.js
@@ -56,9 +56,7 @@ export function getEventDuration(start, end) {
  * @returns {object} Calendar state with signal methods
  */
 export function createCalendarState(options = {}) {
-  const { startDate, initialEvents = [], hours = {} } = options;
-  const hourStart = hours.start ?? 7;
-  const hourEnd = hours.end ?? 19;
+  const { startDate, initialEvents = [] } = options;
 
   // State signals would be injected by @basenative/runtime,
   // but for testability, we expose as a mock
@@ -284,7 +282,6 @@ export function createPipelineState(options = {}) {
      * @param {Array<string>} cardOrder - Array of card IDs in desired order
      */
     reorderCards: (columnId, cardOrder) => {
-      const columnCards = cardsData.filter(c => c.columnId === columnId);
       const orderMap = new Map(cardOrder.map((id, idx) => [id, idx]));
 
       cardsData = cardsData.sort((a, b) => {

--- a/packages/components/src/calendar.js
+++ b/packages/components/src/calendar.js
@@ -266,7 +266,7 @@ export function initCalendarDragDrop(container, callbacks = {}) {
     } catch { /* ignore malformed drag data */ }
   }
 
-  function handleDragEnd(e) {
+  function handleDragEnd(_e) {
     container.querySelectorAll('[data-dragging]').forEach(el =>
       el.removeAttribute('data-dragging')
     );
@@ -302,15 +302,11 @@ export function initCalendarDragDrop(container, callbacks = {}) {
  */
 export function initPipelineDragDrop(container, callbacks = {}) {
   const { onCardMove } = callbacks;
-  let draggedCard = null;
-  let sourceColumn = null;
 
   function handleDragStart(e) {
     const card = e.target.closest('[data-card-id]');
     if (!card) return;
 
-    draggedCard = card;
-    sourceColumn = card.closest('[data-column-id]');
     e.dataTransfer.setData('text/plain', JSON.stringify({
       type: 'pipeline-card',
       cardId: card.dataset.cardId,
@@ -356,9 +352,7 @@ export function initPipelineDragDrop(container, callbacks = {}) {
     } catch { /* ignore malformed drag data */ }
   }
 
-  function handleDragEnd(e) {
-    draggedCard = null;
-    sourceColumn = null;
+  function handleDragEnd(_e) {
     container.querySelectorAll('[data-dragging]').forEach(el =>
       el.removeAttribute('data-dragging')
     );

--- a/packages/components/src/dialog.js
+++ b/packages/components/src/dialog.js
@@ -6,7 +6,7 @@ export function renderDialog(options = {}) {
     title,
     content = '',
     open = false,
-    modal = true,
+    modal: _modal = true,
     closable = true,
     size = 'default',
     footer = '',

--- a/packages/config/project.json
+++ b/packages/config/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/config/src/config.test.js
+++ b/packages/config/src/config.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseEnvFile, loadEnv } from './env.js';
+import { parseEnvFile } from './env.js';
 import { string, number, boolean, oneOf, optional, validateConfig, zodAdapter } from './schema.js';
 import { defineConfig } from './index.js';
 

--- a/packages/date/project.json
+++ b/packages/date/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/db/project.json
+++ b/packages/db/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/db/src/db.test.js
+++ b/packages/db/src/db.test.js
@@ -280,10 +280,8 @@ describe('migrate', () => {
 
   function makeAdapter() {
     // In-memory SQLite-like adapter using maps
-    const tables = new Map();
-    const migTable = '_migrations';
 
-    async function execute(sql, params = []) {
+    async function execute(_sql, _params = []) {
       // Minimal in-memory adapter
     }
 
@@ -294,7 +292,7 @@ describe('migrate', () => {
       return { rows: [] };
     }
 
-    async function queryOne(sql) {
+    async function queryOne(_sql) {
       return null;
     }
 

--- a/packages/doppler/project.json
+++ b/packages/doppler/project.json
@@ -4,12 +4,23 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js", "{projectRoot}/test/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js",
+        "{projectRoot}/test/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/doppler/src/index.js
+++ b/packages/doppler/src/index.js
@@ -112,7 +112,7 @@ async function fetchDopplerSecrets(project, config) {
   try {
     return JSON.parse(result.stdout);
   } catch (err) {
-    throw new Error(`Could not parse doppler output as JSON: ${err.message}`);
+    throw new Error(`Could not parse doppler output as JSON: ${err.message}`, { cause: err });
   }
 }
 

--- a/packages/doppler/src/required.js
+++ b/packages/doppler/src/required.js
@@ -39,7 +39,7 @@ export function loadRequired(filePath) {
   try {
     raw = JSON.parse(readFileSync(full, 'utf-8'));
   } catch (err) {
-    throw new Error(`doppler-required.json is not valid JSON: ${err.message}`);
+    throw new Error(`doppler-required.json is not valid JSON: ${err.message}`, { cause: err });
   }
   return validateRequired(raw);
 }

--- a/packages/favicon/project.json
+++ b/packages/favicon/project.json
@@ -4,12 +4,23 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js", "{projectRoot}/test/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js",
+        "{projectRoot}/test/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/favicon/src/glyphs.js
+++ b/packages/favicon/src/glyphs.js
@@ -180,7 +180,6 @@ export const symbols = {
   asterisk: (p) => {
     const spokes = [];
     for (let i = 0; i < 6; i++) {
-      const a = (i * Math.PI) / 3;
       spokes.push(
         `<rect x="${C - 44}" y="${C - 340}" width="88" height="680" rx="44" fill="${p.accent}" transform="rotate(${(i * 60).toFixed(2)} ${C} ${C})"/>`,
       );

--- a/packages/favicon/src/png.js
+++ b/packages/favicon/src/png.js
@@ -33,6 +33,7 @@ async function loadResvg() {
           "shipped transitively via the optional peer `@basenative/og-image`. " +
           "Install with: pnpm add @basenative/og-image\n" +
           `Underlying error: ${err && /** @type {any} */ (err).message}`,
+        { cause: err },
       );
     }
     // resvg-wasm needs initWasm() called once per isolate. The `@basenative/

--- a/packages/fetch/project.json
+++ b/packages/fetch/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/fetch/src/index.js
+++ b/packages/fetch/src/index.js
@@ -1,4 +1,4 @@
-import { signal, computed, effect } from '@basenative/runtime';
+import { signal, computed } from '@basenative/runtime';
 
 /**
  * Create a signal-based async resource.
@@ -9,7 +9,7 @@ import { signal, computed, effect } from '@basenative/runtime';
  * @returns {object} Resource with data, loading, error signals
  */
 export function createResource(fetcher, options = {}) {
-  const { initialData, immediate = true, key } = options;
+  const { initialData, immediate = true, key: _key } = options;
 
   const data = signal(initialData ?? null);
   const loading = signal(false);

--- a/packages/flags/project.json
+++ b/packages/flags/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/flags/src/flags.js
+++ b/packages/flags/src/flags.js
@@ -39,7 +39,7 @@ export function createFlagManager(provider, options = {}) {
     async getAll(context = {}) {
       const allFlags = await provider.getAllFlags();
       const result = {};
-      for (const [name, flag] of Object.entries(allFlags)) {
+      for (const [name, _flag] of Object.entries(allFlags)) {
         result[name] = await this.isEnabled(name, context);
       }
       return result;

--- a/packages/flags/src/provider-integration.test.js
+++ b/packages/flags/src/provider-integration.test.js
@@ -416,7 +416,7 @@ describe('Provider compatibility layer', () => {
   });
 
   it('works with provider that has getAllFlags but no individual get', async () => {
-    const allProvider = {
+    const _allProvider = {
       async getAllFlags() {
         return {
           flag1: { enabled: true },

--- a/packages/forms/project.json
+++ b/packages/forms/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/forms/src/validation.test.js
+++ b/packages/forms/src/validation.test.js
@@ -780,7 +780,7 @@ describe('validators — comprehensive validation module coverage', () => {
 
     it('validates URL format', () => {
       const urlValidator = pattern(
-        /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)$/,
+        /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)$/,
         'Invalid URL'
       );
 

--- a/packages/i18n/project.json
+++ b/packages/i18n/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/i18n/src/i18n.test.js
+++ b/packages/i18n/src/i18n.test.js
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach } from 'node:test';
+import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { writeFile, mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';

--- a/packages/integrations/project.json
+++ b/packages/integrations/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/keyboard/project.json
+++ b/packages/keyboard/project.json
@@ -4,12 +4,23 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js", "{projectRoot}/test/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js",
+        "{projectRoot}/test/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/logger/project.json
+++ b/packages/logger/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/logger/src/index.js
+++ b/packages/logger/src/index.js
@@ -66,7 +66,7 @@ export function consoleTransport() {
       if (pretty) {
         const levelName = LEVEL_NAMES[entry.level] ?? 'info';
         const color = entry.level >= 50 ? '\x1b[31m' : entry.level >= 40 ? '\x1b[33m' : '\x1b[36m';
-        const { level, time, msg, name, ...rest } = entry;
+        const { level: _level, time: _time, msg, name, ...rest } = entry;
         const prefix = name ? `[${name}] ` : '';
         const extra = Object.keys(rest).length > 0 ? ' ' + JSON.stringify(rest) : '';
         console.log(`${color}${levelName.toUpperCase()}\x1b[0m ${prefix}${msg}${extra}`);

--- a/packages/logger/src/logger.test.js
+++ b/packages/logger/src/logger.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { createLogger, consoleTransport, streamTransport, multiTransport, requestLogger, LEVELS, LEVEL_NAMES } from './index.js';
+import { createLogger, streamTransport, multiTransport, requestLogger, LEVELS, LEVEL_NAMES } from './index.js';
 
 function captureTransport() {
   const entries = [];

--- a/packages/markdown/project.json
+++ b/packages/markdown/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/markdown/src/markdown.js
+++ b/packages/markdown/src/markdown.js
@@ -130,7 +130,7 @@ function parseInline(text) {
  * @param {boolean} [options.sanitize=true]  Escape HTML entities in source
  * @returns {string} HTML output
  */
-export function parse(source, options = {}) {
+export function parse(source, _options = {}) {
   const lines = source.replace(/\r\n/g, '\n').split('\n');
   const blocks = [];
   let i = 0;
@@ -146,7 +146,6 @@ export function parse(source, options = {}) {
 
     // Fenced code block
     if (line.trimStart().startsWith('```')) {
-      const indent = line.length - line.trimStart().length;
       const lang = line.trimStart().slice(3).trim();
       const codeLines = [];
       i++;

--- a/packages/middleware/project.json
+++ b/packages/middleware/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/middleware/src/adapters/express.js
+++ b/packages/middleware/src/adapters/express.js
@@ -50,7 +50,7 @@ export function toExpressMiddleware(pipeline) {
 /**
  * Create a BaseNative context from Express req/res.
  */
-function createExpressContext(req, res) {
+function createExpressContext(req, _res) {
   return {
     request: {
       method: req.method,

--- a/packages/middleware/src/adapters/fastify.js
+++ b/packages/middleware/src/adapters/fastify.js
@@ -53,7 +53,7 @@ export function toFastifyPlugin(pipeline) {
  * @param {object} reply - Fastify Reply
  * @returns {object} Common middleware context
  */
-function createFastifyContext(request, reply) {
+function createFastifyContext(request, _reply) {
   return {
     request: {
       method: request.method,

--- a/packages/middleware/src/middleware.test.js
+++ b/packages/middleware/src/middleware.test.js
@@ -526,21 +526,6 @@ describe('Express adapter', () => {
     };
   }
 
-  function mockExpressRes() {
-    const state = { code: 200, headers: {}, body: undefined };
-    return {
-      setHeader: (k, v) => { state.headers[k] = v; },
-      status: (code) => { state.code = code; return res; },
-      send: (body) => { state.body = body; },
-      cookie: () => {},
-      _state: state,
-      get _self() { return res; },
-    };
-    // eslint-disable-next-line no-unreachable
-    var res = { setHeader: (k, v) => { state.headers[k] = v; }, status: (code) => { state.code = code; return res; }, send: (body) => { state.body = body; }, cookie: () => {}, _state: state };
-    return res;
-  }
-
   it('creates context from Express req', () => {
     const req = mockExpressReq({ method: 'POST', url: '/api/data', path: '/api/data', query: {} });
     const res = { setHeader: () => {}, status: () => ({}), send: () => {}, cookie: () => {} };

--- a/packages/notify/project.json
+++ b/packages/notify/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/notify/src/notify.test.js
+++ b/packages/notify/src/notify.test.js
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, mock } from 'node:test';
+import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { renderEmail, createEmailSender } from './email.js';
 import { createNotificationCenter } from './inapp.js';

--- a/packages/og-image/project.json
+++ b/packages/og-image/project.json
@@ -4,12 +4,23 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js", "{projectRoot}/test/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js",
+        "{projectRoot}/test/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/persist/project.json
+++ b/packages/persist/project.json
@@ -4,12 +4,23 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js", "{projectRoot}/test/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js",
+        "{projectRoot}/test/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -184,7 +184,7 @@ export async function hydrateFromServer(args) {
   if (local !== null) {
     try { args.onResolve(local, { source: 'local', local }); } catch (e) { args.onError?.(e); }
   }
-  let server = null;
+  let server;
   try {
     server = await args.fetch();
   } catch (e) {

--- a/packages/realtime/project.json
+++ b/packages/realtime/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/realtime/src/realtime.test.js
+++ b/packages/realtime/src/realtime.test.js
@@ -365,7 +365,7 @@ describe('createSSEServer — edge cases', () => {
   it('formats multi-line data as multiple data: lines', () => {
     const sse = createSSEServer({ heartbeatInterval: 0 });
     const res = mockResponse();
-    const id = sse.addClient(res, { id: 'ml' });
+    sse.addClient(res, { id: 'ml' });
     sse.send('ml', 'note', 'line1\nline2');
     const allChunks = res.chunks.join('');
     assert.ok(allChunks.includes('data: line1'));

--- a/packages/router/project.json
+++ b/packages/router/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/runtime/project.json
+++ b/packages/runtime/project.json
@@ -4,11 +4,13 @@
     "test": {
       "cache": true,
       "command": "node --test",
+      "options": { "cwd": "{projectRoot}" },
       "inputs": ["{projectRoot}/src/**/*.js"]
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
+      "options": { "cwd": "{projectRoot}" },
       "inputs": ["{projectRoot}/src/**/*.js"]
     }
   }

--- a/packages/runtime/src/csp.test.js
+++ b/packages/runtime/src/csp.test.js
@@ -7,7 +7,6 @@ const ROOT = resolve(import.meta.dirname, '..', '..', '..');
 const SOURCE_DIRS = [
   join(ROOT, 'packages', 'runtime', 'src'),
   join(ROOT, 'packages', 'server', 'src'),
-  join(ROOT, 'src', 'shared'),
 ];
 const DISALLOWED = /\b(?:new\s+Function\b|eval\s*\(|setTimeout\s*\(\s*['"]|setInterval\s*\(\s*['"])/;
 

--- a/packages/runtime/src/debug.js
+++ b/packages/runtime/src/debug.js
@@ -14,7 +14,7 @@
  *   // → [BN:debug] signal:count set (1)
  */
 
-import { signal, effect } from './signals.js';
+import { effect } from './signals.js';
 
 let _debugEnabled = false;
 let _label = '';

--- a/packages/runtime/src/effect-dom-scale.test.js
+++ b/packages/runtime/src/effect-dom-scale.test.js
@@ -22,7 +22,6 @@ test('effect() re-render overhead at scale — benchmarking tests', async (t) =>
   await t.test('should create 1000 signal→effect pairs efficiently', () => {
     const nodeCount = 1000;
     const result = measureEffect('create 1000 signal→effect pairs', () => {
-      const nodes = [];
       const effects = [];
       for (let i = 0; i < nodeCount; i++) {
         const s = signal(i);

--- a/packages/runtime/src/lazy.test.js
+++ b/packages/runtime/src/lazy.test.js
@@ -34,7 +34,7 @@ function makeElement(tag = 'div') {
   const listeners = {};
   return {
     tagName: tag.toUpperCase(),
-    addEventListener(evt, fn, opts) {
+    addEventListener(evt, fn, _opts) {
       listeners[evt] = listeners[evt] || [];
       listeners[evt].push(fn);
     },
@@ -145,7 +145,7 @@ describe('lazyHydrate', () => {
   it('hydrates element via convenience wrapper', () => {
     const el = makeElement();
     let called = false;
-    const h = lazyHydrate(el, () => { called = true; });
+    lazyHydrate(el, () => { called = true; });
     const io = MockIntersectionObserver._instances[0];
     io._trigger([{ target: el, isIntersecting: true }]);
     assert.equal(called, true);
@@ -176,8 +176,8 @@ describe('hydrateOnIdle', () => {
 describe('hydrateOnInteraction', () => {
   it('sets up event listeners on the element', () => {
     const el = makeElement();
-    let called = false;
-    hydrateOnInteraction(el, () => { called = true; });
+    let _called = false;
+    hydrateOnInteraction(el, () => { _called = true; });
     assert.ok(el._listeners['click']?.length > 0);
     assert.ok(el._listeners['focus']?.length > 0);
     assert.ok(el._listeners['mouseenter']?.length > 0);

--- a/packages/runtime/src/plugins.test.js
+++ b/packages/runtime/src/plugins.test.js
@@ -89,7 +89,7 @@ describe('createPluginRegistry', () => {
 
   it('custom directives can be registered and retrieved', () => {
     const registry = createPluginRegistry();
-    const handler = (el, value) => {};
+    const handler = (_el, _value) => {};
 
     registry.register(
       definePlugin({

--- a/packages/runtime/src/signals.test.js
+++ b/packages/runtime/src/signals.test.js
@@ -311,7 +311,7 @@ describe('effect advanced', () => {
 
   it('error in effect body propagates synchronously', () => {
     const s = signal(0);
-    const fx = effect(() => {
+    effect(() => {
       if (s() > 0) throw new Error('boom');
     });
     assert.throws(() => s.set(1), /boom/);

--- a/packages/server/project.json
+++ b/packages/server/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/server/src/defer.test.js
+++ b/packages/server/src/defer.test.js
@@ -133,7 +133,7 @@ describe('@defer directive — script injection logic', () => {
     const options = {};
     render(`<template @defer><span>Test</span></template>`, {}, options);
     const resolved = resolveDeferred(options);
-    assert.match(resolved[0].script, /querySelector\('[^\)]+data-bn-defer="d0"[^\)]*'\)/);
+    assert.match(resolved[0].script, /querySelector\('[^)]+data-bn-defer="d0"[^)]*'\)/);
   });
 
   it('deferred script injects rendered HTML into placeholder', () => {
@@ -847,7 +847,7 @@ describe('@defer — diagnostic handling', () => {
       {},
       options
     );
-    const resolved = resolveDeferred(options);
+    resolveDeferred(options);
     assert.ok(diagnostics.some(d => d.code === 'BN_FOR_INVALID_SYNTAX'));
   });
 

--- a/packages/server/src/render.js
+++ b/packages/server/src/render.js
@@ -327,7 +327,7 @@ export function resolveDeferred(options) {
         `t.removeAttribute('data-bn-defer');` +
         `var e=new CustomEvent('bn:defer',{detail:{id:'${id}'}});` +
         `document.dispatchEvent(e)}` +
-        `})();<\/script>`,
+        `})();</script>`,
     };
   });
 }

--- a/packages/server/src/render.test.js
+++ b/packages/server/src/render.test.js
@@ -344,7 +344,6 @@ describe('render — additional edge cases', () => {
 
   // --- Arithmetic in interpolation ---
   it('renders arithmetic expression', () => {
-    const html = render('<p>{{ a * b + c }}</p>', { a: 3, b: 4, c: 2 });
     assert.equal(render('<p>{{ a * b + c }}</p>', { a: 3, b: 4, c: 2 }).trim(), '<p>14</p>');
   });
 
@@ -489,7 +488,7 @@ describe('render — more directive edge cases', () => {
 describe('render — untested paths', () => {
   it('@for emits BN_FOR_INVALID_SYNTAX for malformed expression', () => {
     const diagnostics = [];
-    const html = render(
+    render(
       `<template @for="invalid syntax here"><span>x</span></template>`,
       {},
       { onDiagnostic: (d) => diagnostics.push(d) }

--- a/packages/share/project.json
+++ b/packages/share/project.json
@@ -4,12 +4,23 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js", "{projectRoot}/test/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js",
+        "{projectRoot}/test/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/station/project.json
+++ b/packages/station/project.json
@@ -4,12 +4,23 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js", "{projectRoot}/test/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js",
+        "{projectRoot}/test/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/tenant/project.json
+++ b/packages/tenant/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/upload/project.json
+++ b/packages/upload/project.json
@@ -4,12 +4,22 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/upload/src/handler.js
+++ b/packages/upload/src/handler.js
@@ -46,7 +46,7 @@ export function createUploadHandler(storage, options = {}) {
   const {
     maxFileSize = 10 * 1024 * 1024, // 10MB
     allowedTypes = [],
-    fieldName = 'file',
+    fieldName: _fieldName = 'file',
     generateFilename = (original) => `${randomBytes(16).toString('hex')}-${original}`,
   } = options;
 

--- a/packages/upload/src/upload.test.js
+++ b/packages/upload/src/upload.test.js
@@ -29,7 +29,6 @@ function buildMultipartBody(boundary, parts) {
 
 describe('parseMultipart', () => {
   it('parses simple multipart body', () => {
-    const boundary = '----boundary';
     const body = `------boundary\r\nContent-Disposition: form-data; name="field1"\r\n\r\nvalue1\r\n------boundary\r\nContent-Disposition: form-data; name="file"; filename="test.txt"\r\nContent-Type: text/plain\r\n\r\nhello world\r\n------boundary--`;
     const parts = parseMultipart(body, `multipart/form-data; boundary=----boundary`);
     assert.equal(parts.length, 2);
@@ -73,7 +72,6 @@ describe('parseMultipart', () => {
 
   it('filters parts with no name', () => {
     // manually build a body with a nameless part
-    const boundary = 'nb';
     const body = `--nb\r\nContent-Disposition: form-data\r\n\r\norphan\r\n--nb--`;
     const parts = parseMultipart(body, `multipart/form-data; boundary=nb`);
     assert.equal(parts.length, 0);
@@ -341,7 +339,6 @@ describe('createUploadHandler', () => {
     tempDir = mkdtempSync(join(tmpdir(), 'bn-upload-'));
     const storage = createLocalStorage({ directory: tempDir });
     const handler = createUploadHandler(storage, { maxFileSize: 5 });
-    const boundary = '----boundary';
     const body = `------boundary\r\nContent-Disposition: form-data; name="file"; filename="big.txt"\r\nContent-Type: text/plain\r\n\r\nhello world too large\r\n------boundary--`;
     const ctx = {
       request: { method: 'POST', headers: { 'content-type': `multipart/form-data; boundary=----boundary` }, body },

--- a/packages/visual-builder/project.json
+++ b/packages/visual-builder/project.json
@@ -4,7 +4,12 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/wrangler-preset/project.json
+++ b/packages/wrangler-preset/project.json
@@ -4,12 +4,23 @@
     "test": {
       "cache": true,
       "command": "node --test",
-      "inputs": ["{projectRoot}/src/**/*.js", "{projectRoot}/test/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js",
+        "{projectRoot}/test/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     },
     "lint": {
       "cache": true,
       "command": "pnpm exec eslint src/",
-      "inputs": ["{projectRoot}/src/**/*.js"]
+      "inputs": [
+        "{projectRoot}/src/**/*.js"
+      ],
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

The CI lint gate was effectively disabled — every package failed with `No files matching the pattern "src/" were found` because Nx's inline `command` form doesn't infer cwd, so `pnpm exec eslint src/` looked for `src/` at the workspace root. Lint never actually ran on any package, so 47 real errors had accumulated.

## Changes

- **`options.cwd: "{projectRoot}"`** added to every `command`-form target in `packages/*/project.json` and `examples/*/project.json` (37 files). Applies to both `lint` and `test`.
- **47 real lint errors fixed** across 30 source/test files in 22 packages — unused imports/locals/args (renamed `_name` where load-bearing, deleted where pure), useless regex escapes, one unreachable test branch, three caught-error throws missing `{ cause }`.
- **`packages/runtime/src/csp.test.js`** — dropped a stale reference to `src/shared/` (workspace-root path that moved into `packages/runtime/src/shared/` long ago; the recursive walk already covers it via the runtime `src/` entry).

## Verification

```
pnpm exec nx run-many --target=lint  → 34 projects pass, 0 errors
pnpm exec nx run-many --target=test  → 40 projects pass, 1300+ tests
```

## Test plan
- [x] Lint clean across all packages
- [x] All package tests pass
- [ ] CI Node 22 lint job goes green for the first time in months

🤖 Generated with [Claude Code](https://claude.com/claude-code)