### PR TITLE
feat(scripts): inventory reports GitHub Packages, the actual publish target

### DIFF
--- a/docs/package-inventory.md
+++ b/docs/package-inventory.md
@@ -5,59 +5,65 @@
 Generated 2026-09-10 · 43 packages.
 
 **Publish target for `@basenative/*` is https://npm.pkg.github.com** (set in `.npmrc`), not npmjs.org.
-Installing any package therefore requires a GitHub PAT with `read:packages` — see
-[CONSUMING-FROM-GH-PACKAGES.md](CONSUMING-FROM-GH-PACKAGES.md). The npmjs column below is a
-stale public mirror from before the move; it is what an external `npm install` resolves to.
+Installing any package therefore requires a GitHub token with `read:packages` — see
+[CONSUMING-FROM-GH-PACKAGES.md](CONSUMING-FROM-GH-PACKAGES.md). The GitHub Packages column is
+the highest version published there; the npmjs column is a stale public mirror from before
+the move and is what an unauthenticated `npm install` resolves to.
 
-| Package | Local | npmjs | State |
-|---|---|---|---|
-| `@basenative/admin` | 1.0.0 | — | never on npmjs |
-| `@basenative/auth` | 0.3.0 | 0.2.0 | behind (0.2.0) |
-| `@basenative/auth-webauthn` | 1.0.2 | — | never on npmjs |
-| `@basenative/builder` | 0.1.0 | — | never on npmjs |
-| `@basenative/claude-config` | 0.2.0 | — | never on npmjs |
-| `@basenative/cli` | 0.4.0 | 0.2.0 | behind (0.2.0) |
-| `@basenative/combobox` | 1.0.0 | — | never on npmjs |
-| `@basenative/components` | 0.4.0 | 0.3.0 | behind (0.3.0) |
-| `@basenative/config` | 0.3.0 | 0.2.0 | behind (0.2.0) |
-| `@basenative/date` | 0.3.0 | 0.2.0 | behind (0.2.0) |
-| `@basenative/db` | 0.3.0 | 0.2.0 | behind (0.2.0) |
-| `@basenative/doppler` | 0.2.0 | — | never on npmjs |
-| `@basenative/eslint-config` | 0.2.0 | — | never on npmjs |
-| `@basenative/evals` | 0.1.0 | — | private |
-| `@basenative/favicon` | 1.0.0 | — | never on npmjs |
-| `@basenative/fetch` | 0.3.0 | 0.2.0 | behind (0.2.0) |
-| `@basenative/flags` | 0.3.0 | 0.2.0 | behind (0.2.0) |
-| `@basenative/fonts` | 0.1.0 | — | private |
-| `@basenative/forms` | 0.4.0 | 0.3.0 | behind (0.3.0) |
-| `@basenative/i18n` | 0.3.0 | 0.2.0 | behind (0.2.0) |
-| `@basenative/icons` | 0.1.0 | — | private |
-| `@basenative/integrations` | 0.1.0 | — | never on npmjs |
-| `@basenative/keyboard` | 1.0.1 | — | never on npmjs |
-| `@basenative/logger` | 0.3.0 | 0.2.0 | behind (0.2.0) |
-| `@basenative/markdown` | 0.1.0 | — | never on npmjs |
-| `@basenative/marketplace` | 0.2.0 | 0.2.0 | in sync |
-| `@basenative/mcp` | 0.1.0 | — | never on npmjs |
-| `@basenative/middleware` | 0.3.0 | 0.2.0 | behind (0.2.0) |
-| `@basenative/notify` | 0.3.0 | 0.2.0 | behind (0.2.0) |
-| `@basenative/og-image` | 0.2.0 | — | never on npmjs |
-| `@basenative/persist` | 1.0.0 | — | never on npmjs |
-| `@basenative/realtime` | 0.3.0 | 0.2.0 | behind (0.2.0) |
-| `@basenative/router` | 0.4.1 | 0.3.0 | behind (0.3.0) |
-| `@basenative/runtime` | 0.4.1 | 0.3.0 | behind (0.3.0) |
-| `@basenative/server` | 0.4.2 | 0.3.0 | behind (0.3.0) |
-| `@basenative/share` | 1.0.0 | — | never on npmjs |
-| `@basenative/station` | 0.2.0 | — | never on npmjs |
-| `@basenative/tenant` | 0.3.0 | 0.2.0 | behind (0.2.0) |
-| `@basenative/tsconfig` | 0.2.0 | — | never on npmjs |
-| `@basenative/upload` | 0.3.0 | 0.2.0 | behind (0.2.0) |
-| `@basenative/validate` | 0.1.0 | — | never on npmjs |
-| `@basenative/visual-builder` | 0.2.0 | 0.2.0 | in sync |
-| `@basenative/wrangler-preset` | 0.2.0 | — | never on npmjs |
+State: **registry ahead** means a version higher than this tree's is already published, so
+the next changeset bump would collide and be skipped — realign the local version first.
+
+| Package | Local | GitHub Packages | npmjs | State |
+|---|---|---|---|---|
+| `@basenative/admin` | 1.0.0 | 1.0.0 | — | in sync |
+| `@basenative/auth` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
+| `@basenative/auth-webauthn` | 1.0.2 | 1.0.2 | — | in sync |
+| `@basenative/builder` | 0.1.0 | — | — | never published |
+| `@basenative/claude-config` | 0.2.0 | 0.2.0 | — | in sync |
+| `@basenative/cli` | 0.4.0 | 0.4.0 | 0.2.0 | in sync |
+| `@basenative/combobox` | 1.0.0 | 1.0.0 | — | in sync |
+| `@basenative/components` | 0.4.0 | 0.4.0 | 0.3.0 | in sync |
+| `@basenative/config` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
+| `@basenative/date` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
+| `@basenative/db` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
+| `@basenative/doppler` | 0.2.0 | 0.2.0 | — | in sync |
+| `@basenative/eslint-config` | 0.2.0 | 0.2.0 | — | in sync |
+| `@basenative/evals` | 0.1.0 | — | — | private |
+| `@basenative/favicon` | 1.0.0 | 1.0.0 | — | in sync |
+| `@basenative/fetch` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
+| `@basenative/flags` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
+| `@basenative/fonts` | 0.1.0 | — | — | private |
+| `@basenative/forms` | 0.4.0 | 0.13.0 | 0.3.0 | **registry ahead** (0.13.0) |
+| `@basenative/i18n` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
+| `@basenative/icons` | 0.1.0 | — | — | private |
+| `@basenative/integrations` | 0.1.0 | 0.1.0 | — | in sync |
+| `@basenative/keyboard` | 1.0.1 | 1.0.0 | — | unreleased bump |
+| `@basenative/logger` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
+| `@basenative/markdown` | 0.1.0 | 0.1.0 | — | in sync |
+| `@basenative/marketplace` | 0.2.0 | 0.2.0 | 0.2.0 | in sync |
+| `@basenative/mcp` | 0.1.0 | — | — | never published |
+| `@basenative/middleware` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
+| `@basenative/notify` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
+| `@basenative/og-image` | 0.2.0 | 0.2.0 | — | in sync |
+| `@basenative/persist` | 1.0.0 | 1.0.0 | — | in sync |
+| `@basenative/realtime` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
+| `@basenative/router` | 0.4.1 | 0.4.0 | 0.3.0 | unreleased bump |
+| `@basenative/runtime` | 0.4.1 | 0.4.1 | 0.3.0 | in sync |
+| `@basenative/server` | 0.4.2 | 0.4.2 | 0.3.0 | in sync |
+| `@basenative/share` | 1.0.0 | 1.0.0 | — | in sync |
+| `@basenative/station` | 0.2.0 | 0.1.0 | — | unreleased bump |
+| `@basenative/tenant` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
+| `@basenative/tsconfig` | 0.2.0 | 0.2.0 | — | in sync |
+| `@basenative/upload` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
+| `@basenative/validate` | 0.1.0 | — | — | never published |
+| `@basenative/visual-builder` | 0.2.0 | 0.2.0 | 0.2.0 | in sync |
+| `@basenative/wrangler-preset` | 0.2.0 | 0.2.0 | — | in sync |
 
 ## Summary
 
 - **40** publishable, **3** private (`@basenative/evals`, `@basenative/fonts`, `@basenative/icons`)
