### PR TITLE
chore(forms): major changeset to clear the Angular-era 0.5–0.13 registry line

### DIFF
--- a/.changeset/forms-realign-registry.md
+++ b/.changeset/forms-realign-registry.md
@@ -1,0 +1,9 @@
+---
+'@basenative/forms': major
+---
+
+Realign `@basenative/forms` with the registry.
+
+GitHub Packages already holds `@basenative/forms` 0.5.0 through 0.13.0, published in January 2026 from the pre-monorepo, Angular-era package (`fesm2022/` bundle, `tslib` dependency). This repository's `@basenative/forms` is a different package with a different API — a signal-based rewrite exporting `createField`, `createForm`, `zodAdapter`, `createWizard` and the validator set — but it still carried the version 0.4.0, so its next patch release would have collided with the existing 0.4.1 and been skipped silently, leaving consumers on the January build.
+
+This is a major release: the API is not compatible with the 0.x Angular line. Consumers of the old line should treat 1.0.0 as a new package.


### PR DESCRIPTION
GitHub Packages already holds `@basenative/forms` **0.5.0–0.13.0**, published in January from the pre-monorepo Angular package (`fesm2022/` bundle, `tslib` dep). This repo's forms is a signal-based rewrite with a different API, still versioned 0.4.0 — so its next patch would collide with the existing 0.4.1 and be skipped silently.

A `major` changeset takes it to **1.0.0**, above every published version, with release notes that say the API is not the old one. No version surgery, no lockfile changes; changesets updates dependents' ranges in the Version Packages PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)