### PR TITLE
chore(claude-config): allow gh pr merge without a per-call prompt

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,6 +31,7 @@
       "Bash(doppler configs:*)",
       "Bash(gh pr list:*)",
       "Bash(gh issue list:*)",
+      "Bash(gh pr merge:*)",
       "Bash(gh pr view:*)",
       "Bash(gh issue view:*)",
       "Bash(bn doctor)",
@@ -56,7 +57,6 @@
       "Bash(doppler secrets upload:*)",
       "Bash(doppler secrets delete:*)",
       "Bash(gh pr create:*)",
-      "Bash(gh pr merge:*)",
       "Bash(gh release create:*)",
       "Bash(git restore:*)",
       "Bash(git clean:*)"

--- a/packages/claude-config/settings/settings.template.json
+++ b/packages/claude-config/settings/settings.template.json
@@ -31,6 +31,7 @@
       "Bash(doppler configs:*)",
       "Bash(gh pr list:*)",
       "Bash(gh issue list:*)",
+      "Bash(gh pr merge:*)",
       "Bash(gh pr view:*)",
       "Bash(gh issue view:*)",
       "Bash(bn doctor)",
@@ -56,7 +57,6 @@
       "Bash(doppler secrets upload:*)",
       "Bash(doppler secrets delete:*)",
       "Bash(gh pr create:*)",
-      "Bash(gh pr merge:*)",
       "Bash(gh release create:*)",
       "Bash(git restore:*)",
       "Bash(git clean:*)"


### PR DESCRIPTION
Owner-made change, committed so it survives regeneration of `.claude/settings.json` from the template. `Bash(gh pr merge:*)` moves from `ask` to `allow`; merges are still gated by branch checks and the repository ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)