### PR TITLE
ci: bump github/codeql-action from 3 to 4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,10 +23,10 @@ jobs:
         language: [javascript-typescript]
     steps:
       - uses: actions/checkout@v6
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Replaces #108, which Dependabot closed with the claim that `github/codeql-action` was already up to date — `main` still pinned `@v3`. Same change, applied by hand. The `codeql` workflow runs on this PR, so the `@v4` action is exercised directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)