+- **1** have a higher version on GitHub Packages than in this tree (`@basenative/forms` 0.4.0 vs 0.13.0)
+- **3** have never been published to GitHub Packages (`@basenative/builder`, `@basenative/mcp`, `@basenative/validate`)
 - **19** have a stale npmjs copy that external installs resolve to
 - **19** have never appeared on npmjs
 - **0** are at 1.0 on npmjs, despite 7 being at 1.x locally

--- a/scripts/package-inventory.js
+++ b/scripts/package-inventory.js
@@ -80,6 +80,11 @@ function readPackages() {
 }
 
 function render(pkgs, registry) {
+  const cmp = (a, b) => {
+    const k = (v) => String(v).split('.').map((n) => parseInt(n, 10) || 0);
+    const [x, y] = [k(a), k(b)];
+    return x[0] - y[0] || x[1] - y[1] || x[2] - y[2];
+  };
   const publishable = pkgs.filter((p) => !p.private);
   const priv = pkgs.filter((p) => p.private);
   const behind = publishable.filter((p) => p.npmjs && p.npmjs !== p.version);
@@ -90,11 +95,6 @@ function render(pkgs, registry) {
     (p) => p.publishConfig?.registry?.replace(/\/$/, '') === registry,
   );
 
-  const cmp = (a, b) => {
-    const k = (v) => String(v).split('.').map((n) => parseInt(n, 10) || 0);
-    const [x, y] = [k(a), k(b)];
-    return x[0] - y[0] || x[1] - y[1] || x[2] - y[2];
-  };
   const rows = pkgs
     .map((p) => {
       let state;

--- a/scripts/package-inventory.js
+++ b/scripts/package-inventory.js
@@ -1,4 +1,5 @@
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -19,12 +20,51 @@ function scopeRegistry() {
   return m ? m[1].replace(/\/$/, '') : 'https://registry.npmjs.org';
 }
 
-/** Latest published version on npmjs, or null. Public mirror only — GH Packages needs auth. */
+/** Latest published version on npmjs, or null. */
 async function npmjsVersion(name) {
   const res = await fetch(`https://registry.npmjs.org/${encodeURIComponent(name)}`);
   if (!res.ok) return null;
   const body = await res.json();
   return body['dist-tags']?.latest ?? null;
+}
+
+/**
+ * A token that can read GitHub Packages: NODE_AUTH_TOKEN / GITHUB_TOKEN in CI,
+ * else the local gh login (needs the read:packages scope). Null if none.
+ */
+function githubPackagesToken() {
+  if (process.env.NODE_AUTH_TOKEN) return process.env.NODE_AUTH_TOKEN;
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
+  try {
+    return execFileSync('gh', ['auth', 'token'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Highest version on GitHub Packages, the scope's actual publish target — or
+ * null when unpublished, or 'unknown' when no token is available.
+ *
+ * "Highest" rather than the latest dist-tag on purpose: @basenative/forms had
+ * 0.5–0.13 published from the pre-monorepo repo while this tree said 0.4.0,
+ * and a latest-tag check would not have shown that a future 0.4.1 publish
+ * would silently collide.
+ */
+async function githubPackagesMax(name, token) {
+  if (!token) return 'unknown';
+  const res = await fetch(`https://npm.pkg.github.com/${encodeURIComponent(name)}`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) return null;
+  const body = await res.json();
+  const versions = Object.keys(body.versions ?? {});
+  if (versions.length === 0) return null;
+  const key = (v) => v.split('.').map((n) => parseInt(n, 10) || 0);
+  return versions.sort((a, b) => {
+    const [x, y] = [key(a), key(b)];
+    return x[0] - y[0] || x[1] - y[1] || x[2] - y[2];
+  }).at(-1);
 }
 
 function readPackages() {
@@ -44,20 +84,27 @@ function render(pkgs, registry) {
   const priv = pkgs.filter((p) => p.private);
   const behind = publishable.filter((p) => p.npmjs && p.npmjs !== p.version);
   const absent = publishable.filter((p) => !p.npmjs);
+  const diverged = publishable.filter((p) => p.ghp && p.ghp !== 'unknown' && cmp(p.version, p.ghp) < 0);
+  const neverGhp = publishable.filter((p) => p.ghp === null);
   const redundant = publishable.filter(
     (p) => p.publishConfig?.registry?.replace(/\/$/, '') === registry,
   );
 
+  const cmp = (a, b) => {
+    const k = (v) => String(v).split('.').map((n) => parseInt(n, 10) || 0);
+    const [x, y] = [k(a), k(b)];
+    return x[0] - y[0] || x[1] - y[1] || x[2] - y[2];
+  };
   const rows = pkgs
     .map((p) => {
-      const state = p.private
-        ? 'private'
-        : !p.npmjs
-          ? 'never on npmjs'
-          : p.npmjs === p.version
-            ? 'in sync'
-            : `behind (${p.npmjs})`;
-      return `| \`${p.name}\` | ${p.version} | ${p.npmjs ?? '—'} | ${state} |`;
+      let state;
+      if (p.private) state = 'private';
+      else if (p.ghp === 'unknown') state = 'no token';
+      else if (!p.ghp) state = 'never published';
+      else if (cmp(p.version, p.ghp) > 0) state = 'unreleased bump';
+      else if (cmp(p.version, p.ghp) === 0) state = 'in sync';
+      else state = `**registry ahead** (${p.ghp})`;
+      return `| \`${p.name}\` | ${p.version} | ${p.ghp === 'unknown' ? '?' : (p.ghp ?? '—')} | ${p.npmjs ?? '—'} | ${state} |`;
     })
     .join('\n');
 
@@ -68,17 +115,23 @@ function render(pkgs, registry) {
 Generated ${new Date().toISOString().slice(0, 10)} · ${pkgs.length} packages.
 
 **Publish target for \`@basenative/*\` is ${registry}** (set in \`.npmrc\`), not npmjs.org.
-Installing any package therefore requires a GitHub PAT with \`read:packages\` — see
-[CONSUMING-FROM-GH-PACKAGES.md](CONSUMING-FROM-GH-PACKAGES.md). The npmjs column below is a
-stale public mirror from before the move; it is what an external \`npm install\` resolves to.
+Installing any package therefore requires a GitHub token with \`read:packages\` — see
+[CONSUMING-FROM-GH-PACKAGES.md](CONSUMING-FROM-GH-PACKAGES.md). The GitHub Packages column is
+the highest version published there; the npmjs column is a stale public mirror from before
+the move and is what an unauthenticated \`npm install\` resolves to.
 
-| Package | Local | npmjs | State |
-|---|---|---|---|
+State: **registry ahead** means a version higher than this tree's is already published, so
+the next changeset bump would collide and be skipped — realign the local version first.
+
+| Package | Local | GitHub Packages | npmjs | State |
+|---|---|---|---|---|
 ${rows}
 
 ## Summary
 
 - **${publishable.length}** publishable, **${priv.length}** private (${priv.map((p) => `\`${p.name}\``).join(', ') || 'none'})
+- **${diverged.length}** have a higher version on GitHub Packages than in this tree (${diverged.map((p) => `\`${p.name}\` ${p.version} vs ${p.ghp}`).join(', ') || 'none'})
+- **${neverGhp.length}** have never been published to GitHub Packages (${neverGhp.map((p) => `\`${p.name}\``).join(', ') || 'none'})
 - **${behind.length}** have a stale npmjs copy that external installs resolve to
 - **${absent.length}** have never appeared on npmjs
 - **0** are at 1.0 on npmjs, despite ${pkgs.filter((p) => p.version.startsWith('1.')).length} being at 1.x locally
@@ -89,7 +142,11 @@ ${rows}
 
 const registry = scopeRegistry();
 const pkgs = readPackages();
-for (const p of pkgs) p.npmjs = p.private ? null : await npmjsVersion(p.name);
+const token = githubPackagesToken();
+for (const p of pkgs) {
+  p.npmjs = p.private ? null : await npmjsVersion(p.name);
+  p.ghp = p.private ? null : await githubPackagesMax(p.name, token);
+}
 const md = render(pkgs, registry);
 
 if (process.argv.includes('--check')) {
@@ -103,10 +160,10 @@ if (process.argv.includes('--check')) {
   const strip = (s) =>
     s
       .replace(/^Generated \d{4}-\d{2}-\d{2}.*$/m, '')
-      // table rows: blank the npmjs version and the derived state cell
-      .replace(/^(\| `[^`]+` \| [^|]+\|)[^|]*\|[^|]*\|$/gm, '$1 - | - |')
-      // summary bullets whose numbers come from the registry
-      .replace(/^- \*\*\d+\*\* have (a stale npmjs copy|never appeared).*$/gm, '')
+      // table rows: blank both registry columns and the derived state cell
+      .replace(/^(\| `[^`]+` \| [^|]+\|)[^|]*\|[^|]*\|[^|]*\|$/gm, '$1 - | - | - |')
+      // summary bullets whose numbers come from a registry
+      .replace(/^- \*\*\d+\*\* have (a stale npmjs copy|never appeared|a higher version|never been published).*$/gm, '')
       .replace(/^- \*\*\d+\*\* are at 1\.0 on npmjs.*$/gm, '');
 
   let current = '';


### PR DESCRIPTION
The inventory only queried npmjs — a stale mirror — while the scope publishes to GitHub Packages. That hid a real divergence: `@basenative/forms` has **0.5–0.13** published there (January, pre-monorepo) while this tree says 0.4.0, so the next changeset bump would collide and be skipped silently.

Adds a GitHub Packages column and a **registry ahead** state; `--check` still ignores registry-derived cells so CI can't fail on someone else's publish. The forms realignment itself follows in a separate PR once I've diffed the published tarball against local source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)