### PR TITLE
fix(release): regenerate lockfile after Version Packages; keep it in sync from now on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm exec changeset publish
-          version: pnpm exec changeset version
+          version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Changesets reads NODE_AUTH_TOKEN for the publish step. GITHUB_TOKEN

--- a/docs/package-inventory.md
+++ b/docs/package-inventory.md
@@ -18,11 +18,11 @@ the next changeset bump would collide and be skipped — realign the local versi
 | `@basenative/admin` | 1.0.0 | 1.0.0 | — | in sync |
 | `@basenative/auth` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
 | `@basenative/auth-webauthn` | 1.0.2 | 1.0.2 | — | in sync |
-| `@basenative/builder` | 0.1.0 | — | — | never published |
+| `@basenative/builder` | 0.1.1 | — | — | never published |
 | `@basenative/claude-config` | 0.2.0 | 0.2.0 | — | in sync |
 | `@basenative/cli` | 0.4.0 | 0.4.0 | 0.2.0 | in sync |
-| `@basenative/combobox` | 1.0.0 | 1.0.0 | — | in sync |
-| `@basenative/components` | 0.4.0 | 0.4.0 | 0.3.0 | in sync |
+| `@basenative/combobox` | 1.0.1 | 1.0.0 | — | unreleased bump |
+| `@basenative/components` | 0.4.1 | 0.4.0 | 0.3.0 | unreleased bump |
 | `@basenative/config` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
 | `@basenative/date` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
 | `@basenative/db` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
@@ -30,42 +30,42 @@ the next changeset bump would collide and be skipped — realign the local versi
 | `@basenative/eslint-config` | 0.2.0 | 0.2.0 | — | in sync |
 | `@basenative/evals` | 0.1.0 | — | — | private |
 | `@basenative/favicon` | 1.0.0 | 1.0.0 | — | in sync |
-| `@basenative/fetch` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
+| `@basenative/fetch` | 0.3.1 | 0.3.0 | 0.2.0 | unreleased bump |
 | `@basenative/flags` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
 | `@basenative/fonts` | 0.1.0 | — | — | private |
-| `@basenative/forms` | 0.4.0 | 0.13.0 | 0.3.0 | **registry ahead** (0.13.0) |
+| `@basenative/forms` | 1.0.0 | 0.13.0 | 0.3.0 | unreleased bump |
 | `@basenative/i18n` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
 | `@basenative/icons` | 0.1.0 | — | — | private |
 | `@basenative/integrations` | 0.1.0 | 0.1.0 | — | in sync |
-| `@basenative/keyboard` | 1.0.1 | 1.0.0 | — | unreleased bump |
+| `@basenative/keyboard` | 1.0.2 | 1.0.0 | — | unreleased bump |
 | `@basenative/logger` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
 | `@basenative/markdown` | 0.1.0 | 0.1.0 | — | in sync |
 | `@basenative/marketplace` | 0.2.0 | 0.2.0 | 0.2.0 | in sync |
-| `@basenative/mcp` | 0.1.0 | — | — | never published |
+| `@basenative/mcp` | 0.1.1 | — | — | never published |
 | `@basenative/middleware` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
 | `@basenative/notify` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
 | `@basenative/og-image` | 0.2.0 | 0.2.0 | — | in sync |
-| `@basenative/persist` | 1.0.0 | 1.0.0 | — | in sync |
+| `@basenative/persist` | 1.0.1 | 1.0.0 | — | unreleased bump |
 | `@basenative/realtime` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
-| `@basenative/router` | 0.4.1 | 0.4.0 | 0.3.0 | unreleased bump |
-| `@basenative/runtime` | 0.4.1 | 0.4.1 | 0.3.0 | in sync |
-| `@basenative/server` | 0.4.2 | 0.4.2 | 0.3.0 | in sync |
+| `@basenative/router` | 0.4.2 | 0.4.0 | 0.3.0 | unreleased bump |
+| `@basenative/runtime` | 0.5.0 | 0.4.1 | 0.3.0 | unreleased bump |
+| `@basenative/server` | 0.5.0 | 0.4.2 | 0.3.0 | unreleased bump |
 | `@basenative/share` | 1.0.0 | 1.0.0 | — | in sync |
 | `@basenative/station` | 0.2.0 | 0.1.0 | — | unreleased bump |
 | `@basenative/tenant` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
 | `@basenative/tsconfig` | 0.2.0 | 0.2.0 | — | in sync |
 | `@basenative/upload` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
