### PR TITLE
fix(express-site): unbreak build:pages for Cloudflare Pages deploy

### DIFF
--- a/examples/express/site-data.js
+++ b/examples/express/site-data.js
@@ -1,3 +1,5 @@
+import { componentCategories, flatComponents } from './component-catalog.js';
+
 export const navPages = [
   'home',
   'tasks',
@@ -49,6 +51,14 @@ export function getTasksPageContext(tasks) {
   return {
     tasks,
     tasksJson: JSON.stringify(tasks),
+  };
+}
+
+export function getComponentsPageContext() {
+  return {
+    categories: componentCategories,
+    totalCount: flatComponents.length,
+    categoryCount: componentCategories.length,
   };
 }
 

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -9,6 +9,7 @@ import { render } from '../packages/server/src/render.js';
 import {
   getComponentsPageContext,
   getHomePageContext,
+  getRoadmapPageContext,
   getTasksPageContext,
   navPages,
   staticTasks,
@@ -84,6 +85,12 @@ const pages = {
     activePage: 'components',
     ctx: getComponentsPageContext(),
   },
+  roadmap: {
+    view: 'roadmap.html',
+    title: 'Roadmap',
+    activePage: 'roadmap',
+    ctx: getRoadmapPageContext(),
+  },
   'test-signals': {
     view: 'test-signals.html',
     title: 'Signal Verification',
@@ -104,12 +111,6 @@ const pages = {
     title: 'Showcase',
     activePage: 'showcase',
     ctx: getShowcaseContext(),
-  },
-  builder: {
-    view: 'builder.html',
-    title: 'Builder',
-    activePage: 'builder',
-    ctx: {},
   },
 };
 


### PR DESCRIPTION
## Summary

`pnpm build:pages` was failing in CI (and blocking Cloudflare Pages deploys) because [scripts/build-pages.js](scripts/build-pages.js) imports `getComponentsPageContext` from `examples/express/site-data.js`, but that export was dropped during the components/roadmap split — `site-data.js` only exports `getRoadmapPageContext` now. This PR restores the missing export and cleans up two pre-existing drifts from `server.js` while in the same file.

- **Restore `getComponentsPageContext`** in [examples/express/site-data.js](examples/express/site-data.js), returning `{ categories, totalCount, categoryCount }` — the exact shape `server.js` builds at `/components`.
- **Add `/roadmap` to the static build.** `views/roadmap.html`, `getRoadmapPageContext`, and `navPages` all already include roadmap; only the static build script was missing the entry.
- **Drop duplicate `builder` key** in the `pages` object — there were two identical entries; removed the trailing one.

## Test plan

- [x] `pnpm install` clean on a fresh worktree off `origin/main`.
- [x] `pnpm build:pages` succeeds.
- [x] `dist/` emits `/`, `/tasks/`, `/playground/`, `/builder/`, `/docs/`, `/components/`, `/roadmap/`, `/test-signals/`, `/showcase/` plus `_headers`.
- [ ] Cloudflare Pages deploy succeeds on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)