### PR TITLE
fix(express-site): inline critical CSS so basenative.com renders

### DIFF
--- a/examples/express/public/styles.css
+++ b/examples/express/public/styles.css
@@ -2190,467 +2190,421 @@
     color: var(--accent);
   }
 
-/* ==========================================================================
+  /* ==========================================================================
    * Components index (/components) + Showcase (/showcase) + per-component pages.
    * Uses native CSS nesting, :has(), and container queries. No classes.
    * ========================================================================== */
 
-/* -- Hero shared by /components and /showcase -- */
-[data-bn-page-hero],
-[data-bn-showcase-header] {
-  margin-block-end: var(--space-2xl);
+  /* -- Hero shared by /components and /showcase -- */
+  [data-bn-page-hero],
+  [data-bn-showcase-header] {
+    margin-block-end: var(--space-2xl);
 
-  & h2 {
-    font-family: var(--font-family);
-    font-stretch: var(--font-serif);
-    font-size: var(--font-size-hero);
-    font-weight: var(--font-weight-normal);
-    letter-spacing: var(--letter-spacing-tight);
-    margin-block-end: var(--space-md);
+    & h2 {
+      font-family: var(--font-family);
+      font-stretch: var(--font-serif);
+      font-size: var(--font-size-hero);
+      font-weight: var(--font-weight-normal);
+      letter-spacing: var(--letter-spacing-tight);
+      margin-block-end: var(--space-md);
 
-    & em {
-      font-style: normal;
-      color: var(--accent);
-    }
-  }
-}
-
-[data-bn-eyebrow] {
-  font-family: var(--font-family);
-  font-stretch: var(--font-mono);
-  font-size: var(--font-size-xs);
-  color: var(--accent);
-  letter-spacing: var(--letter-spacing-wider);
-  text-transform: uppercase;
-  margin-block-end: var(--space-sm);
-}
-
-[data-bn-lede] {
-  font-size: var(--font-size-lg);
-  color: var(--text-1);
-  max-inline-size: var(--size-text-max);
-  margin-block-end: var(--space-lg);
-
-  & code {
-    font-size: 0.95em;
-    color: var(--accent);
-    background: var(--surface-2);
-    padding: 0.1em 0.4em;
-    border-radius: var(--radius-sm);
-  }
-}
-
-[data-bn-page-hero-actions],
-[data-bn-showcase-actions] {
-  display: flex;
-  gap: var(--space-sm);
-  flex-wrap: wrap;
-}
-
-[data-bn-cta] {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-sm);
-  padding: var(--space-sm) var(--space-lg);
-  min-block-size: 2.75rem;
-  border-radius: var(--radius-sm);
-  font-family: var(--font-family);
-  font-stretch: var(--font-mono);
-  font-size: var(--font-size-sm);
-  text-decoration: none;
-  border: var(--border-width) solid transparent;
-  transition:
-    background var(--duration-fast),
-    border-color var(--duration-fast),
-    color var(--duration-fast),
-    box-shadow var(--duration-med);
-
-  &[data-bn-cta="primary"] {
-    background: var(--accent);
-    color: var(--surface-0);
-    border-color: var(--accent);
-
-    &:hover {
-      background: var(--accent-dim);
-      box-shadow: var(--shadow-btn);
+      & em {
+        font-style: normal;
+        color: var(--accent);
+      }
     }
   }
 
-  &[data-bn-cta="secondary"] {
-    background: transparent;
-    color: var(--text-1);
-    border-color: var(--border-accent);
-
-    &:hover {
-      background: var(--surface-2);
-      color: var(--accent);
-      border-color: var(--accent);
-    }
-  }
-}
-
-/* -- /components category TOC -- */
-[data-bn-component-toc] {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-xs);
-  padding: var(--space-md);
-  border: var(--border-width) solid var(--border);
-  border-radius: var(--radius-md);
-  margin-block-end: var(--space-2xl);
-  position: sticky;
-  inset-block-start: var(--space-sm);
-  z-index: 5;
-  backdrop-filter: blur(8px);
-  background: color-mix(in srgb, var(--surface-1) 92%, transparent);
-
-  & a {
+  [data-bn-eyebrow] {
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
     font-size: var(--font-size-xs);
-    color: var(--text-2);
-    text-decoration: none;
-    padding: var(--space-xs) var(--space-sm);
+    color: var(--accent);
+    letter-spacing: var(--letter-spacing-wider);
+    text-transform: uppercase;
+    margin-block-end: var(--space-sm);
+  }
+
+  [data-bn-lede] {
+    font-size: var(--font-size-lg);
+    color: var(--text-1);
+    max-inline-size: var(--size-text-max);
+    margin-block-end: var(--space-lg);
+
+    & code {
+      font-size: 0.95em;
+      color: var(--accent);
+      background: var(--surface-2);
+      padding: 0.1em 0.4em;
+      border-radius: var(--radius-sm);
+    }
+  }
+
+  [data-bn-page-hero-actions],
+  [data-bn-showcase-actions] {
+    display: flex;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+  }
+
+  [data-bn-cta] {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-sm) var(--space-lg);
+    min-block-size: 2.75rem;
     border-radius: var(--radius-sm);
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono);
+    font-size: var(--font-size-sm);
+    text-decoration: none;
+    border: var(--border-width) solid transparent;
     transition:
       background var(--duration-fast),
-      color var(--duration-fast);
+      border-color var(--duration-fast),
+      color var(--duration-fast),
+      box-shadow var(--duration-med);
 
-    &:hover {
-      background: var(--surface-3);
-      color: var(--accent);
+    &[data-bn-cta='primary'] {
+      background: var(--accent);
+      color: var(--surface-0);
+      border-color: var(--accent);
+
+      &:hover {
+        background: var(--accent-dim);
+        box-shadow: var(--shadow-btn);
+      }
     }
-  }
-}
 