-| `@basenative/validate` | 0.1.0 | — | — | never published |
+| `@basenative/validate` | 0.1.1 | — | — | never published |
 | `@basenative/visual-builder` | 0.2.0 | 0.2.0 | 0.2.0 | in sync |
 | `@basenative/wrangler-preset` | 0.2.0 | 0.2.0 | — | in sync |
 
 ## Summary
 
 - **40** publishable, **3** private (`@basenative/evals`, `@basenative/fonts`, `@basenative/icons`)
-- **1** have a higher version on GitHub Packages than in this tree (`@basenative/forms` 0.4.0 vs 0.13.0)
+- **0** have a higher version on GitHub Packages than in this tree (none)
 - **3** have never been published to GitHub Packages (`@basenative/builder`, `@basenative/mcp`, `@basenative/validate`)
 - **19** have a stale npmjs copy that external installs resolve to
 - **19** have never appeared on npmjs
-- **0** are at 1.0 on npmjs, despite 7 being at 1.x locally
+- **0** are at 1.0 on npmjs, despite 8 being at 1.x locally
 - **17** set `publishConfig.registry` to the same value `.npmrc` already
   supplies for the whole scope — redundant, and drifts if the scope target ever moves

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -307,7 +307,7 @@ packages/auth-webauthn/src/d1-stores.js · `import { d1UserSessions } from '@bas
 Cloudflare D1 store factory for @basenative/auth-webauthn.
 packages/auth-webauthn/src/d1-stores.js · `import { migration } from '@basenative/auth-webauthn';`
 
-### `@basenative/builder` (v0.1.0)
+### `@basenative/builder` (v0.1.1)
 
 Signal-based drag-and-drop component builder for BaseNative — composes layouts, generates clean BaseNative code
 
@@ -439,7 +439,7 @@ Prints the help message listing all commands.
 #### `bn --version`
 Prints the installed CLI version.
 
-### `@basenative/combobox` (v1.0.0)
+### `@basenative/combobox` (v1.0.1)
 
 @basenative/combobox — accessible typeahead combobox primitive.
 
@@ -488,7 +488,7 @@ packages/combobox/src/a11y.js · `import { escapeOnKeydown } from '@basenative/c
 Announce a transient message to screen readers via the widget's aria-live region. Used for "N options available" / "Press Enter to create '...'" style hints. Idempotent — safe to call repeatedly.
 packages/combobox/src/a11y.js · `import { announce } from '@basenative/combobox';`
 
-### `@basenative/components` (v0.4.0)
+### `@basenative/components` (v0.4.1)
 
 15 semantic UI components with CSS custom property theming and density scales
 
@@ -1069,7 +1069,7 @@ packages/favicon/src/png.js · `import { toPng } from '@basenative/favicon';`
 Convenience: rasterize the canonical icon set in one call. Returns a map of filename → PNG bytes ready to write under `public/`.
 packages/favicon/src/png.js · `import { toIconSet } from '@basenative/favicon';`
 
-### `@basenative/fetch` (v0.3.0)
+### `@basenative/fetch` (v0.3.1)
 
 Signal-based resource fetching with caching and SSR preload support
 
@@ -1203,7 +1203,7 @@ Fetches flags from an HTTP endpoint. Supports polling for updates. **Parameters:
 Cloudflare KV-backed feature flag provider with edge caching.
 packages/flags/src/providers/kv.js · `import { createKVProvider } from '@basenative/flags';`
 
-### `@basenative/forms` (v0.4.0)
+### `@basenative/forms` (v1.0.0)
 
 Signal-based form state with dirty/touched tracking and schema validation adapters
 
