### PR TITLE
docs: runtime bundle is 9.2KB gzipped, not 8.8KB

### DIFF
--- a/.claude/agents/basenative-package-author.md
+++ b/.claude/agents/basenative-package-author.md
@@ -36,7 +36,7 @@ Ask up front (one round of questions, then proceed):
 - **No TypeScript source.** `.d.ts` only, in `types/` if needed.
 - **ESM only.** No CommonJS, no `require`.
 - **Node `node:test`** for tests. Never Jest, never Vitest.
-- **`@basenative/runtime` stays under its 10KB gzipped CI budget** (currently 8.8KB) — never add deps to it.
+- **`@basenative/runtime` stays under its 10KB gzipped CI budget** (currently 9.2KB) — never add deps to it.
 - Match the **constitution's four axioms** if the package touches DOM/HTML.
 
 ## Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ chore(ci): add bundle size check to PR workflow
 ## Key Invariants to Preserve
 
 1. `@basenative/runtime` must stay under **10KB gzipped** — the budget enforced by
-   `scripts/bundle-size.js` in CI. Currently 8.8KB. (The long-standing "<5KB" claim
+   `scripts/bundle-size.js` in CI. Currently 9.2KB. (The long-standing "<5KB" claim
    was never true against the measured build; the budget has always been 10KB.)
 2. The CSP-safe evaluator must never use `eval` or `new Function`
 3. All parameterized DB queries use `?` placeholders — never string interpolation

--- a/PRD.md
+++ b/PRD.md
@@ -93,7 +93,7 @@ Modern web development is buried under abstraction layers that obscure what the 
 ## Success Metrics
 
 - **Token reduction**: ~70% fewer tokens vs equivalent React/Angular markup for identical UI
-- **Bundle size**: Runtime under 10KB gzipped (measured 8.8KB) with zero production dependencies
+- **Bundle size**: Runtime under 10KB gzipped (measured 9.2KB) with zero production dependencies
 - **Zero-shot LLM comprehension**: Any BaseNative template parseable by an LLM without framework-specific training
 - **Adoption**: npm download growth, GitHub stars, community component contributions
 - **Spec compliance**: W3C primitives as the only API surface — no proprietary abstractions

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Measured by `scripts/bundle-size.js`, enforced in CI:
 
 | Package | Gzipped | Budget |
 |---|---|---|
-| `@basenative/runtime` | 8.8KB | 10KB |
+| `@basenative/runtime` | 9.2KB | 10KB |
 | `@basenative/server` | 2.2KB | 16KB |
 
 Zero production dependencies in the runtime.

--- a/docs/CONSUMING-FROM-GH-PACKAGES.md
+++ b/docs/CONSUMING-FROM-GH-PACKAGES.md
@@ -63,7 +63,7 @@ After the next release tag, all of these will be on GitHub Packages:
 
 | Package | Purpose |
 |---|---|
-| `@basenative/runtime` | signal-based runtime (8.8KB gzipped) |
+| `@basenative/runtime` | signal-based runtime (9.2KB gzipped) |
 | `@basenative/server`, `router`, `components`, `forms`, `fetch`, `realtime` | app stack |
 | `@basenative/auth`, `auth-webauthn` | auth + passkeys |
 | `@basenative/db`, `middleware`, `upload`, `tenant`, `flags`, `notify`, `i18n`, `date`, `markdown` | backend + utility |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -17,7 +17,7 @@ Every DuganLabs project consumes BaseNative. When a new shared concern emerges, 
 
 ## 2. Goals
 
-1. **Lightweight runtime.** 8.8KB gzipped signal core (10KB CI budget). No build step required.
+1. **Lightweight runtime.** 9.2KB gzipped signal core (10KB CI budget). No build step required.
 2. **Useful primitives.** Auth, components, router, DB, forms, realtime, OG images, virtual keyboard, admin, persist, share — everything a serious app needs without re-rolling.
 3. **CLI-first.** `bn` is the front door. `bn create`, `bn prd`, `bn speckit`, `bn deploy`, `bn doctor`.
 4. **Open-source by default.** All packages Apache-2.0. Visible repo. Contribution-friendly.

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -120,7 +120,7 @@ Manages environment variables for the project.
 
 ### `bn analyze`
 
-Analyzes bundle size and reports dependency sizes. Useful for verifying that `@basenative/runtime` stays under its 10KB gzipped budget (currently 8.8KB).
+Analyzes bundle size and reports dependency sizes. Useful for verifying that `@basenative/runtime` stays under its 10KB gzipped budget (currently 9.2KB).
 
 ---
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -104,7 +104,7 @@ const html = render(`
 |-------|------------|
 | JSX requires transpilation | Native HTML, no build step |
 | Virtual DOM diffs | Direct DOM mutation via signals |
-| 45KB+ runtime | 8.8KB gzipped runtime |
+| 45KB+ runtime | 9.2KB gzipped runtime |
 | Component = function | Component = HTML template |
 | useState + useEffect | signal + effect |
 

--- a/examples/express/showcase-data.js
+++ b/examples/express/showcase-data.js
@@ -38,7 +38,7 @@ export const PACKAGES = [
   {
     name: '@basenative/runtime',
     tag: 'core',
-    summary: 'Signal-based web runtime over native HTML — zero build step, 8.8KB gzipped (10KB budget).',
+    summary: 'Signal-based web runtime over native HTML — zero build step, 9.2KB gzipped (10KB budget).',
   },
   {
     name: '@basenative/server',

--- a/examples/express/site-data.js
+++ b/examples/express/site-data.js
@@ -37,7 +37,7 @@ export function getHomePageContext() {
       { label: 'security boundary', value: 'no eval, no Function' },
       { label: 'render()', value: 'template string at runtime' },
       { label: 'self-check loop', value: 'validate + mcp + evals' },
-      { label: '@basenative/runtime (gzip)', value: '8.8KB / 10KB budget' },
+      { label: '@basenative/runtime (gzip)', value: '9.2KB / 10KB budget' },
     ],
     updates: [
       { id: 1, text: 'Initial proof of concept complete', date: '2025-01-15' },

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -431,7 +431,7 @@ Deploys the application to BaseNative Cloud. **Options:** - `--env <name>` — t
 Manages environment variables for the project. **Subcommands:** - `bn env set <KEY> <VALUE>` — sets an environment variable - `bn env get <KEY>` — reads a single variable - `bn env list` — lists all configured variables - `bn env delete <K…
 
 #### `bn analyze`
-Analyzes bundle size and reports dependency sizes. Useful for verifying that `@basenative/runtime` stays under its 10KB gzipped budget (currently 8.8KB).
+Analyzes bundle size and reports dependency sizes. Useful for verifying that `@basenative/runtime` stays under its 10KB gzipped budget (currently 9.2KB).
 
 #### `bn help`
 Prints the help message listing all commands.

--- a/packages/claude-config/agents/basenative-package-author.md
+++ b/packages/claude-config/agents/basenative-package-author.md
@@ -36,7 +36,7 @@ Ask up front (one round of questions, then proceed):
 - **No TypeScript source.** `.d.ts` only, in `types/` if needed.
 - **ESM only.** No CommonJS, no `require`.
 - **Node `node:test`** for tests. Never Jest, never Vitest.
-- **`@basenative/runtime` stays under its 10KB gzipped CI budget** (currently 8.8KB) — never add deps to it.
+- **`@basenative/runtime` stays under its 10KB gzipped CI budget** (currently 9.2KB) — never add deps to it.
 - Match the **constitution's four axioms** if the package touches DOM/HTML.
 
 ## Workflow


### PR DESCRIPTION
Follow-up to #137. The escaping work grew `@basenative/runtime` from 9,005 to 9,384 bytes gzipped — **9.2KB** against the 10KB CI budget. Every place that stated 8.8KB now states the measured number (README, CLAUDE.md invariant, docs, package-author agent, site copy). `docs/blog/` is left alone as a dated artifact.

Verification: `scripts/bundle-size.js` on `main` after #137 reports `@basenative/runtime 9384 gzip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)