### PR TITLE
ci: bump github/codeql-action from 3 to 4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,10 +23,10 @@ jobs:
         language: [javascript-typescript]
     steps:
       - uses: actions/checkout@v7
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Replaces #140 (which conflicted with the `checkout@v7` bump that merged after it was cut) and #108 (which Dependabot closed while `main` still pinned `@v3`). Same two-line change. The `codeql` workflow runs on this PR, exercising `@v4` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)