@@ -1385,7 +1385,7 @@ packages/integrations/src/yield.js · `import { calculateOptimalTransferTiming }
 Calculate the break-even point for a transfer based on yield difference.
 packages/integrations/src/yield.js · `import { calculateBreakEven } from '@basenative/integrations';`
 
-### `@basenative/keyboard` (v1.0.1)
+### `@basenative/keyboard` (v1.0.2)
 
 @basenative/keyboard — accessible mobile-first virtual keyboard primitive.
 
@@ -1567,7 +1567,7 @@ packages/marketplace/src/card.js · `import { renderPackageCard } from '@basenat
 CSS for package cards. Include once on the page.
 packages/marketplace/src/card.js · `import { packageCardStyles } from '@basenative/marketplace';`
 
-### `@basenative/mcp` (v0.1.0)
+### `@basenative/mcp` (v0.1.1)
 
 MCP server exposing BaseNative validation, SSR preview, and directive reference to any agent
 
@@ -1786,7 +1786,7 @@ packages/og-image/src/presets.js · `import { scoreCardPreset } from '@basenativ
 The full preset map — handy for table-driven dispatch.
 packages/og-image/src/presets.js · `import { presets } from '@basenative/og-image';`
 
-### `@basenative/persist` (v1.0.0)
+### `@basenative/persist` (v1.0.1)
 
 @basenative/persist — TTL-aware local persistence + signal binding + server-rehydrate hook.
 
@@ -1919,7 +1919,7 @@ Returns an array of all channel name strings.
 #### createWSHandler(options)
 Creates a WebSocket connection handler with message routing. **Parameters:** - `options.onConnect(ws, req)` — called when a client connects - `options.onDisconnect(ws, code, reason)` — called when a client disconnects - `options.onMessage(…
 
-### `@basenative/router` (v0.4.1)
+### `@basenative/router` (v0.4.2)
 
 SSR-aware path routing with named params, wildcards, and history API integration
 
@@ -1957,7 +1957,7 @@ Intercepts internal link clicks for client-side navigation.
 const cleanup = interceptLinks(document.body, router);
 ```
 
-### `@basenative/runtime` (v0.4.1)
+### `@basenative/runtime` (v0.5.0)
 
 Signal-based web runtime over native HTML — zero build step, zero production dependencies
 
@@ -2239,7 +2239,7 @@ packages/runtime/src/shared/escape.js · `import { sanitizeUrl } from '@basenati
 Locate every `{{ expression }}` in `text`, linearly.
 packages/runtime/src/shared/escape.js · `import { findInterpolations } from '@basenative/runtime';`
 
-### `@basenative/server` (v0.4.2)
+### `@basenative/server` (v0.5.0)
 
 Server-side rendering with streaming support for BaseNative templates
 
@@ -2557,7 +2557,7 @@ All storage adapters implement the same interface:
 }
 ```
 
-### `@basenative/validate` (v0.1.0)
+### `@basenative/validate` (v0.1.1)
 
 Structured validation for BaseNative templates — machine-actionable errors a model can repair from the error object alone
 

--- a/llms.txt
+++ b/llms.txt
@@ -10,11 +10,11 @@ Full API surface: [llms-full.txt](./llms-full.txt). Each package's dedicated doc
 - `@basenative/admin` v1.0.0 — Pluggable admin & moderation surface — protected-route helpers, role/permission primitives, audit-l… → packages/admin/src
 - `@basenative/auth` v0.3.0 — Authentication, session management, RBAC, and OAuth2/OIDC for BaseNative apps → docs/api/auth.md
 - `@basenative/auth-webauthn` v1.0.2 — WebAuthn (passkey) adapter for @basenative/auth — server, client, and Cloudflare Workers/Pages hand… → packages/auth-webauthn/src
-- `@basenative/builder` v0.1.0 — Signal-based drag-and-drop component builder for BaseNative — composes layouts, generates clean Bas… → packages/builder/src
+- `@basenative/builder` v0.1.1 — Signal-based drag-and-drop component builder for BaseNative — composes layouts, generates clean Bas… → packages/builder/src
 - `@basenative/claude-config` v0.2.0 — Bundled Claude Code subagents, skills, slash commands, hooks, and settings for DuganLabs / BaseNati… → packages/claude-config/src
 - `@basenative/cli` v0.4.0 — The bn CLI — front door for BaseNative / DuganLabs projects (create, prd, speckit, gh, nx, deploy,… → docs/api/cli.md
-- `@basenative/combobox` v1.0.0 — Accessible combobox primitive — typeahead input that filters an existing list and lets the user cre… → packages/combobox/src
-- `@basenative/components` v0.4.0 — 15 semantic UI components with CSS custom property theming and density scales → docs/api/components.md
+- `@basenative/combobox` v1.0.1 — Accessible combobox primitive — typeahead input that filters an existing list and lets the user cre… → packages/combobox/src
+- `@basenative/components` v0.4.1 — 15 semantic UI components with CSS custom property theming and density scales → docs/api/components.md
 - `@basenative/config` v0.3.0 — Type-safe environment configuration loading and validation → docs/api/config.md
 - `@basenative/date` v0.3.0 — Date utilities, timezone handling, relative time formatting, and date ranges → docs/api/date.md
 - `@basenative/db` v0.3.0 — Query builder with SQLite, PostgreSQL, and Cloudflare D1 adapters → docs/api/db.md
@@ -22,31 +22,31 @@ Full API surface: [llms-full.txt](./llms-full.txt). Each package's dedicated doc
 - `@basenative/eslint-config` v0.2.0 — Shared ESLint flat-config for DuganLabs projects — security, hygiene, zero-noise defaults → packages/eslint-config/src
 - `@basenative/evals` v0.1.0 — Eval harness measuring whether models actually produce correct BaseNative → (private)
 - `@basenative/favicon` v1.0.0 — SVG-first favicon generator + design primitives — apple-touch-icon, maskable, manifest, and the rig… → packages/favicon/src
-- `@basenative/fetch` v0.3.0 — Signal-based resource fetching with caching and SSR preload support → docs/api/fetch.md
+- `@basenative/fetch` v0.3.1 — Signal-based resource fetching with caching and SSR preload support → docs/api/fetch.md
 - `@basenative/flags` v0.3.0 — Feature flags with percentage rollouts and @feature template directive → docs/api/flags.md
 - `@basenative/fonts` v0.1.0 — Font loading utilities for BaseNative applications → (private)
-- `@basenative/forms` v0.4.0 — Signal-based form state with dirty/touched tracking and schema validation adapters → docs/api/forms.md
+- `@basenative/forms` v1.0.0 — Signal-based form state with dirty/touched tracking and schema validation adapters → docs/api/forms.md
 - `@basenative/i18n` v0.3.0 — ICU message formatting, locale detection, and @t template directive → docs/api/i18n.md
 - `@basenative/icons` v0.1.0 — Icon system for BaseNative applications → (private)
 - `@basenative/integrations` v0.1.0 — Headless third-party integration wrappers for BaseNative apps → packages/integrations/src
-- `@basenative/keyboard` v1.0.1 — Accessible mobile-first on-screen virtual keyboard primitive — layout-agnostic, signal-driven key s… → packages/keyboard/src
+- `@basenative/keyboard` v1.0.2 — Accessible mobile-first on-screen virtual keyboard primitive — layout-agnostic, signal-driven key s… → packages/keyboard/src
 - `@basenative/logger` v0.3.0 — Structured logging with multiple transports and child logger support → docs/api/logger.md
 - `@basenative/markdown` v0.1.0 — Zero-dependency ES module markdown parser and SSR-safe HTML renderer → packages/markdown/src
 - `@basenative/marketplace` v0.2.0 — Component registry for BaseNative — publishing and discovery infrastructure → docs/api/marketplace.md
-- `@basenative/mcp` v0.1.0 — MCP server exposing BaseNative validation, SSR preview, and directive reference to any agent → packages/mcp/src
+- `@basenative/mcp` v0.1.1 — MCP server exposing BaseNative validation, SSR preview, and directive reference to any agent → packages/mcp/src
 - `@basenative/middleware` v0.3.0 — Request pipeline middleware — CORS, rate limiting, CSRF, and adapters → docs/api/middleware.md
 - `@basenative/notify` v0.3.0 — Email notifications via SMTP and SendGrid with template rendering → docs/api/notify.md
 - `@basenative/og-image` v0.2.0 — Worker-runtime OG / social share PNG renderer — satori + resvg-wasm with KV-cached fonts and themab… → packages/og-image/src
-- `@basenative/persist` v1.0.0 — Signal-driven local persistence with TTL, conflict resolution, and a server-rehydrate hook for Base… → packages/persist/src
+- `@basenative/persist` v1.0.1 — Signal-driven local persistence with TTL, conflict resolution, and a server-rehydrate hook for Base… → packages/persist/src
 - `@basenative/realtime` v0.3.0 — SSE and WebSocket connections with signal-based reactive message streams → docs/api/realtime.md
-- `@basenative/router` v0.4.1 — SSR-aware path routing with named params, wildcards, and history API integration → docs/api/router.md
-- `@basenative/runtime` v0.4.1 — Signal-based web runtime over native HTML — zero build step, zero production dependencies → docs/api/runtime.md
-- `@basenative/server` v0.4.2 — Server-side rendering with streaming support for BaseNative templates → docs/api/server.md
+- `@basenative/router` v0.4.2 — SSR-aware path routing with named params, wildcards, and history API integration → docs/api/router.md
+- `@basenative/runtime` v0.5.0 — Signal-based web runtime over native HTML — zero build step, zero production dependencies → docs/api/runtime.md
+- `@basenative/server` v0.5.0 — Server-side rendering with streaming support for BaseNative templates → docs/api/server.md
 - `@basenative/share` v1.0.0 — Native Web Share + clipboard fallback, share-card mint client+server, and OG-redirect landing page… → packages/share/src
 - `@basenative/station` v0.2.0 — Queue-driven local-inference primitive — drives a cloudflared-tunneled vLLM tower (or any OpenAI-co… → packages/station/src
 - `@basenative/tenant` v0.3.0 — Multi-tenant middleware with subdomain/path resolution and row-level query scoping → docs/api/tenant.md
 - `@basenative/tsconfig` v0.2.0 — Shared base tsconfigs for DuganLabs projects — strict, modern, runtime-targeted → packages/tsconfig/src
 - `@basenative/upload` v0.3.0 — File upload handling with R2 and S3 adapter support → docs/api/upload.md
-- `@basenative/validate` v0.1.0 — Structured validation for BaseNative templates — machine-actionable errors a model can repair from… → packages/validate/src
+- `@basenative/validate` v0.1.1 — Structured validation for BaseNative templates — machine-actionable errors a model can repair from… → packages/validate/src
 - `@basenative/visual-builder` v0.2.0 — No-code template builder for BaseNative components → docs/api/visual-builder.md
 - `@basenative/wrangler-preset` v0.2.0 — Pinned Wrangler version + typed wrangler.toml fragment generator. Pin once, every project moves tog… → packages/wrangler-preset/src

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "audit:observatory": "node scripts/audit/observatory.mjs",
     "audit:ux": "node scripts/audit/laws-of-ux.mjs",
     "audit": "pnpm audit:axe && pnpm audit:ux",
-    "bundle-size": "node scripts/bundle-size.js"
+    "bundle-size": "node scripts/bundle-size.js",
+    "version": "changeset version && pnpm install --lockfile-only --ignore-scripts"
   },
   "devDependencies": {
     "@changesets/cli": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 3.0.2
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.10.0(supports-color@7.2.0))
+        version: 10.0.1(eslint@10.10.0)
       '@playwright/test':
         specifier: ^1.63.0
         version: 1.63.0
@@ -22,10 +22,10 @@ importers:
         version: 0.28.2
       eslint:
         specifier: ^10.10.0
-        version: 10.10.0(supports-color@7.2.0)
+        version: 10.10.0
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.10.0(supports-color@7.2.0))
+        version: 10.1.8(eslint@10.10.0)
       globals:
         specifier: ^17.12.0
         version: 17.12.0
@@ -95,7 +95,7 @@ importers:
         version: link:../../packages/server
       express:
         specifier: ^5.1.0
-        version: 5.2.1(supports-color@10.2.2)
+        version: 5.2.1
 
   examples/enterprise-v2:
     dependencies:
@@ -155,7 +155,7 @@ importers:
         version: link:../../packages/upload
       express:
         specifier: ^5.1.0
-        version: 5.2.1(supports-color@10.2.2)
+        version: 5.2.1
 
   examples/express:
     dependencies:
@@ -176,7 +176,7 @@ importers:
         version: link:../../packages/server
       express:
         specifier: ^5.1.0
-        version: 5.2.1(supports-color@10.2.2)
+        version: 5.2.1
 
   examples/node:
     dependencies:
@@ -266,13 +266,13 @@ importers:
     dependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.10.0(supports-color@10.2.2))
+        version: 10.0.1(eslint@10.10.0)
       eslint:
         specifier: '>=9.0.0'
-        version: 10.10.0(supports-color@10.2.2)
+        version: 10.10.0
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.10.0(supports-color@10.2.2))
+        version: 10.1.8(eslint@10.10.0)
       globals:
         specifier: ^17.12.0
         version: 17.12.0
@@ -280,10 +280,10 @@ importers:
   packages/evals:
     dependencies:
       '@basenative/server':
-        specifier: workspace:^0.4.0
+        specifier: workspace:^0.5.0
         version: link:../server
       '@basenative/validate':
-        specifier: workspace:^0.1.0
+        specifier: workspace:^0.1.1
         version: link:../validate
 
   packages/favicon:
@@ -329,13 +329,13 @@ importers:
   packages/mcp:
     dependencies:
       '@basenative/runtime':
-        specifier: workspace:^0.4.0
+        specifier: workspace:^0.5.0
         version: link:../runtime
       '@basenative/server':
-        specifier: workspace:^0.4.0
+        specifier: workspace:^0.5.0
         version: link:../server
       '@basenative/validate':
-        specifier: workspace:^0.1.0
+        specifier: workspace:^0.1.1
         version: link:../validate
 
   packages/middleware: {}
@@ -370,7 +370,7 @@ importers:
   packages/server:
     dependencies:
       '@basenative/runtime':
-        specifier: workspace:^0.4.0
+        specifier: workspace:^0.5.0
         version: link:../runtime
       node-html-parser:
         specifier: ^9.0.4
@@ -393,7 +393,7 @@ importers:
   packages/validate:
     dependencies:
       '@basenative/runtime':
-        specifier: workspace:^0.4.0
+        specifier: workspace:^0.5.0
         version: link:../runtime
 
   packages/visual-builder: {}
@@ -988,105 +988,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1176,25 +1160,21 @@ packages:
     resolution: {integrity: sha512-CzDkhtI+HYKGWPbjfMhslrgGpWer/qGd6MOFwkjxI8JYdqRV0BYivnAuqogsyPpBDNzalxK8xM55MD/f+edQ+w==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@23.2.0':
     resolution: {integrity: sha512-poDmLBCX4WHcYwlklFingeqHVSaTdeUe5jhuQhR6BygDpFdVk4kibovEHh4A5LRkPag4SACNRy1VRBKoaoEyUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@23.2.0':
     resolution: {integrity: sha512-8E8IAkJJw1+eF9UNZKZnc1UDDNOmRaGQbb/AXL8Ix0MP3LObDjIyX9NLYxrtcb9HUcWrygcuKsySum+E5C4s3w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@23.2.0':
     resolution: {integrity: sha512-X/i1GfhqeOM1pGNBDDeIDKhtpXKnYjBR8hv8YoVW9pHQXAJ2iUux6SCP1Gg5tIKUYTdZRvsknf0g7KEw3p1sug==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@23.2.0':
     resolution: {integrity: sha512-MSXbpHVSduWYnCu8MyPs88H6XnbU20jHWUvtPFDFkxgA8Slhl09hzpp2xq8TS4M8dS2OxK4QWcZyszqRMkwQrw==}
@@ -2863,27 +2843,14 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@10.10.0(supports-color@10.2.2))':
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.10.0)':
     dependencies:
-      eslint: 10.10.0(supports-color@10.2.2)
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/eslint-utils@4.10.1(eslint@10.10.0(supports-color@7.2.0))':
-    dependencies:
-      eslint: 10.10.0(supports-color@7.2.0)
+      eslint: 10.10.0
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5(supports-color@10.2.2)':
-    dependencies:
-      '@eslint/object-schema': 3.0.5
-      debug: 4.4.3(supports-color@10.2.2)
-      minimatch: 10.2.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@eslint/config-array@0.23.5(supports-color@7.2.0)':
+  '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3(supports-color@7.2.0)
@@ -2899,13 +2866,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.10.0(supports-color@10.2.2))':
+  '@eslint/js@10.0.1(eslint@10.10.0)':
     optionalDependencies:
-      eslint: 10.10.0(supports-color@10.2.2)
-
-  '@eslint/js@10.0.1(eslint@10.10.0(supports-color@7.2.0))':
-    optionalDependencies:
-      eslint: 10.10.0(supports-color@7.2.0)
+      eslint: 10.10.0
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -3273,11 +3236,11 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  body-parser@2.2.2(supports-color@10.2.2):
+  body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@7.2.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -3406,12 +3369,6 @@ snapshots:
       postcss-value-parser: 4.2.0
 
   css-what@6.2.2: {}
-
-  debug@4.4.3(supports-color@10.2.2):
-    dependencies:
-      ms: 2.1.3
-    optionalDependencies:
-      supports-color: 10.2.2
 
   debug@4.4.3(supports-color@7.2.0):
     dependencies:
@@ -3586,13 +3543,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.10.0(supports-color@10.2.2)):
+  eslint-config-prettier@10.1.8(eslint@10.10.0):
     dependencies:
-      eslint: 10.10.0(supports-color@10.2.2)
-
-  eslint-config-prettier@10.1.8(eslint@10.10.0(supports-color@7.2.0)):
-    dependencies:
-      eslint: 10.10.0(supports-color@7.2.0)
+      eslint: 10.10.0
 
   eslint-scope@9.1.2:
     dependencies:
@@ -3605,46 +3558,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.10.0(supports-color@10.2.2):
+  eslint@10.10.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.10.0(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.10.0)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5(supports-color@10.2.2)
-      '@eslint/config-helpers': 0.7.0
-      '@eslint/core': 1.2.1
-      '@eslint/plugin-kit': 0.7.3
-      '@humanfs/node': 0.16.8
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.9
-      ajv: 6.15.0
-      cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@10.2.2)
-      escape-string-regexp: 4.0.0
-      eslint-scope: 9.1.2
-      eslint-visitor-keys: 5.0.1
-      espree: 11.2.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 11.1.5
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.6
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint@10.10.0(supports-color@7.2.0):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.10.0(supports-color@7.2.0))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5(supports-color@7.2.0)
+      '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.3
@@ -3695,20 +3613,20 @@ snapshots:
 
   etag@1.8.1: {}
 
-  express@5.2.1(supports-color@10.2.2):
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2(supports-color@10.2.2)
+      body-parser: 2.2.2
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@10.2.2)
+      finalhandler: 2.1.1
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -3719,9 +3637,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.0
       range-parser: 1.2.1
-      router: 2.2.0(supports-color@10.2.2)
-      send: 1.2.1(supports-color@10.2.2)
-      serve-static: 2.2.1(supports-color@10.2.2)
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
@@ -3762,9 +3680,9 @@ snapshots:
     dependencies:
       flat-cache: 6.1.23
 
-  finalhandler@2.1.1(supports-color@10.2.2):
+  finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@7.2.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -4322,9 +4240,9 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  router@2.2.0(supports-color@10.2.2):
+  router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -4360,9 +4278,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1(supports-color@10.2.2):
+  send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@7.2.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -4376,12 +4294,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1(supports-color@10.2.2):
+  serve-static@2.2.1:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@10.2.2)
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
The #101 merge rewrote internal workspace ranges in package.json files but nothing regenerated `pnpm-lock.yaml`, so `pnpm install --frozen-lockfile` fails on `main`: the Release run died before `changeset publish` (nothing from 0.5.0 was published) and every CI run on `main` fails the same way.

- lockfile regenerated with pnpm 10.18.3 (what CI runs)
- root `version` script = `changeset version && pnpm install --lockfile-only`, wired into `release.yml`, so future Version Packages PRs carry a matching lockfile

Once this merges, Release re-runs on `main` and publishes the already-bumped versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)