-/* -- /components category section -- */
-[data-bn-component-category] {
-  margin-block-end: var(--space-3xl);
-  scroll-margin-block-start: var(--space-2xl);
-}
+    &[data-bn-cta='secondary'] {
+      background: transparent;
+      color: var(--text-1);
+      border-color: var(--border-accent);
 
-[data-bn-component-category-head] {
-  display: block;
-  margin-block-end: var(--space-lg);
-  border: none;
-  padding: 0;
-  background: none;
-
-  & h2 {
-    font-family: var(--font-family);
-    font-stretch: var(--font-serif);
-    font-size: var(--font-size-2xl);
-    font-weight: var(--font-weight-normal);
-    margin-block-end: var(--space-xs);
-  }
-
-  & p {
-    color: var(--text-2);
-    font-size: var(--font-size-base);
-    max-inline-size: var(--size-text-max);
-  }
-}
-
-/* -- Component grid -- */
-[data-bn-component-grid] {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
-  gap: var(--space-md);
-  list-style: none;
-  padding: 0;
-  margin: 0;
-
-  & > li {
-    display: flex;
-    background: none;
-    border: none;
-    padding: 0;
-  }
-}
-
-[data-bn-component-card] {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-  inline-size: 100%;
-  padding: var(--space-lg);
-  background: var(--surface-1);
-  border: var(--border-width) solid var(--border);
-  border-radius: var(--radius-md);
-  text-decoration: none;
-  color: inherit;
-  transition:
-    border-color var(--duration-med),
-    background var(--duration-med),
-    transform var(--duration-med);
-  container-type: inline-size;
-
-  &:hover {
-    border-color: var(--accent-dim);
-    background: var(--surface-2);
-    transform: translateY(-2px);
-  }
-
-  &:focus-visible {
-    outline: var(--border-inline-width) solid var(--accent);
-    outline-offset: var(--border-inline-width);
-  }
-
-  & > header {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: var(--space-sm);
-    margin: 0;
-    padding: 0;
-    background: none;
-    border: none;
-
-    & h3 {
-      font-family: var(--font-family);
-      font-stretch: var(--font-serif);
-      font-size: var(--font-size-lg);
-      font-weight: var(--font-weight-normal);
-      color: var(--text-0);
-      letter-spacing: var(--letter-spacing-tight);
+      &:hover {
+        background: var(--surface-2);
+        color: var(--accent);
+        border-color: var(--accent);
+      }
     }
   }
 
-  & > p {
-    flex: 1;
-    color: var(--text-1);
-    font-size: var(--font-size-sm);
-    line-height: var(--line-height-tight);
-    margin: 0;
-  }
-
-  & > footer {
+  /* -- /components category TOC -- */
+  [data-bn-component-toc] {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-sm);
-    color: var(--accent);
-    font-size: var(--font-size-md);
-    margin: 0;
-    padding: 0;
-    border: none;
-    background: none;
-
-    & [data-bn-component-fn] {
-      color: var(--text-2);
-      font-size: var(--font-size-xs);
-    }
-  }
-
-  &:hover > footer {
-    color: var(--text-0);
-  }
-}
-
-[data-bn-component-tag] {
-  font-family: var(--font-family);
-  font-stretch: var(--font-mono);
-  font-size: var(--font-size-xs);
-  color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-  padding: 0.15rem 0.45rem;
-  border-radius: var(--radius-sm);
-  white-space: nowrap;
-}
-
-/* -- Axioms list on /components -- */
-[data-bn-component-philosophy] {
-  margin-block-start: var(--space-3xl);
-  padding-block: var(--space-2xl);
-  border-block-start: var(--border-width) solid var(--border);
-
-  & > h2 em {
-    font-style: normal;
-    color: var(--accent);
-  }
-}
-
-[data-bn-axioms] {
-  counter-reset: axiom;
-  list-style: none;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
-  gap: var(--space-lg);
-  padding: 0;
-  margin-block-start: var(--space-lg);
-
-  & > li {
-    counter-increment: axiom;
-    background: var(--surface-1);
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+    padding: var(--space-md);
     border: var(--border-width) solid var(--border);
     border-radius: var(--radius-md);
-    padding: var(--space-lg);
-    position: relative;
+    margin-block-end: var(--space-2xl);
+    position: sticky;
+    inset-block-start: var(--space-sm);
+    z-index: 5;
+    backdrop-filter: blur(8px);
+    background: color-mix(in srgb, var(--surface-1) 92%, transparent);
 
-    &::before {
-      content: counter(axiom, decimal-leading-zero);
+    & a {
       font-family: var(--font-family);
       font-stretch: var(--font-mono);
       font-size: var(--font-size-xs);
-      color: var(--accent);
-      letter-spacing: var(--letter-spacing-wider);
-      margin-block-end: var(--space-sm);
-      display: block;
-    }
+      color: var(--text-2);
+      text-decoration: none;
+      padding: var(--space-xs) var(--space-sm);
+      border-radius: var(--radius-sm);
+      transition:
+        background var(--duration-fast),
+        color var(--duration-fast);
 
-    & h3 {
+      &:hover {
+        background: var(--surface-3);
+        color: var(--accent);
+      }
+    }
+  }
+
+  /* -- /components category section -- */
+  [data-bn-component-category] {
+    margin-block-end: var(--space-3xl);
+    scroll-margin-block-start: var(--space-2xl);
+  }
+
+  [data-bn-component-category-head] {
+    display: block;
+    margin-block-end: var(--space-lg);
+    border: none;
+    padding: 0;
+    background: none;
+
+    & h2 {
       font-family: var(--font-family);
       font-stretch: var(--font-serif);
-      font-size: var(--font-size-lg);
+      font-size: var(--font-size-2xl);
       font-weight: var(--font-weight-normal);
-      color: var(--text-0);
       margin-block-end: var(--space-xs);
     }
 
     & p {
-      color: var(--text-1);
-      font-size: var(--font-size-sm);
-      line-height: var(--line-height-tight);
+      color: var(--text-2);
+      font-size: var(--font-size-base);
+      max-inline-size: var(--size-text-max);
     }
   }
 
-  & code {
-    font-family: var(--font-family);
-    font-stretch: var(--font-mono);
-    font-size: 0.95em;
-    color: var(--accent);
-    background: var(--surface-2);
-    padding: 0.1em 0.35em;
-    border-radius: var(--radius-sm);
+  /* -- Component grid -- */
+  [data-bn-component-grid] {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
+    gap: var(--space-md);
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    & > li {
+      display: flex;
+      background: none;
+      border: none;
+      padding: 0;
+    }
   }
-}
 
-/* -- Per-component page (/components/:slug) -- */
-[data-bn-component-page] {
-  background: none;
-  border: none;
-  padding: 0;
-  container: page-component / inline-size;
-
-  &:hover {
-    border-color: transparent;
-    box-shadow: none;
-  }
-}
-
-[data-bn-component-hero] {
-  display: block;
-  margin-block: var(--space-xl) var(--space-2xl);
-  background: none;
-  border: none;
-  padding: 0;
-
-  & h2 {
-    font-family: var(--font-family);
-    font-stretch: var(--font-serif);
-    font-size: var(--font-size-hero);
-    font-weight: var(--font-weight-normal);
-    margin-block-end: var(--space-sm);
-    letter-spacing: var(--letter-spacing-tight);
-  }
-}
-
-[data-bn-component-meta] {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
-  gap: var(--space-md);
-  margin-block-start: var(--space-lg);
-  padding-block: var(--space-md);
-  border-block: var(--border-width) solid var(--border);
-
-  & > div {
+  [data-bn-component-card] {
     display: flex;
     flex-direction: column;
-    gap: var(--space-xs);
+    gap: var(--space-sm);
+    inline-size: 100%;
+    padding: var(--space-lg);
+    background: var(--surface-1);
+    border: var(--border-width) solid var(--border);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: inherit;
+    transition:
+      border-color var(--duration-med),
+      background var(--duration-med),
+      transform var(--duration-med);
+    container-type: inline-size;
+
+    &:hover {
+      border-color: var(--accent-dim);
+      background: var(--surface-2);
+      transform: translateY(-2px);
+    }
+
+    &:focus-visible {
+      outline: var(--border-inline-width) solid var(--accent);
+      outline-offset: var(--border-inline-width);
+    }
+
+    & > header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: var(--space-sm);
+      margin: 0;
+      padding: 0;
+      background: none;
+      border: none;
+
+      & h3 {
+        font-family: var(--font-family);
+        font-stretch: var(--font-serif);
+        font-size: var(--font-size-lg);
+        font-weight: var(--font-weight-normal);
+        color: var(--text-0);
+        letter-spacing: var(--letter-spacing-tight);
+      }
+    }
+
+    & > p {
+      flex: 1;
+      color: var(--text-1);
+      font-size: var(--font-size-sm);
+      line-height: var(--line-height-tight);
+      margin: 0;
+    }
+
+    & > footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--space-sm);
+      color: var(--accent);
+      font-size: var(--font-size-md);
+      margin: 0;
+      padding: 0;
+      border: none;
+      background: none;
+
+      & [data-bn-component-fn] {
+        color: var(--text-2);
+        font-size: var(--font-size-xs);
+      }
+    }
+
+    &:hover > footer {
+      color: var(--text-0);
+    }
   }
 
-  & dt {
+  [data-bn-component-tag] {
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
     font-size: var(--font-size-xs);
-    color: var(--text-2);
-    text-transform: uppercase;
-    letter-spacing: var(--letter-spacing-wider);
-  }
-
-  & dd {
-    margin: 0;
-  }
-
-  & code {
-    font-family: var(--font-family);
-    font-stretch: var(--font-mono);
-    font-size: var(--font-size-sm);
     color: var(--accent);
-  }
-}
-
-/* Section heading style shared across the component-page sections. */
-[data-bn-component-quickstart] > header,
-[data-bn-component-examples] > header,
-[data-bn-component-api] > header {
-  display: block;
-  background: none;
-  border: none;
-  padding: 0;
-  margin-block-end: var(--space-md);
-
-  & > h3 {
-    font-family: var(--font-family);
-    font-stretch: var(--font-serif);
-    font-size: var(--font-size-2xl);
-    font-weight: var(--font-weight-normal);
-    letter-spacing: var(--letter-spacing-tight);
-    margin-block-end: var(--space-xs);
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    padding: 0.15rem 0.45rem;
+    border-radius: var(--radius-sm);
+    white-space: nowrap;
   }
 
-  & > p {
-    color: var(--text-1);
-    font-size: var(--font-size-base);
-    max-inline-size: var(--size-text-max);
-    margin: 0;
-  }
-}
+  /* -- Axioms list on /components -- */
+  [data-bn-component-philosophy] {
+    margin-block-start: var(--space-3xl);
+    padding-block: var(--space-2xl);
+    border-block-start: var(--border-width) solid var(--border);
 
-[data-bn-component-quickstart],
-[data-bn-component-examples],
-[data-bn-component-api] {
-  margin-block-end: var(--space-2xl);
-}
-
-[data-bn-component-quickstart] > pre {
-  margin: 0;
-}
-
-/* Per example block. */
-[data-bn-component-example] {
-  margin-block-end: var(--space-2xl);
-  padding-block-end: var(--space-xl);
-  border-block-end: var(--border-width) solid var(--border);
-
-  &:last-of-type {
-    border-block-end: none;
-    padding-block-end: 0;
+    & > h2 em {
+      font-style: normal;
+      color: var(--accent);
+    }
   }
 
-  & > header {
+  [data-bn-axioms] {
+    counter-reset: axiom;
+    list-style: none;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    gap: var(--space-lg);
+    padding: 0;
+    margin-block-start: var(--space-lg);
+
+    & > li {
+      counter-increment: axiom;
+      background: var(--surface-1);
+      border: var(--border-width) solid var(--border);
+      border-radius: var(--radius-md);
+      padding: var(--space-lg);
+      position: relative;
+
+      &::before {
+        content: counter(axiom, decimal-leading-zero);
+        font-family: var(--font-family);
+        font-stretch: var(--font-mono);
+        font-size: var(--font-size-xs);
+        color: var(--accent);
+        letter-spacing: var(--letter-spacing-wider);
+        margin-block-end: var(--space-sm);
+        display: block;
+      }
+
+      & h3 {
+        font-family: var(--font-family);
+        font-stretch: var(--font-serif);
+        font-size: var(--font-size-lg);
+        font-weight: var(--font-weight-normal);
+        color: var(--text-0);
+        margin-block-end: var(--space-xs);
+      }
+
+      & p {
+        color: var(--text-1);
+        font-size: var(--font-size-sm);
+        line-height: var(--line-height-tight);
+      }
+    }
+
+    & code {
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: 0.95em;
+      color: var(--accent);
+      background: var(--surface-2);
+      padding: 0.1em 0.35em;
+      border-radius: var(--radius-sm);
+    }
+  }
+
+  /* -- Per-component page (/components/:slug) -- */
+  [data-bn-component-page] {
+    background: none;
+    border: none;
+    padding: 0;
+    container: page-component / inline-size;
+
+    &:hover {
+      border-color: transparent;
+      box-shadow: none;
+    }
+  }
+
+  [data-bn-component-hero] {
     display: block;
-    margin-block-end: var(--space-md);
+    margin-block: var(--space-xl) var(--space-2xl);
     background: none;
     border: none;
     padding: 0;
 
-    & > h4 {
+    & h2 {
       font-family: var(--font-family);
       font-stretch: var(--font-serif);
-      font-size: var(--font-size-xl);
+      font-size: var(--font-size-hero);
       font-weight: var(--font-weight-normal);
-      color: var(--text-0);
+      margin-block-end: var(--space-sm);
+      letter-spacing: var(--letter-spacing-tight);
+    }
+  }
+
+  [data-bn-component-meta] {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    gap: var(--space-md);
+    margin-block-start: var(--space-lg);
+    padding-block: var(--space-md);
+    border-block: var(--border-width) solid var(--border);
+
+    & > div {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-xs);
+    }
+
+    & dt {
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-xs);
+      color: var(--text-2);
+      text-transform: uppercase;
+      letter-spacing: var(--letter-spacing-wider);
+    }
+
+    & dd {
+      margin: 0;
+    }
+
+    & code {
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-sm);
+      color: var(--accent);
+    }
+  }
+
+  /* Section heading style shared across the component-page sections. */
+  [data-bn-component-quickstart] > header,
+  [data-bn-component-examples] > header,
+  [data-bn-component-api] > header {
+    display: block;
+    background: none;
+    border: none;
+    padding: 0;
+    margin-block-end: var(--space-md);
+
+    & > h3 {
+      font-family: var(--font-family);
+      font-stretch: var(--font-serif);
+      font-size: var(--font-size-2xl);
+      font-weight: var(--font-weight-normal);
       letter-spacing: var(--letter-spacing-tight);
       margin-block-end: var(--space-xs);
     }
@@ -2662,465 +2616,502 @@
       margin: 0;
     }
   }
-}
 
-/* Side-by-side preview + source. Stacks on narrow containers. */
-[data-bn-component-split] {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--space-md);
-
-  @container page-component (min-width: 48rem) {
-    & {
-      grid-template-columns: 1fr 1fr;
-    }
+  [data-bn-component-quickstart],
+  [data-bn-component-examples],
+  [data-bn-component-api] {
+    margin-block-end: var(--space-2xl);
   }
-}
 
-/* Live render figure. */
-[data-bn-component-preview],
-[data-bn-component-source] {
-  margin: 0;
-  padding: 0;
-  background: var(--surface-1);
-  border: var(--border-width) solid var(--border);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-
-  & > figcaption {
-    font-family: var(--font-family);
-    font-stretch: var(--font-mono);
-    font-size: var(--font-size-xs);
-    color: var(--text-2);
-    text-transform: uppercase;
-    letter-spacing: var(--letter-spacing-wider);
-    padding: var(--space-sm) var(--space-md);
-    background: var(--surface-2);
-    border-block-end: var(--border-width) solid var(--border);
-  }
-}
-
-[data-bn-component-preview] {
-  & > output {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-md);
-    align-items: center;
-    padding: var(--space-xl);
-    flex: 1;
-    background-color: var(--surface-inset);
-    background-image:
-      linear-gradient(45deg, var(--surface-1) 25%, transparent 25%),
-      linear-gradient(-45deg, var(--surface-1) 25%, transparent 25%),
-      linear-gradient(45deg, transparent 75%, var(--surface-1) 75%),
-      linear-gradient(-45deg, transparent 75%, var(--surface-1) 75%);
-    background-size: 24px 24px;
-    background-position:
-      0 0,
-      0 12px,
-      12px -12px,
-      12px 0;
-    min-block-size: 8rem;
-
-    /* When the preview contains a form-style demo, drop the row layout
-         so labels and fields stack vertically. */
-    &:has([data-bn="field"]),
-    &:has([data-bn="fieldset"]),
-    &:has(textarea) {
-      flex-direction: column;
-      align-items: stretch;
-      gap: var(--space-md);
-    }
-  }
-}
-
-[data-bn-component-source] {
-  & > pre {
+  [data-bn-component-quickstart] > pre {
     margin: 0;
-    padding: var(--space-md);
-    background: var(--surface-inset);
-    border: none;
-    border-radius: 0;
-    flex: 1;
-    font-size: var(--font-size-xs);
-    line-height: var(--line-height-code);
-    overflow-x: auto;
-    max-block-size: 22rem;
   }
-}
 
-/* API options table. */
-[data-bn-component-api] {
-  & > table {
-    inline-size: 100%;
-    border-collapse: collapse;
+  /* Per example block. */
+  [data-bn-component-example] {
+    margin-block-end: var(--space-2xl);
+    padding-block-end: var(--space-xl);
+    border-block-end: var(--border-width) solid var(--border);
+
+    &:last-of-type {
+      border-block-end: none;
+      padding-block-end: 0;
+    }
+
+    & > header {
+      display: block;
+      margin-block-end: var(--space-md);
+      background: none;
+      border: none;
+      padding: 0;
+
+      & > h4 {
+        font-family: var(--font-family);
+        font-stretch: var(--font-serif);
+        font-size: var(--font-size-xl);
+        font-weight: var(--font-weight-normal);
+        color: var(--text-0);
+        letter-spacing: var(--letter-spacing-tight);
+        margin-block-end: var(--space-xs);
+      }
+
+      & > p {
+        color: var(--text-1);
+        font-size: var(--font-size-base);
+        max-inline-size: var(--size-text-max);
+        margin: 0;
+      }
+    }
+  }
+
+  /* Side-by-side preview + source. Stacks on narrow containers. */
+  [data-bn-component-split] {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-md);
+
+    @container page-component (min-width: 48rem) {
+      & {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
+  }
+
+  /* Live render figure. */
+  [data-bn-component-preview],
+  [data-bn-component-source] {
+    margin: 0;
+    padding: 0;
     background: var(--surface-1);
     border: var(--border-width) solid var(--border);
     border-radius: var(--radius-md);
     overflow: hidden;
-    font-size: var(--font-size-sm);
+    display: flex;
+    flex-direction: column;
+
+    & > figcaption {
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-xs);
+      color: var(--text-2);
+      text-transform: uppercase;
+      letter-spacing: var(--letter-spacing-wider);
+      padding: var(--space-sm) var(--space-md);
+      background: var(--surface-2);
+      border-block-end: var(--border-width) solid var(--border);
+    }
   }
 
-  & thead {
-    background: var(--surface-2);
+  [data-bn-component-preview] {
+    & > output {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-md);
+      align-items: center;
+      padding: var(--space-xl);
+      flex: 1;
+      background-color: var(--surface-inset);
+      background-image:
+        linear-gradient(45deg, var(--surface-1) 25%, transparent 25%),
+        linear-gradient(-45deg, var(--surface-1) 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, var(--surface-1) 75%),
+        linear-gradient(-45deg, transparent 75%, var(--surface-1) 75%);
+      background-size: 24px 24px;
+      background-position:
+        0 0,
+        0 12px,
+        12px -12px,
+        12px 0;
+      min-block-size: 8rem;
+
+      /* When the preview contains a form-style demo, drop the row layout
+         so labels and fields stack vertically. */
+      &:has([data-bn='field']),
+      &:has([data-bn='fieldset']),
+      &:has(textarea) {
+        flex-direction: column;
+        align-items: stretch;
+        gap: var(--space-md);
+      }
+    }
   }
 
-  & th,
-  & td {
-    text-align: start;
-    padding: var(--space-sm) var(--space-md);
-    border-block-end: var(--border-width) solid var(--border);
-    vertical-align: top;
+  [data-bn-component-source] {
+    & > pre {
+      margin: 0;
+      padding: var(--space-md);
+      background: var(--surface-inset);
+      border: none;
+      border-radius: 0;
+      flex: 1;
+      font-size: var(--font-size-xs);
+      line-height: var(--line-height-code);
+      overflow-x: auto;
+      max-block-size: 22rem;
+    }
   }
 
-  & thead th {
-    font-family: var(--font-family);
-    font-stretch: var(--font-mono);
-    font-size: var(--font-size-xs);
-    color: var(--text-2);
-    text-transform: uppercase;
-    letter-spacing: var(--letter-spacing-wider);
-    font-weight: var(--font-weight-normal);
-  }
+  /* API options table. */
+  [data-bn-component-api] {
+    & > table {
+      inline-size: 100%;
+      border-collapse: collapse;
+      background: var(--surface-1);
+      border: var(--border-width) solid var(--border);
+      border-radius: var(--radius-md);
+      overflow: hidden;
+      font-size: var(--font-size-sm);
+    }
 
-  & tbody tr:last-child > * {
-    border-block-end: none;
-  }
-
-  & tbody th[scope="row"] {
-    color: var(--accent);
-    font-weight: var(--font-weight-normal);
-  }
-
-  & code {
-    font-family: var(--font-family);
-    font-stretch: var(--font-mono);
-    font-size: var(--font-size-xs);
-    color: var(--text-1);
-  }
-
-  & tbody th[scope="row"] code {
-    color: var(--accent);
-  }
-}
-
-/* Pager between sibling component pages. */
-[data-bn-component-pager] {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: var(--space-md);
-  padding-block: var(--space-xl);
-  margin-block-start: var(--space-xl);
-  border-block-start: var(--border-width) solid var(--border);
-
-  & a {
-    font-family: var(--font-family);
-    font-stretch: var(--font-mono);
-    font-size: var(--font-size-sm);
-    color: var(--text-1);
-    text-decoration: none;
-    padding: var(--space-sm) var(--space-md);
-    border-radius: var(--radius-sm);
-    transition:
-      background var(--duration-fast),
-      color var(--duration-fast);
-
-    &:hover {
-      color: var(--accent);
+    & thead {
       background: var(--surface-2);
     }
 
-    &[rel="prev"] {
-      justify-self: start;
+    & th,
+    & td {
+      text-align: start;
+      padding: var(--space-sm) var(--space-md);
+      border-block-end: var(--border-width) solid var(--border);
+      vertical-align: top;
     }
 
-    &[rel="next"] {
-      justify-self: end;
+    & thead th {
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-xs);
+      color: var(--text-2);
+      text-transform: uppercase;
+      letter-spacing: var(--letter-spacing-wider);
+      font-weight: var(--font-weight-normal);
+    }
+
+    & tbody tr:last-child > * {
+      border-block-end: none;
+    }
+
+    & tbody th[scope='row'] {
+      color: var(--accent);
+      font-weight: var(--font-weight-normal);
+    }
+
+    & code {
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-xs);
+      color: var(--text-1);
+    }
+
+    & tbody th[scope='row'] code {
+      color: var(--accent);
     }
   }
 
-  & [data-bn-component-pager-index] {
-    color: var(--text-2);
-    justify-self: center;
+  /* Pager between sibling component pages. */
+  [data-bn-component-pager] {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: var(--space-md);
+    padding-block: var(--space-xl);
+    margin-block-start: var(--space-xl);
+    border-block-start: var(--border-width) solid var(--border);
+
+    & a {
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-sm);
+      color: var(--text-1);
+      text-decoration: none;
+      padding: var(--space-sm) var(--space-md);
+      border-radius: var(--radius-sm);
+      transition:
+        background var(--duration-fast),
+        color var(--duration-fast);
+
+      &:hover {
+        color: var(--accent);
+        background: var(--surface-2);
+      }
+
+      &[rel='prev'] {
+        justify-self: start;
+      }
+
+      &[rel='next'] {
+        justify-self: end;
+      }
+    }
+
+    & [data-bn-component-pager-index] {
+      color: var(--text-2);
+      justify-self: center;
+    }
   }
-}
 
-/* -- Demo-page interactive helpers -- */
-[data-bn-demo-row] {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-sm);
-  align-items: center;
-}
+  /* -- Demo-page interactive helpers -- */
+  [data-bn-demo-row] {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    align-items: center;
+  }
 
-[data-bn-demo-counter] {
-  display: block;
-  font-family: var(--font-family);
-  font-stretch: var(--font-serif);
-  font-size: var(--font-size-2xl);
-  color: var(--accent);
-  margin-block-end: var(--space-sm);
-}
-
-[data-bn-demo-bio-count],
-[data-bn-demo-words],
-[data-bn-demo-region-out],
-[data-bn-demo-tier-out],
-[data-bn-demo-progress-out],
-[data-bn-demo-pager-out] {
-  display: block;
-  margin-block-start: var(--space-sm);
-  font-family: var(--font-family);
-  font-stretch: var(--font-mono);
-  font-size: var(--font-size-xs);
-  color: var(--text-2);
-}
-
-/* Generic styled "live readout" block used by reactive demos. */
-[data-demo-display] {
-  margin-block-start: var(--space-md);
-  padding: var(--space-md) var(--space-lg);
-  background: var(--surface-2);
-  border: var(--border-width) dashed var(--border-accent);
-  border-radius: var(--radius-sm);
-  color: var(--text-1);
-  font-size: var(--font-size-sm);
-  line-height: var(--line-height-tight);
-
-  & strong {
+  [data-bn-demo-counter] {
     display: block;
-    color: var(--text-0);
-    margin-block-end: var(--space-xs);
-  }
-
-  & p {
-    margin: 0;
-  }
-}
-
-/* Theme card flips its surface based on the toggle's data attribute. */
-[data-bn-demo-theme-card] {
-  transition:
-    background var(--duration-med),
-    color var(--duration-med),
-    border-color var(--duration-med);
-
-  &[data-dim="on"] {
-    background: var(--surface-0);
-    color: var(--text-2);
-    border-color: var(--accent-dim);
-  }
-}
-
-/* Stack of dismissible alerts */
-[data-bn-demo-alert-stack] {
-  margin-block-start: var(--space-md);
-  display: grid;
-  gap: var(--space-sm);
-}
-
-[data-bn-demo-alert-stack]:empty {
-  display: none;
-}
-
-/* -- Showcase page (/showcase) layout -- */
-[data-bn-showcase] {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--space-lg);
-  background: none;
-  border: none;
-  padding: 0;
-  container-type: normal;
-
-  &:hover {
-    border-color: transparent;
-    box-shadow: none;
-  }
-}
-
-[data-bn-showcase-header] {
-  grid-column: 1 / -1;
-  display: block;
-  background: none;
-  border: none;
-  padding: 0;
-  margin-block-end: var(--space-2xl);
-}
-
-[data-bn-showcase-toc] {
-  background: var(--surface-1);
-  border: var(--border-width) solid var(--border);
-  border-radius: var(--radius-md);
-  padding: var(--space-md) var(--space-lg);
-  position: sticky;
-  inset-block-start: var(--space-sm);
-  z-index: 5;
-  backdrop-filter: blur(8px);
-  background: color-mix(in srgb, var(--surface-1) 92%, transparent);
-
-  & h3 {
     font-family: var(--font-family);
-    font-stretch: var(--font-mono);
-    font-size: var(--font-size-xs);
-    color: var(--text-2);
-    text-transform: uppercase;
-    letter-spacing: var(--letter-spacing-wider);
+    font-stretch: var(--font-serif);
+    font-size: var(--font-size-2xl);
+    color: var(--accent);
     margin-block-end: var(--space-sm);
   }
 
-  & ol {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-xs);
-  }
-
-  & ol li {
-    background: none;
-    border: none;
-    padding: 0;
-  }
-
-  & a {
+  [data-bn-demo-bio-count],
+  [data-bn-demo-words],
+  [data-bn-demo-region-out],
+  [data-bn-demo-tier-out],
+  [data-bn-demo-progress-out],
+  [data-bn-demo-pager-out] {
+    display: block;
+    margin-block-start: var(--space-sm);
     font-family: var(--font-family);
     font-stretch: var(--font-mono);
     font-size: var(--font-size-xs);
-    color: var(--text-1);
-    text-decoration: none;
-    padding: var(--space-xs) var(--space-sm);
+    color: var(--text-2);
+  }
+
+  /* Generic styled "live readout" block used by reactive demos. */
+  [data-demo-display] {
+    margin-block-start: var(--space-md);
+    padding: var(--space-md) var(--space-lg);
+    background: var(--surface-2);
+    border: var(--border-width) dashed var(--border-accent);
     border-radius: var(--radius-sm);
-    transition:
-      background var(--duration-fast),
-      color var(--duration-fast);
+    color: var(--text-1);
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-tight);
 
-    &:hover {
-      background: var(--surface-3);
-      color: var(--accent);
-    }
-
-    &[aria-current="true"] {
-      background: color-mix(in srgb, var(--accent) 15%, transparent);
-      color: var(--accent);
-    }
-  }
-}
-
-[data-bn-showcase-section] {
-  scroll-margin-block-start: 6rem;
-  margin: 0;
-  padding-block: var(--space-xl);
-  border-block-start: var(--border-width) solid var(--border);
-  background: none;
-
-  &:first-of-type {
-    border-block-start: none;
-    padding-block-start: 0;
-  }
-
-  & > header {
-    margin: 0 0 var(--space-lg) 0;
-    padding: 0;
-    background: none;
-    border: none;
-    display: block;
-
-    & h2 {
-      font-family: var(--font-family);
-      font-stretch: var(--font-serif);
-      font-size: var(--font-size-2xl);
-      font-weight: var(--font-weight-normal);
-      letter-spacing: var(--letter-spacing-tight);
+    & strong {
+      display: block;
+      color: var(--text-0);
       margin-block-end: var(--space-xs);
     }
 
     & p {
-      color: var(--text-1);
-      font-size: var(--font-size-base);
-      max-inline-size: var(--size-text-max);
       margin: 0;
     }
+  }
 
-    & code {
-      color: var(--accent);
-      font-family: var(--font-family);
-      font-stretch: var(--font-mono);
+  /* Theme card flips its surface based on the toggle's data attribute. */
+  [data-bn-demo-theme-card] {
+    transition:
+      background var(--duration-med),
+      color var(--duration-med),
+      border-color var(--duration-med);
+
+    &[data-dim='on'] {
+      background: var(--surface-0);
+      color: var(--text-2);
+      border-color: var(--accent-dim);
     }
   }
-}
 
-[data-bn-showcase-demo] {
-  margin: 0 0 var(--space-md) 0;
-  padding: 0;
-  background: var(--surface-1);
-  border: var(--border-width) solid var(--border);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-
-  & figcaption {
-    font-family: var(--font-family);
-    font-stretch: var(--font-mono);
-    font-size: var(--font-size-xs);
-    color: var(--text-2);
-    text-transform: uppercase;
-    letter-spacing: var(--letter-spacing-wider);
-    padding: var(--space-sm) var(--space-md);
-    background: var(--surface-2);
-    border-block-end: var(--border-width) solid var(--border);
+  /* Stack of dismissible alerts */
+  [data-bn-demo-alert-stack] {
+    margin-block-start: var(--space-md);
+    display: grid;
+    gap: var(--space-sm);
   }
 
-  & > output {
-    display: block;
-    padding: var(--space-xl);
-    background: var(--surface-inset);
+  [data-bn-demo-alert-stack]:empty {
+    display: none;
   }
-}
 
-[data-bn-showcase-row] {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-md);
-  align-items: center;
-}
-
-[data-bn-showcase-form] {
-  display: grid;
-  gap: var(--space-lg);
-  max-inline-size: 32rem;
-}
-
-[data-bn-showcase-stack] {
-  display: grid;
-  gap: var(--space-sm);
-}
-
-[data-bn-showcase-card] {
-  max-inline-size: 24rem;
-}
-
-/* Two-column showcase layout once there is room for a sidebar. */
-@container page (min-width: 56rem) {
+  /* -- Showcase page (/showcase) layout -- */
   [data-bn-showcase] {
-    grid-template-columns: 14rem 1fr;
-    align-items: start;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-lg);
+    background: none;
+    border: none;
+    padding: 0;
+    container-type: normal;
+
+    &:hover {
+      border-color: transparent;
+      box-shadow: none;
+    }
   }
 
   [data-bn-showcase-toc] {
+    background: var(--surface-1);
+    border: var(--border-width) solid var(--border);
+    border-radius: var(--radius-md);
+    padding: var(--space-md) var(--space-lg);
     position: sticky;
-    inset-block-start: var(--space-md);
-    align-self: start;
+    inset-block-start: var(--space-sm);
+    z-index: 5;
+    backdrop-filter: blur(8px);
+    background: color-mix(in srgb, var(--surface-1) 92%, transparent);
+
+    & h3 {
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-xs);
+      color: var(--text-2);
+      text-transform: uppercase;
+      letter-spacing: var(--letter-spacing-wider);
+      margin-block-end: var(--space-sm);
+    }
 
     & ol {
-      flex-direction: column;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-wrap: wrap;
       gap: var(--space-xs);
     }
+
+    & ol li {
+      background: none;
+      border: none;
+      padding: 0;
+    }
+
+    & a {
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-xs);
+      color: var(--text-1);
+      text-decoration: none;
+      padding: var(--space-xs) var(--space-sm);
+      border-radius: var(--radius-sm);
+      transition:
+        background var(--duration-fast),
+        color var(--duration-fast);
+
+      &:hover {
+        background: var(--surface-3);
+        color: var(--accent);
+      }
+
+      &[aria-current='true'] {
+        background: color-mix(in srgb, var(--accent) 15%, transparent);
+        color: var(--accent);
+      }
+    }
   }
-}
+
+  [data-bn-showcase-section] {
+    scroll-margin-block-start: 6rem;
+    margin: 0;
+    padding-block: var(--space-xl);
+    border-block-start: var(--border-width) solid var(--border);
+    background: none;
+
+    &:first-of-type {
+      border-block-start: none;
+      padding-block-start: 0;
+    }
+
+    & > header {
+      margin: 0 0 var(--space-lg) 0;
+      padding: 0;
+      background: none;
+      border: none;
+      display: block;
+
+      & h2 {
+        font-family: var(--font-family);
+        font-stretch: var(--font-serif);
+        font-size: var(--font-size-2xl);
+        font-weight: var(--font-weight-normal);
+        letter-spacing: var(--letter-spacing-tight);
+        margin-block-end: var(--space-xs);
+      }
+
+      & p {
+        color: var(--text-1);
+        font-size: var(--font-size-base);
+        max-inline-size: var(--size-text-max);
+        margin: 0;
+      }
+
+      & code {
+        color: var(--accent);
+        font-family: var(--font-family);
+        font-stretch: var(--font-mono);
+      }
+    }
+  }
+
+  [data-bn-showcase-demo] {
+    margin: 0 0 var(--space-md) 0;
+    padding: 0;
+    background: var(--surface-1);
+    border: var(--border-width) solid var(--border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+
+    & figcaption {
+      font-family: var(--font-family);
+      font-stretch: var(--font-mono);
+      font-size: var(--font-size-xs);
+      color: var(--text-2);
+      text-transform: uppercase;
+      letter-spacing: var(--letter-spacing-wider);
+      padding: var(--space-sm) var(--space-md);
+      background: var(--surface-2);
+      border-block-end: var(--border-width) solid var(--border);
+    }
+
+    & > output {
+      display: block;
+      padding: var(--space-xl);
+      background: var(--surface-inset);
+    }
+  }
+
+  [data-bn-showcase-row] {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+    align-items: center;
+  }
+
+  [data-bn-showcase-form] {
+    display: grid;
+    gap: var(--space-lg);
+    max-inline-size: 32rem;
+  }
+
+  [data-bn-showcase-stack] {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  [data-bn-showcase-card] {
+    max-inline-size: 24rem;
+  }
+
+  /* Two-column showcase layout once there is room for a sidebar. */
+  @container page (min-width: 56rem) {
+    [data-bn-showcase] {
+      grid-template-columns: 14rem 1fr;
+      align-items: start;
+    }
+
+    [data-bn-showcase-toc] {
+      position: sticky;
+      inset-block-start: var(--space-md);
+      align-self: start;
+
+      & ol {
+        flex-direction: column;
+        gap: var(--space-xs);
+      }
+    }
+  }
   /* -- Component overrides for express theme -- */
   [data-bn='button'] {
     min-block-size: 2.75rem;
@@ -3800,4 +3791,3 @@
     }
   }
 }
-

--- a/examples/express/views/layout.html
+++ b/examples/express/views/layout.html
@@ -27,6 +27,151 @@
 <link rel="stylesheet" href="/fonts/fonts.css">
 <link rel="stylesheet" href="/theme.css">
 <link rel="stylesheet" href="/styles.css">
+<style data-bn-critical>
+  /* Critical layout — unlayered, plain selectors, no nesting.
+     Wins over external @layer rules so first paint is correct
+     even if a later stylesheet fails to parse modern features. */
+  [data-bn-skip-link] {
+    position: absolute;
+    inset-inline-start: -9999px;
+    inset-block-start: -9999px;
+    z-index: 10000;
+    padding: var(--space-sm, 0.5rem) var(--space-md, 1rem);
+    background: var(--accent, #e8a44a);
+    color: var(--surface-0, #0a0a0c);
+    font-weight: var(--font-weight-semibold, 600);
+    text-decoration: none;
+    border-radius: 0 0 var(--radius-sm, 0.25rem) 0;
+  }
+  [data-bn-skip-link]:focus {
+    inset-inline-start: 0;
+    inset-block-start: 0;
+  }
+  [data-bn-visually-hidden] {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+  body > [data-bn-site-header] {
+    border-block-end: var(--border-width, 1px) solid var(--border, #2a2a38);
+    background: var(--surface-1, #131318);
+  }
+  body > [data-bn-site-header] > nav {
+    max-inline-size: var(--size-inline-max, 52rem);
+    margin-inline: auto;
+    padding: var(--space-md, 1rem) var(--space-lg, 1.5rem);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-md, 1rem);
+    flex-wrap: wrap;
+    min-inline-size: 0;
+  }
+  body > [data-bn-site-header] h1 {
+    font-family: var(--font-family);
+    font-stretch: var(--font-serif, expanded);
+    font-size: var(--font-size-xl, 1.25rem);
+    font-weight: var(--font-weight-normal, 400);
+    letter-spacing: var(--letter-spacing-tight, -0.02em);
+  }
+  body > [data-bn-site-header] h1 em {
+    font-style: normal;
+    color: var(--accent, #e8a44a);
+  }
+  body > [data-bn-site-header] [data-bn-wordmark] {
+    color: inherit;
+    text-decoration: none;
+  }
+  body > [data-bn-site-header] menu {
+    list-style: none;
+    display: flex;
+    gap: var(--space-md, 1rem);
+    margin: 0;
+    padding: 0;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    min-inline-size: 0;
+    max-inline-size: 100%;
+  }
+  body > [data-bn-site-header] menu::-webkit-scrollbar { display: none; }
+  body > [data-bn-site-header] menu li {
+    list-style: none;
+    scroll-snap-align: start;
+    flex: 0 0 auto;
+  }
+  body > [data-bn-site-header] menu a {
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono, ultra-condensed);
+    font-size: var(--font-size-sm, 0.8rem);
+    color: var(--text-1, #b0adc0);
+    text-decoration: none;
+    padding: var(--space-sm, 0.5rem) var(--space-md, 1rem);
+    min-block-size: 2.75rem;
+    display: inline-flex;
+    align-items: center;
+    border-radius: var(--radius-sm, 0.25rem);
+    transition: color var(--duration-fast, 0.15s), background var(--duration-fast, 0.15s);
+  }
+  body > [data-bn-site-header] menu a:hover {
+    color: var(--accent, #e8a44a);
+    background: var(--surface-2, #1a1a22);
+  }
+  body > [data-bn-site-header] menu a[aria-current="page"] {
+    color: var(--accent, #e8a44a);
+  }
+  body > [data-bn-site-footer] {
+    border-block-start: var(--border-width, 1px) solid var(--border, #2a2a38);
+    padding: var(--space-lg, 1.5rem);
+    text-align: center;
+    display: grid;
+    gap: var(--space-sm, 0.5rem);
+  }
+  body > [data-bn-site-footer] nav {
+    display: flex;
+    gap: var(--space-md, 1rem);
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  body > [data-bn-site-footer] nav a {
+    font-family: var(--font-family);
+    font-stretch: var(--font-mono, ultra-condensed);
+    font-size: var(--font-size-xs, 0.75rem);
+    color: var(--text-2, #7a7890);
+    text-decoration: none;
+  }
+  body > [data-bn-site-footer] nav a:hover { color: var(--accent, #e8a44a); }
+  /* Showcase header visual hierarchy — override article > header { display:flex } */
+  [data-bn-showcase-header] {
+    display: block;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0 0 var(--space-2xl, 3rem);
+  }
+  [data-bn-showcase-header] [data-bn-eyebrow] {
+    display: block;
+    margin: 0 0 var(--space-sm, 0.5rem);
+  }
+  [data-bn-showcase-header] > h2 { margin: 0 0 var(--space-md, 1rem); }
+  [data-bn-showcase-header] [data-bn-lede] { margin: 0 0 var(--space-lg, 1.5rem); }
+  [data-bn-showcase-header] [data-bn-showcase-actions] {
+    display: flex;
+    gap: var(--space-sm, 0.5rem);
+    flex-wrap: wrap;
+  }
+  /* Empty state hidden until query toggles attribute on :root */
+  [data-bn-showcase-empty] { display: none; }
+  :root[data-bn-showcase-empty] [data-bn-showcase-empty] { display: block; }
+</style>
 </head>
 <body>
   <a href="#main-content" data-bn-skip-link>Skip to main content</a>


### PR DESCRIPTION
## Summary
- Inline a self-contained critical-path `<style>` block in `examples/express/views/layout.html` using plain (non-nested) `data-bn-*` selectors. Wins the cascade vs layered external CSS so the first paint is correct on every page.
- Covers the rules the deployed site was failing to apply: `[data-bn-skip-link]` visibility, `[data-bn-visually-hidden]`, `[data-bn-site-header]` nav/menu/wordmark layout, `[data-bn-site-footer]`, `[data-bn-showcase-header]` visual hierarchy (eyebrow → h2 → lede → CTAs), and `[data-bn-showcase-empty]` default-hidden state.
- Remove a duplicate `[data-bn-showcase-header]` block in `examples/express/public/styles.css` that was redundant with the consolidated rule.

## Why this needed inlining
Every layout-critical rule previously lived inside `@layer states` using `& foo` nested syntax. If any later layered stylesheet failed to parse a modern feature (`color-mix`, `:has()`, nesting, `@scope`), the critical path silently fell back to UA defaults — bullet-pointed `<menu>`, visible skip link, crammed showcase header. Per the BaseNative "use adopted stylesheets or inline styles in SSR templates" axiom, the fix is to ship the critical rules unlayered and unnested in `<head>`.

## Test plan
- [x] `pnpm build:pages` succeeds (`Done → dist/`)
- [x] Inline `<style data-bn-critical>` block present in every built page (verified `dist/index.html`, `dist/showcase/index.html`, `dist/components/index.html`, `dist/roadmap/index.html`)
- [x] Local Express render verified for `/`, `/showcase`, `/components`, `/tasks`, `/roadmap`
- [x] `[data-bn-skip-link]` computed `inset-inline-start: -9999px` (hidden until focus)
- [x] `body > [data-bn-site-header] menu` computed `display: flex; list-style-type: none; padding-inline-start: 0`
- [x] `[data-bn-showcase-empty]` computed `display: none`
- [x] `[data-bn-showcase-header]` computed `display: block` (overrides `article > header { display: flex }`)
- [ ] Deploy preview: confirm bullets gone, skip link hidden, showcase header has hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)