### PR TITLE
fix(components): harden renderers — shared escaping, deterministic ids, a11y fixes, dedup

### DIFF
--- a/.changeset/components-harden.md
+++ b/.changeset/components-harden.md
@@ -1,0 +1,13 @@
+---
+'@basenative/components': minor
+---
+
+Harden every renderer: one escaping policy, deterministic ids, accessibility fixes.
+
+**Escaping (behaviour change).** Every attribute interpolation (id, name, value, placeholder, alt, src, href, aria-\*, data-\*, variant/size/position) and every text-semantic field (label, helpText, error, caption, emptyMessage, item and option labels, tooltip content, breadcrumb labels, avatar name, table and grid cell values, calendar and pipeline titles) is now HTML-escaped through `@basenative/runtime/shared/escape` — the same escaper the SSR renderer uses — replacing nine private, divergent copies (one of which did not escape `<`). Designated **content slots** are not escaped and are documented as `HTML slot: not escaped; pass trusted markup only`: button/badge/alert content, card header/body/footer, dialog and drawer body and footer, accordion and tab panel content, dropdown and tooltip triggers, icons, DataGrid `render()`, custom `renderItem`, and `attrs`. `renderBadge` content was previously escaped and is now a slot.
+
+**Deterministic ids (behaviour change).** Generated ids are `bn-<prefix>-<n>` from a counter instead of `Math.random()`, so SSR output is stable and `aria-controls` / `aria-labelledby` pairs survive hydration. New exports `nextId(prefix)` and `resetIds()` — call `resetIds()` once per SSR request. Every renderer honours an explicit `id` first. `showToast` ids are now strings and accept `options.id`.
+
+**Fixes.** Tree/TreeGrid leaves no longer emit `aria-expanded="undefined"`; Input help and error get distinct `<id>-help` / `<id>-error` ids and `aria-describedby` lists both; Textarea and Select emit `aria-describedby` and an error id (Select gains `helpText`); Dialog honours `modal`; tab buttons are `type="button"`; a closed Drawer is `inert`; Progress guards `max=0`; Calendar uses local time consistently (day headers no longer shift in non-UTC zones); Avatar with an `<img>` no longer double-announces; a missing `attrs` no longer leaves a stray space.
+
+Tests: 136 → 301.

--- a/docs/api/components.md
+++ b/docs/api/components.md
@@ -7,6 +7,29 @@ All components render semantic HTML. Include the CSS:
 <link rel="stylesheet" href="@basenative/components/theme.css" />
 ```
 
+## Escaping Policy
+
+Every renderer uses the runtime's shared `escapeText` / `escapeAttr` (`@basenative/runtime/shared/escape`):
+
+- **Escaped** — every attribute interpolation (`id`, `name`, `value`, `placeholder`, `alt`, `src`, `href`, `aria-*`, `data-*`, variant/size/position fragments) and every text-semantic field (`label`, `helpText`, `error`, `caption`, `emptyMessage`, item labels, tooltip content, breadcrumb labels, avatar name, tree/table cell values, calendar and pipeline titles).
+- **Not escaped (HTML slots)** — designated composition points documented on each parameter as "HTML slot: not escaped; pass trusted markup only": button content, card header/body/footer, alert content, badge content, dialog/drawer body and footer, accordion and tab panel content, dropdown/tooltip trigger, menu/command/tree icons, breadcrumb separator, a DataGrid column's `render()` result, a custom `renderItem`, and every `attrs` option.
+
+```js
+renderInput({ name: 'q', label: '<b>Not bold</b>' })   // label is escaped
+renderButton('<b>Bold</b>')                             // content is a slot
+```
+
+## Deterministic Ids
+
+```js
+import { nextId, resetIds } from '@basenative/components';
+
+resetIds();            // once per SSR request, before rendering
+nextId('dialog');      // 'bn-dialog-1'
+```
+
+Renderers that need an id draw from a module counter, never `Math.random()`, so two renders of the same page produce identical markup. Every renderer honours an explicit `id` option first. Hydration matches server and client markup by id, so pass explicit `id`s to hydrated components, or render the same components in the same order on both sides and call `resetIds()` per request.
+
 ## Button
 
 ```js

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -502,6 +502,22 @@ Source: `packages/components/src` · Docs: `docs/api/components.md`
 - `./reset.css` → `./src/reset.css` (non-JS resource export)
 - `./states.css` → `./src/states.css` (non-JS resource export)
 
+### Escaping Policy
+Every renderer uses the runtime's shared `escapeText` / `escapeAttr` (`@basenative/runtime/shared/escape`): - **Escaped** — every attribute interpolation (`id`, `name`, `value`, `placeholder`, `alt`, `src`, `href`, `aria-*`, `data-*`, vari…
+```js
+renderInput({ name: 'q', label: '<b>Not bold</b>' })   // label is escaped
+renderButton('<b>Bold</b>')                             // content is a slot
+```
+
+### Deterministic Ids
+Renderers that need an id draw from a module counter, never `Math.random()`, so two renders of the same page produce identical markup. Every renderer honours an explicit `id` option first. Hydration matches server and client markup by id,…
+```js
+import { nextId, resetIds } from '@basenative/components';
+
+resetIds();            // once per SSR request, before rendering
+nextId('dialog');      // 'bn-dialog-1'
+```
+
 ### Button
 Variants: `primary`, `secondary`, `destructive`, `ghost`. Sizes: `default`, `sm`, `lg`.
 ```js
@@ -613,11 +629,11 @@ Returns the CSS class string for a button variant.
 packages/components/src/button.js · `import { buttonVariants } from '@basenative/components';`
 
 #### `renderCombobox(options = {})` (function)
-Combobox — searchable dropdown with keyboard navigation. Uses native <input> + <datalist> pattern with progressive enhancement.
+Combobox — searchable dropdown with keyboard navigation, rendered as a native <input> + <datalist>. Attributes, label and option labels are escaped.
 packages/components/src/combobox.js · `import { renderCombobox } from '@basenative/components';`
 
 #### `renderMultiselect(options = {})` (function)
-Multiselect — multiple value selection with tags/chips.
+Multiselect — multiple value selection with tags/chips over a hidden native <select multiple>. Attributes, label, tag text and option labels are escaped.
 packages/components/src/multiselect.js · `import { renderMultiselect } from '@basenative/components';`
 
 #### `renderDataGrid(options = {})` (function)
@@ -633,7 +649,7 @@ TreeGrid — tree structure combined with table columns.
 packages/components/src/tree.js · `import { renderTreeGrid } from '@basenative/components';`
 
 #### `renderVirtualList(options = {})` (function)
-Virtualizer — renders a virtual scroll container placeholder. Actual virtualization happens client-side via hydration. Server renders a window of items + a spacer for total height.
+Virtualizer — renders a virtual scroll container placeholder: a window of items plus a spacer for total height; actual virtualization happens client-side via hydration.
 packages/components/src/virtualizer.js · `import { renderVirtualList } from '@basenative/components';`
 
 #### `renderDialog(options = {})` (function)
@@ -645,7 +661,7 @@ Drawer — side panel that slides in from the edge.
 packages/components/src/drawer.js · `import { renderDrawer } from '@basenative/components';`
 
 #### `renderTabs(options = {})` (function)
-Tabs — tab navigation with panels.
+Tabs — tab navigation with panels. Tab buttons are type="button" and wired to their panels with aria-controls / aria-labelledby.
 packages/components/src/tabs.js · `import { renderTabs } from '@basenative/components';`
 
 #### `renderAccordion(options = {})` (function)
@@ -653,7 +669,7 @@ Accordion — collapsible sections using native <details>/<summary>.
 packages/components/src/accordion.js · `import { renderAccordion } from '@basenative/components';`
 
 #### `renderBreadcrumb(options = {})` (function)
-Breadcrumb — navigation trail.
+Breadcrumb — navigation trail; the last item is aria-current="page".
 packages/components/src/breadcrumb.js · `import { renderBreadcrumb } from '@basenative/components';`
 
 #### `renderAvatar(options = {})` (function)
@@ -665,11 +681,11 @@ Tooltip — popover-based tooltip using the Popover API.
 packages/components/src/tooltip.js · `import { renderTooltip } from '@basenative/components';`
 
 #### `renderDropdownMenu(options = {})` (function)
-Dropdown menu — popover-based menu.
+Dropdown menu — popover-based menu with role="menu" / "menuitem".
 packages/components/src/dropdown-menu.js · `import { renderDropdownMenu } from '@basenative/components';`
 
 #### `renderCommandPalette(options = {})` (function)
-Command palette — Cmd+K style searchable command menu.
+Command palette — Cmd+K style searchable command menu in a native <dialog>.
 packages/components/src/command-palette.js · `import { renderCommandPalette } from '@basenative/components';`
 
 #### `renderCalendar(options = {})` (function)

--- a/packages/components/src/accordion.js
+++ b/packages/components/src/accordion.js
@@ -1,25 +1,40 @@
 /**
  * Accordion — collapsible sections using native <details>/<summary>.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { nextId } from './ids.js';
+import { attrsSuffix } from './internal/attrs.js';
+
+/**
+ * Accordion — collapsible sections using native <details>/<summary>.
+ *
+ * @param {object} [options]
+ * @param {Array<{title: string, content?: string, open?: boolean}>} [options.items]
+ *   title is escaped text; content is an HTML slot: not escaped; pass trusted markup only
+ * @param {boolean} [options.multiple]  Allow several sections open at once
+ * @param {string} [options.id]     Defaults to nextId('accordion')
+ * @param {string} [options.attrs]  Raw attribute markup appended to the wrapper; not escaped
+ * @returns {string}
+ */
 export function renderAccordion(options = {}) {
   const {
     items = [],
     multiple = false,
-    id = `bn-accordion-${Math.random().toString(36).slice(2)}`,
+    id = nextId('accordion'),
     attrs = '',
   } = options;
 
-  const exclusiveName = multiple ? '' : ` name="${id}"`;
+  const exclusiveName = multiple ? '' : ` name="${escapeAttr(id)}"`;
 
   const sectionsHtml = items
-    .map((item, _i) => {
+    .map(item => {
       const open = item.open ? ' open' : '';
       return `<details data-bn="accordion-item"${exclusiveName}${open}>
-  <summary data-bn="accordion-header">${item.title}</summary>
-  <div data-bn="accordion-content">${item.content}</div>
+  <summary data-bn="accordion-header">${escapeText(item.title ?? '')}</summary>
+  <div data-bn="accordion-content">${item.content ?? ''}</div>
 </details>`;
     })
     .join('');
 
-  return `<div data-bn="accordion" id="${id}" ${attrs}>${sectionsHtml}</div>`;
+  return `<div data-bn="accordion" id="${escapeAttr(id)}"${attrsSuffix(attrs)}>${sectionsHtml}</div>`;
 }

--- a/packages/components/src/alert.js
+++ b/packages/components/src/alert.js
@@ -2,13 +2,23 @@
  * Alert component — inline feedback with semantic role="alert".
  * Variants: info, success, warning, error
  */
+import { escapeAttr } from '@basenative/runtime/shared/escape';
 
+/**
+ * Alert component — inline feedback; error/warning use role="alert", others role="status".
+ *
+ * @param {string} content  HTML slot: not escaped; pass trusted markup only
+ * @param {object} [options]
+ * @param {'info'|'success'|'warning'|'error'} [options.variant='info']
+ * @param {boolean} [options.dismissible]
+ * @returns {string}
+ */
 export function renderAlert(content, options = {}) {
   const variant = options.variant || 'info';
   const dismissible = options.dismissible || false;
   const role = variant === 'error' || variant === 'warning' ? 'alert' : 'status';
 
-  let html = `<div data-bn="alert" data-variant="${variant}" role="${role}">`;
+  let html = `<div data-bn="alert" data-variant="${escapeAttr(variant)}" role="${role}">`;
   html += `<span data-bn="alert-content">${content}</span>`;
   if (dismissible) {
     html += `<button data-bn="alert-dismiss" type="button" aria-label="Dismiss">×</button>`;

--- a/packages/components/src/avatar.js
+++ b/packages/components/src/avatar.js
@@ -1,6 +1,25 @@
 /**
  * Avatar — user avatar with image, initials, or icon fallback.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { attrsSuffix } from './internal/attrs.js';
+
+/**
+ * Avatar — user avatar with image, initials, or icon fallback.
+ *
+ * With `src` the <img alt> carries the accessible name and the wrapper has no
+ * role, so screen readers announce it once. Without `src` the wrapper is
+ * role="img" with an aria-label and shows escaped initials.
+ *
+ * @param {object} [options]
+ * @param {string} [options.src]
+ * @param {string} [options.alt]
+ * @param {string} [options.name]  Escaped text; also the source of the initials
+ * @param {string} [options.size='default']
+ * @param {string} [options.shape='circle']
+ * @param {string} [options.attrs]  Raw attribute markup appended to the wrapper; not escaped
+ * @returns {string}
+ */
 export function renderAvatar(options = {}) {
   const {
     src,
@@ -16,9 +35,11 @@ export function renderAvatar(options = {}) {
     return name.split(' ').map(w => w[0]).slice(0, 2).join('').toUpperCase();
   }
 
-  const content = src
-    ? `<img src="${src}" alt="${alt || name || ''}" data-bn="avatar-img">`
-    : `<span data-bn="avatar-initials">${getInitials(name)}</span>`;
+  const wrapperStart = `<span data-bn="avatar" data-size="${escapeAttr(size)}" data-shape="${escapeAttr(shape)}"`;
 
-  return `<span data-bn="avatar" data-size="${size}" data-shape="${shape}" role="img" aria-label="${alt || name || 'Avatar'}" ${attrs}>${content}</span>`;
+  if (src) {
+    return `${wrapperStart}${attrsSuffix(attrs)}><img src="${escapeAttr(src)}" alt="${escapeAttr(alt || name || '')}" data-bn="avatar-img"></span>`;
+  }
+
+  return `${wrapperStart} role="img" aria-label="${escapeAttr(alt || name || 'Avatar')}"${attrsSuffix(attrs)}><span data-bn="avatar-initials">${escapeText(getInitials(name))}</span></span>`;
 }

--- a/packages/components/src/badge.js
+++ b/packages/components/src/badge.js
@@ -2,12 +2,17 @@
  * Badge component — status indicator.
  * Variants: default, primary, success, warning, error
  */
+import { escapeAttr } from '@basenative/runtime/shared/escape';
 
+/**
+ * Badge component — status indicator.
+ *
+ * @param {string} content  HTML slot: not escaped; pass trusted markup only
+ * @param {object} [options]
+ * @param {'default'|'primary'|'success'|'warning'|'error'} [options.variant='default']
+ * @returns {string}
+ */
 export function renderBadge(content, options = {}) {
   const variant = options.variant || 'default';
-  return `<span data-bn="badge" data-variant="${variant}">${escapeHtml(content)}</span>`;
-}
-
-function escapeHtml(str) {
-  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return `<span data-bn="badge" data-variant="${escapeAttr(variant)}">${content}</span>`;
 }

--- a/packages/components/src/breadcrumb.js
+++ b/packages/components/src/breadcrumb.js
@@ -1,6 +1,18 @@
 /**
  * Breadcrumb — navigation trail.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { attrsSuffix } from './internal/attrs.js';
+
+/**
+ * Breadcrumb — navigation trail; the last item is aria-current="page".
+ *
+ * @param {object} [options]
+ * @param {Array<{label: string, href?: string}>} [options.items]  label is escaped text; href is an escaped attribute
+ * @param {string} [options.separator='/']  HTML slot: not escaped; pass trusted markup only
+ * @param {string} [options.attrs]  Raw attribute markup appended to the <nav>; not escaped
+ * @returns {string}
+ */
 export function renderBreadcrumb(options = {}) {
   const {
     items = [],
@@ -12,13 +24,13 @@ export function renderBreadcrumb(options = {}) {
     .map((item, i) => {
       const isLast = i === items.length - 1;
       if (isLast) {
-        return `<li data-bn="breadcrumb-item" aria-current="page">${item.label}</li>`;
+        return `<li data-bn="breadcrumb-item" aria-current="page">${escapeText(item.label)}</li>`;
       }
-      return `<li data-bn="breadcrumb-item"><a href="${item.href}">${item.label}</a><span data-bn="breadcrumb-separator" aria-hidden="true">${separator}</span></li>`;
+      return `<li data-bn="breadcrumb-item"><a href="${escapeAttr(item.href)}">${escapeText(item.label)}</a><span data-bn="breadcrumb-separator" aria-hidden="true">${separator}</span></li>`;
     })
     .join('');
 
-  return `<nav data-bn="breadcrumb" aria-label="Breadcrumb" ${attrs}>
+  return `<nav data-bn="breadcrumb" aria-label="Breadcrumb"${attrsSuffix(attrs)}>
   <ol data-bn="breadcrumb-list">${itemsHtml}</ol>
 </nav>`;
 }

--- a/packages/components/src/button.js
+++ b/packages/components/src/button.js
@@ -10,6 +10,8 @@
  *     Submit
  *   </button>
  */
+import { escapeAttr } from '@basenative/runtime/shared/escape';
+import { attrsSuffix } from './internal/attrs.js';
 
 /**
  * Returns the CSS class string for a button variant.
@@ -20,6 +22,15 @@ export function buttonVariants(variant = 'primary', size = 'default') {
 
 /**
  * Server-side render helper for a button element.
+ *
+ * @param {string} content  HTML slot: not escaped; pass trusted markup only
+ * @param {object} [options]
+ * @param {string} [options.variant='primary']
+ * @param {string} [options.size='default']
+ * @param {boolean} [options.disabled]
+ * @param {string} [options.type='button']
+ * @param {string} [options.attrs]  Raw attribute markup appended to the <button>; not escaped
+ * @returns {string}
  */
 export function renderButton(content, options = {}) {
   const variant = options.variant || 'primary';
@@ -28,5 +39,5 @@ export function renderButton(content, options = {}) {
   const type = options.type || 'button';
   const attrs = options.attrs || '';
 
-  return `<button data-bn="button" data-variant="${variant}" data-size="${size}" type="${type}"${disabled} ${attrs}>${content}</button>`;
+  return `<button data-bn="button" data-variant="${escapeAttr(variant)}" data-size="${escapeAttr(size)}" type="${escapeAttr(type)}"${disabled}${attrsSuffix(attrs)}>${content}</button>`;
 }

--- a/packages/components/src/calendar.js
+++ b/packages/components/src/calendar.js
@@ -12,36 +12,72 @@
  *   })
  *
  * Client-side: initCalendarDragDrop(container, { onDrop })
+ *
+ * All dates are interpreted in local time: a bare `YYYY-MM-DD` startDate is the
+ * local midnight of that day (not UTC), day columns are keyed by local date,
+ * and event rows are computed from local hours.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { nextId } from './ids.js';
+import { attrsSuffix } from './internal/attrs.js';
+import { bindDrag, clearDragState, readDragData } from './internal/drag.js';
+
+/**
+ * Parse a date value as local time. `YYYY-MM-DD` would be parsed as UTC by
+ * `new Date()`, which shifts the day in any non-UTC zone; build it locally.
+ */
+function parseLocalDate(value) {
+  if (value instanceof Date) return new Date(value.getTime());
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(value));
+  if (m) return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  return new Date(value);
+}
+
+/** Local-time `YYYY-MM-DD` for a Date. */
+function toLocalDateString(d) {
+  const pad = n => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
 
 /**
  * Format an ISO date string to a short day label.
  */
 function formatDay(dateStr) {
-  const d = new Date(dateStr);
+  const d = parseLocalDate(dateStr);
   const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
   return `${days[d.getDay()]} ${d.getMonth() + 1}/${d.getDate()}`;
 }
 
 /**
- * Get array of date strings (YYYY-MM-DD) for a week starting at startDate.
+ * Get array of date strings (YYYY-MM-DD, local) for a week starting at startDate.
  */
 function weekDates(startDate) {
   const dates = [];
-  const d = new Date(startDate);
+  const d = parseLocalDate(startDate);
   for (let i = 0; i < 7; i++) {
-    const iso = d.toISOString().split('T')[0];
-    dates.push(iso);
+    dates.push(toLocalDateString(d));
     d.setDate(d.getDate() + 1);
   }
   return dates;
 }
 
+function localHour(value) {
+  const d = new Date(value);
+  return d.getHours() + d.getMinutes() / 60;
+}
+
+function timeLabel(value) {
+  return new Date(value).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}
+
 /**
  * Server-side render a weekly calendar grid with event blocks.
  *
+ * Event title, assignee and emptyMessage are escaped text; ids, status and
+ * color are escaped attributes.
+ *
  * @param {object} options
- * @param {string} options.startDate      ISO date for the week start (Monday)
+ * @param {string} options.startDate      ISO date for the week start (Monday); local time
  * @param {Array}  options.events         Array of event objects
  * @param {string} options.events[].id
  * @param {string} options.events[].title
@@ -54,8 +90,8 @@ function weekDates(startDate) {
  * @param {number} [options.hours.start=7]
  * @param {number} [options.hours.end=19]
  * @param {string} [options.emptyMessage='No events']
- * @param {string} [options.id]
- * @param {string} [options.attrs]
+ * @param {string} [options.id]            Defaults to nextId('calendar')
+ * @param {string} [options.attrs]         Raw attribute markup appended to the wrapper; not escaped
  * @returns {string} HTML
  */
 export function renderCalendar(options = {}) {
@@ -64,7 +100,7 @@ export function renderCalendar(options = {}) {
     events = [],
     hours = {},
     emptyMessage = 'No events',
-    id = `bn-calendar-${Math.random().toString(36).slice(2)}`,
+    id = nextId('calendar'),
     attrs = '',
   } = options;
 
@@ -92,17 +128,17 @@ export function renderCalendar(options = {}) {
     const dayEvents = events.filter(e => e.start && e.start.startsWith(date));
 
     const eventBlocks = dayEvents.map(ev => {
-      const startHour = new Date(ev.start).getHours() + new Date(ev.start).getMinutes() / 60;
-      const endHour = new Date(ev.end).getHours() + new Date(ev.end).getMinutes() / 60;
+      const startHour = localHour(ev.start);
+      const endHour = localHour(ev.end);
       const topRow = Math.max(startHour - hourStart + 2, 2);
       const span = Math.max(endHour - startHour, 0.5);
-      const statusAttr = ev.status ? ` data-status="${ev.status}"` : '';
-      const colorStyle = ev.color ? ` --bn-calendar-event-color: ${ev.color};` : '';
+      const statusAttr = ev.status ? ` data-status="${escapeAttr(ev.status)}"` : '';
+      const colorStyle = ev.color ? ` --bn-calendar-event-color: ${escapeAttr(ev.color)};` : '';
 
-      return `<div data-bn="calendar-event" draggable="true" data-event-id="${ev.id}"${statusAttr} title="${ev.title}" style="grid-row: ${topRow} / span ${Math.ceil(span)};${colorStyle}">
-  <span data-bn="calendar-event-title">${ev.title}</span>
-  ${ev.assignee ? `<span data-bn="calendar-event-assignee">${ev.assignee}</span>` : ''}
-  <span data-bn="calendar-event-time">${new Date(ev.start).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })} – ${new Date(ev.end).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}</span>
+      return `<div data-bn="calendar-event" draggable="true" data-event-id="${escapeAttr(ev.id)}"${statusAttr} title="${escapeAttr(ev.title)}" style="grid-row: ${topRow} / span ${Math.ceil(span)};${colorStyle}">
+  <span data-bn="calendar-event-title">${escapeText(ev.title)}</span>
+  ${ev.assignee ? `<span data-bn="calendar-event-assignee">${escapeText(ev.assignee)}</span>` : ''}
+  <span data-bn="calendar-event-time">${timeLabel(ev.start)} – ${timeLabel(ev.end)}</span>
 </div>`;
     }).join('');
 
@@ -120,7 +156,7 @@ export function renderCalendar(options = {}) {
 </div>`;
   }).join('');
 
-  return `<div data-bn="calendar" id="${id}" ${attrs}>
+  return `<div data-bn="calendar" id="${escapeAttr(id)}"${attrsSuffix(attrs)}>
   <div data-bn="calendar-grid" style="--bn-calendar-hours: ${totalHours}; --bn-calendar-cols: 7;">
     <div data-bn="calendar-corner"></div>
     ${headerCells}
@@ -129,7 +165,7 @@ export function renderCalendar(options = {}) {
     </div>
     ${dayColumns}
   </div>
-  ${events.length === 0 ? `<div data-bn="calendar-empty">${emptyMessage}</div>` : ''}
+  ${events.length === 0 ? `<div data-bn="calendar-empty">${escapeText(emptyMessage)}</div>` : ''}
 </div>`;
 }
 
@@ -139,38 +175,41 @@ export function renderCalendar(options = {}) {
  *
  * @param {object} options
  * @param {string} options.id
- * @param {string} options.title
- * @param {string} [options.subtitle]
+ * @param {string} options.title      Escaped text
+ * @param {string} [options.subtitle] Escaped text
  * @param {string} [options.status]
- * @param {string} [options.attrs]
+ * @param {string} [options.attrs]    Raw attribute markup appended to the block; not escaped
  * @returns {string} HTML
  */
 export function renderPipelineBlock(options = {}) {
   const { id, title, subtitle, status, attrs = '' } = options;
-  const statusAttr = status ? ` data-status="${status}"` : '';
+  const statusAttr = status ? ` data-status="${escapeAttr(status)}"` : '';
 
-  return `<div data-bn="pipeline-block" draggable="true" data-block-id="${id}"${statusAttr} ${attrs}>
-  <span data-bn="pipeline-block-title">${title}</span>
-  ${subtitle ? `<span data-bn="pipeline-block-subtitle">${subtitle}</span>` : ''}
+  return `<div data-bn="pipeline-block" draggable="true" data-block-id="${escapeAttr(id)}"${statusAttr}${attrsSuffix(attrs)}>
+  <span data-bn="pipeline-block-title">${escapeText(title)}</span>
+  ${subtitle ? `<span data-bn="pipeline-block-subtitle">${escapeText(subtitle)}</span>` : ''}
 </div>`;
 }
 
 /**
  * Render a kanban-style pipeline view with draggable columns and cards.
  *
+ * Column titles, card title/subtitle/description and emptyMessage are escaped
+ * text; ids and status are escaped attributes.
+ *
  * @param {object} options
  * @param {Array} options.columns - Column definitions: [{ id: 'new', title: 'New Leads' }, ...]
  * @param {Array} options.cards - Card definitions: [{ id: 'c1', columnId: 'new', title: 'Acme Corp', ... }, ...]
- * @param {string} [options.id] - Container ID
+ * @param {string} [options.id] - Container ID; defaults to nextId('pipeline')
  * @param {string} [options.emptyMessage] - Message when no cards
- * @param {string} [options.attrs] - Additional attributes
+ * @param {string} [options.attrs] - Raw attribute markup appended to the wrapper; not escaped
  * @returns {string} HTML
  */
 export function renderPipeline(options = {}) {
   const {
     columns = [],
     cards = [],
-    id = `bn-pipeline-${Math.random().toString(36).slice(2)}`,
+    id = nextId('pipeline'),
     emptyMessage = 'No items',
     attrs = '',
   } = options;
@@ -178,23 +217,23 @@ export function renderPipeline(options = {}) {
   const columnElems = columns.map(col => {
     const colCards = cards.filter(c => c.columnId === col.id);
     const cardsHtml = colCards.map(card => {
-      const statusAttr = card.status ? ` data-status="${card.status}"` : '';
-      return `<article data-bn="pipeline-card" data-card-id="${card.id}" draggable="true"${statusAttr} title="${card.title}">
-  <div data-bn="pipeline-card-title">${card.title}</div>
-  ${card.subtitle ? `<div data-bn="pipeline-card-subtitle">${card.subtitle}</div>` : ''}
-  ${card.description ? `<div data-bn="pipeline-card-description">${card.description}</div>` : ''}
+      const statusAttr = card.status ? ` data-status="${escapeAttr(card.status)}"` : '';
+      return `<article data-bn="pipeline-card" data-card-id="${escapeAttr(card.id)}" draggable="true"${statusAttr} title="${escapeAttr(card.title)}">
+  <div data-bn="pipeline-card-title">${escapeText(card.title)}</div>
+  ${card.subtitle ? `<div data-bn="pipeline-card-subtitle">${escapeText(card.subtitle)}</div>` : ''}
+  ${card.description ? `<div data-bn="pipeline-card-description">${escapeText(card.description)}</div>` : ''}
 </article>`;
     }).join('');
 
-    return `<section data-bn="pipeline-column" data-column-id="${col.id}">
-  <header data-bn="pipeline-column-header">${col.title}</header>
+    return `<section data-bn="pipeline-column" data-column-id="${escapeAttr(col.id)}">
+  <header data-bn="pipeline-column-header">${escapeText(col.title)}</header>
   <div data-bn="pipeline-column-cards">
-    ${cardsHtml || `<div data-bn="pipeline-empty">${emptyMessage}</div>`}
+    ${cardsHtml || `<div data-bn="pipeline-empty">${escapeText(emptyMessage)}</div>`}
   </div>
 </section>`;
   }).join('');
 
-  return `<div data-bn="pipeline" id="${id}" ${attrs}>
+  return `<div data-bn="pipeline" id="${escapeAttr(id)}"${attrsSuffix(attrs)}>
   ${columnElems}
 </div>`;
 }
@@ -210,52 +249,52 @@ export function renderPipeline(options = {}) {
 export function initCalendarDragDrop(container, callbacks = {}) {
   const { onDrop } = callbacks;
 
-  function handleDragStart(e) {
-    const event = e.target.closest('[data-event-id]');
-    const block = e.target.closest('[data-block-id]');
-    if (event) {
-      e.dataTransfer.setData('text/plain', JSON.stringify({
-        type: 'event',
-        id: event.dataset.eventId,
-      }));
-      e.dataTransfer.effectAllowed = 'move';
-      event.setAttribute('data-dragging', '');
-    } else if (block) {
-      e.dataTransfer.setData('text/plain', JSON.stringify({
-        type: 'pipeline',
-        id: block.dataset.blockId,
-      }));
-      e.dataTransfer.effectAllowed = 'copy';
-      block.setAttribute('data-dragging', '');
-    }
-  }
+  return bindDrag(container, {
+    dragstart(e) {
+      const event = e.target.closest('[data-event-id]');
+      const block = e.target.closest('[data-block-id]');
+      if (event) {
+        e.dataTransfer.setData('text/plain', JSON.stringify({
+          type: 'event',
+          id: event.dataset.eventId,
+        }));
+        e.dataTransfer.effectAllowed = 'move';
+        event.setAttribute('data-dragging', '');
+      } else if (block) {
+        e.dataTransfer.setData('text/plain', JSON.stringify({
+          type: 'pipeline',
+          id: block.dataset.blockId,
+        }));
+        e.dataTransfer.effectAllowed = 'copy';
+        block.setAttribute('data-dragging', '');
+      }
+    },
 
-  function handleDragOver(e) {
-    const slot = e.target.closest('[data-bn="calendar-slot"]');
-    if (slot) {
+    dragover(e) {
+      const slot = e.target.closest('[data-bn="calendar-slot"]');
+      if (slot) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        slot.setAttribute('data-drop-target', '');
+      }
+    },
+
+    dragleave(e) {
+      const slot = e.target.closest('[data-bn="calendar-slot"]');
+      if (slot) {
+        slot.removeAttribute('data-drop-target');
+      }
+    },
+
+    drop(e) {
       e.preventDefault();
-      e.dataTransfer.dropEffect = 'move';
-      slot.setAttribute('data-drop-target', '');
-    }
-  }
+      const slot = e.target.closest('[data-bn="calendar-slot"]');
+      if (!slot) return;
 
-  function handleDragLeave(e) {
-    const slot = e.target.closest('[data-bn="calendar-slot"]');
-    if (slot) {
       slot.removeAttribute('data-drop-target');
-    }
-  }
 
-  function handleDrop(e) {
-    e.preventDefault();
-    const slot = e.target.closest('[data-bn="calendar-slot"]');
-    if (!slot) return;
-
-    slot.removeAttribute('data-drop-target');
-
-    try {
-      const data = JSON.parse(e.dataTransfer.getData('text/plain'));
-      if (onDrop) {
+      const data = readDragData(e);
+      if (data && onDrop) {
         onDrop({
           eventId: data.id,
           date: slot.dataset.date,
@@ -263,33 +302,12 @@ export function initCalendarDragDrop(container, callbacks = {}) {
           sourceType: data.type,
         });
       }
-    } catch { /* ignore malformed drag data */ }
-  }
-
-  function handleDragEnd(_e) {
-    container.querySelectorAll('[data-dragging]').forEach(el =>
-      el.removeAttribute('data-dragging')
-    );
-    container.querySelectorAll('[data-drop-target]').forEach(el =>
-      el.removeAttribute('data-drop-target')
-    );
-  }
-
-  container.addEventListener('dragstart', handleDragStart);
-  container.addEventListener('dragover', handleDragOver);
-  container.addEventListener('dragleave', handleDragLeave);
-  container.addEventListener('drop', handleDrop);
-  container.addEventListener('dragend', handleDragEnd);
-
-  return {
-    destroy() {
-      container.removeEventListener('dragstart', handleDragStart);
-      container.removeEventListener('dragover', handleDragOver);
-      container.removeEventListener('dragleave', handleDragLeave);
-      container.removeEventListener('drop', handleDrop);
-      container.removeEventListener('dragend', handleDragEnd);
     },
-  };
+
+    dragend() {
+      clearDragState(container);
+    },
+  });
 }
 
 /**
@@ -303,77 +321,56 @@ export function initCalendarDragDrop(container, callbacks = {}) {
 export function initPipelineDragDrop(container, callbacks = {}) {
   const { onCardMove } = callbacks;
 
-  function handleDragStart(e) {
-    const card = e.target.closest('[data-card-id]');
-    if (!card) return;
+  return bindDrag(container, {
+    dragstart(e) {
+      const card = e.target.closest('[data-card-id]');
+      if (!card) return;
 
-    e.dataTransfer.setData('text/plain', JSON.stringify({
-      type: 'pipeline-card',
-      cardId: card.dataset.cardId,
-    }));
-    e.dataTransfer.effectAllowed = 'move';
-    card.setAttribute('data-dragging', '');
-  }
+      e.dataTransfer.setData('text/plain', JSON.stringify({
+        type: 'pipeline-card',
+        cardId: card.dataset.cardId,
+      }));
+      e.dataTransfer.effectAllowed = 'move';
+      card.setAttribute('data-dragging', '');
+    },
 
-  function handleDragOver(e) {
-    const cardArea = e.target.closest('[data-bn="pipeline-column-cards"]');
-    if (cardArea) {
+    dragover(e) {
+      const cardArea = e.target.closest('[data-bn="pipeline-column-cards"]');
+      if (cardArea) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        cardArea.setAttribute('data-drop-target', '');
+      }
+    },
+
+    dragleave(e) {
+      if (!e.target.closest('[data-card-id]')) {
+        container.querySelectorAll('[data-drop-target]').forEach(el =>
+          el.removeAttribute('data-drop-target')
+        );
+      }
+    },
+
+    drop(e) {
       e.preventDefault();
-      e.dataTransfer.dropEffect = 'move';
-      cardArea.setAttribute('data-drop-target', '');
-    }
-  }
+      const cardArea = e.target.closest('[data-bn="pipeline-column-cards"]');
+      if (!cardArea) return;
 
-  function handleDragLeave(e) {
-    if (!e.target.closest('[data-card-id]')) {
-      container.querySelectorAll('[data-drop-target]').forEach(el =>
-        el.removeAttribute('data-drop-target')
-      );
-    }
-  }
+      cardArea.removeAttribute('data-drop-target');
 
-  function handleDrop(e) {
-    e.preventDefault();
-    const cardArea = e.target.closest('[data-bn="pipeline-column-cards"]');
-    if (!cardArea) return;
-
-    cardArea.removeAttribute('data-drop-target');
-
-    try {
-      const data = JSON.parse(e.dataTransfer.getData('text/plain'));
+      const data = readDragData(e);
       const targetColumn = cardArea.closest('[data-column-id]');
-      if (onCardMove && targetColumn) {
+      if (data && onCardMove && targetColumn) {
         onCardMove({
           cardId: data.cardId,
           targetColumnId: targetColumn.dataset.columnId,
           position: null,
         });
       }
-    } catch { /* ignore malformed drag data */ }
-  }
-
-  function handleDragEnd(_e) {
-    container.querySelectorAll('[data-dragging]').forEach(el =>
-      el.removeAttribute('data-dragging')
-    );
-    container.querySelectorAll('[data-drop-target]').forEach(el =>
-      el.removeAttribute('data-drop-target')
-    );
-  }
-
-  container.addEventListener('dragstart', handleDragStart);
-  container.addEventListener('dragover', handleDragOver);
-  container.addEventListener('dragleave', handleDragLeave);
-  container.addEventListener('drop', handleDrop);
-  container.addEventListener('dragend', handleDragEnd);
-
-  return {
-    destroy() {
-      container.removeEventListener('dragstart', handleDragStart);
-      container.removeEventListener('dragover', handleDragOver);
-      container.removeEventListener('dragleave', handleDragLeave);
-      container.removeEventListener('drop', handleDrop);
-      container.removeEventListener('dragend', handleDragEnd);
     },
-  };
+
+    dragend() {
+      clearDragState(container);
+    },
+  });
 }

--- a/packages/components/src/card.js
+++ b/packages/components/src/card.js
@@ -1,11 +1,22 @@
 /**
  * Card component — semantic <article> container.
  */
+import { escapeAttr } from '@basenative/runtime/shared/escape';
 
+/**
+ * Card component — semantic <article> container.
+ *
+ * @param {object} [options]
+ * @param {string} [options.header]  HTML slot: not escaped; pass trusted markup only
+ * @param {string} [options.body]    HTML slot: not escaped; pass trusted markup only
+ * @param {string} [options.footer]  HTML slot: not escaped; pass trusted markup only
+ * @param {string} [options.variant='default']
+ * @returns {string}
+ */
 export function renderCard(options = {}) {
   const { header = '', body = '', footer = '', variant = 'default' } = options;
 
-  let html = `<article data-bn="card" data-variant="${variant}">`;
+  let html = `<article data-bn="card" data-variant="${escapeAttr(variant)}">`;
   if (header) {
     html += `<header data-bn="card-header">${header}</header>`;
   }

--- a/packages/components/src/checkbox.js
+++ b/packages/components/src/checkbox.js
@@ -1,18 +1,28 @@
 /**
  * Checkbox component — native <input type="checkbox"> with label association.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { attrsSuffix } from './internal/attrs.js';
 
+/**
+ * Checkbox component — native <input type="checkbox"> with label association.
+ *
+ * @param {object} options
+ * @param {string} options.name
+ * @param {string} [options.label]   Escaped text
+ * @param {boolean} [options.checked]
+ * @param {boolean} [options.disabled]
+ * @param {string} [options.value]
+ * @param {string} [options.id]      Defaults to name
+ * @param {string} [options.attrs]   Raw attribute markup appended to the <label>; not escaped
+ * @returns {string}
+ */
 export function renderCheckbox(options = {}) {
   const { name, label, checked = false, disabled = false, value = '', attrs = '' } = options;
   const id = options.id || name;
   const checkedAttr = checked ? ' checked' : '';
   const disabledAttr = disabled ? ' disabled' : '';
   const valueAttr = value ? ` value="${escapeAttr(value)}"` : '';
-  const extra = attrs ? ' ' + attrs : '';
 
-  return `<label data-bn="checkbox-label"${extra}><input data-bn="checkbox" type="checkbox" id="${id}" name="${name}"${valueAttr}${checkedAttr}${disabledAttr} /><span>${label || ''}</span></label>`;
-}
-
-function escapeAttr(str) {
-  return String(str).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  return `<label data-bn="checkbox-label"${attrsSuffix(attrs)}><input data-bn="checkbox" type="checkbox" id="${escapeAttr(id)}" name="${escapeAttr(name)}"${valueAttr}${checkedAttr}${disabledAttr} /><span>${escapeText(label || '')}</span></label>`;
 }

--- a/packages/components/src/combobox.js
+++ b/packages/components/src/combobox.js
@@ -2,6 +2,27 @@
  * Combobox — searchable dropdown with keyboard navigation.
  * Uses native <input> + <datalist> pattern with progressive enhancement.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { nextId } from './ids.js';
+import { attrsSuffix } from './internal/attrs.js';
+import { normalizeItem } from './internal/items.js';
+
+/**
+ * Combobox — searchable dropdown with keyboard navigation, rendered as a native
+ * <input> + <datalist>. Attributes, label and option labels are escaped.
+ *
+ * @param {object} options
+ * @param {string} [options.name]
+ * @param {string} [options.label]   Escaped text
+ * @param {Array<string | {value: string, label: string}>} [options.items]
+ * @param {string} [options.placeholder]
+ * @param {boolean} [options.required]
+ * @param {boolean} [options.disabled]
+ * @param {string} [options.value]
+ * @param {string} [options.id]      Defaults to `bn-combobox-<name>`, or nextId() without a name
+ * @param {string} [options.attrs]   Raw attribute markup appended to the <input>; not escaped
+ * @returns {string}
+ */
 export function renderCombobox(options = {}) {
   const {
     name,
@@ -11,7 +32,7 @@ export function renderCombobox(options = {}) {
     required = false,
     disabled = false,
     value = '',
-    id = `bn-combobox-${name || Math.random().toString(36).slice(2)}`,
+    id = name ? `bn-combobox-${name}` : nextId('combobox'),
     attrs = '',
   } = options;
 
@@ -19,16 +40,15 @@ export function renderCombobox(options = {}) {
   const req = required ? ' required' : '';
   const dis = disabled ? ' disabled' : '';
   const optionsHtml = items
-    .map(item => {
-      const val = typeof item === 'string' ? item : item.value;
-      const text = typeof item === 'string' ? item : item.label;
-      return `<option value="${val}">${text}</option>`;
+    .map(raw => {
+      const item = normalizeItem(raw);
+      return `<option value="${escapeAttr(item.value)}">${escapeText(item.label)}</option>`;
     })
     .join('');
 
   return `<div data-bn="combobox">
-  ${label ? `<label for="${id}" data-bn="label">${label}</label>` : ''}
-  <input type="text" id="${id}" name="${name}" list="${listId}" value="${value}" placeholder="${placeholder}"${req}${dis} data-bn="combobox-input" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false" ${attrs}>
-  <datalist id="${listId}">${optionsHtml}</datalist>
+  ${label ? `<label for="${escapeAttr(id)}" data-bn="label">${escapeText(label)}</label>` : ''}
+  <input type="text" id="${escapeAttr(id)}" name="${escapeAttr(name)}" list="${escapeAttr(listId)}" value="${escapeAttr(value)}" placeholder="${escapeAttr(placeholder)}"${req}${dis} data-bn="combobox-input" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false"${attrsSuffix(attrs)}>
+  <datalist id="${escapeAttr(listId)}">${optionsHtml}</datalist>
 </div>`;
 }

--- a/packages/components/src/command-palette.js
+++ b/packages/components/src/command-palette.js
@@ -1,12 +1,28 @@
 /**
  * Command palette — Cmd+K style searchable command menu.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { nextId } from './ids.js';
+import { attrsSuffix } from './internal/attrs.js';
+
+/**
+ * Command palette — Cmd+K style searchable command menu in a native <dialog>.
+ *
+ * @param {object} [options]
+ * @param {Array<{label: string, action?: string, id?: string, group?: string, icon?: string, shortcut?: string}>} [options.commands]
+ *   label, group and shortcut are escaped text; action/id are escaped attributes; icon is an HTML slot: not escaped; pass trusted markup only
+ * @param {string} [options.placeholder]
+ * @param {boolean} [options.open]
+ * @param {string} [options.id]     Defaults to nextId('command')
+ * @param {string} [options.attrs]  Raw attribute markup appended to the <dialog>; not escaped
+ * @returns {string}
+ */
 export function renderCommandPalette(options = {}) {
   const {
     commands = [],
     placeholder = 'Type a command...',
     open = false,
-    id = `bn-command-${Math.random().toString(36).slice(2)}`,
+    id = nextId('command'),
     attrs = '',
   } = options;
 
@@ -22,19 +38,19 @@ export function renderCommandPalette(options = {}) {
     const itemsHtml = cmds
       .map(cmd => {
         const icon = cmd.icon ? `<span data-bn="command-icon">${cmd.icon}</span>` : '';
-        const shortcut = cmd.shortcut ? `<kbd data-bn="command-shortcut">${cmd.shortcut}</kbd>` : '';
-        return `<button data-bn="command-item" role="option" data-action="${cmd.action ?? cmd.id ?? ''}" type="button">${icon}<span data-bn="command-label">${cmd.label}</span>${shortcut}</button>`;
+        const shortcut = cmd.shortcut ? `<kbd data-bn="command-shortcut">${escapeText(cmd.shortcut)}</kbd>` : '';
+        return `<button data-bn="command-item" role="option" data-action="${escapeAttr(cmd.action ?? cmd.id ?? '')}" type="button">${icon}<span data-bn="command-label">${escapeText(cmd.label ?? '')}</span>${shortcut}</button>`;
       })
       .join('');
-    groupsHtml += `<div data-bn="command-group" role="group" aria-label="${groupName}">
-  <div data-bn="command-group-label">${groupName}</div>
+    groupsHtml += `<div data-bn="command-group" role="group" aria-label="${escapeAttr(groupName)}">
+  <div data-bn="command-group-label">${escapeText(groupName)}</div>
   ${itemsHtml}
 </div>`;
   }
 
-  return `<dialog data-bn="command-palette" id="${id}"${open ? ' open' : ''} ${attrs}>
+  return `<dialog data-bn="command-palette" id="${escapeAttr(id)}"${open ? ' open' : ''}${attrsSuffix(attrs)}>
   <div data-bn="command-header">
-    <input data-bn="command-input" type="text" placeholder="${placeholder}" role="combobox" aria-expanded="true" autocomplete="off" autofocus>
+    <input data-bn="command-input" type="text" placeholder="${escapeAttr(placeholder)}" role="combobox" aria-expanded="true" autocomplete="off" autofocus>
   </div>
   <div data-bn="command-list" role="listbox">${groupsHtml}</div>
   <div data-bn="command-footer">

--- a/packages/components/src/components.test.js
+++ b/packages/components/src/components.test.js
@@ -30,7 +30,33 @@ import { renderDataGrid } from './datagrid.js';
 import { renderTree, renderTreeGrid } from './tree.js';
 import { renderVirtualList } from './virtualizer.js';
 import { renderAvatar } from './avatar.js';
-import { renderCalendar, renderPipelineBlock, renderPipeline } from './calendar.js';
+import { renderCalendar, renderPipelineBlock, renderPipeline, initCalendarDragDrop, initPipelineDragDrop } from './calendar.js';
+import { renderLayoutGrid } from './layout-grid.js';
+import { createToaster, showToast, dismissToast } from './toast.js';
+import { nextId, resetIds } from './ids.js';
+import * as api from './index.js';
+import { bindDrag } from './internal/drag.js';
+import { normalizeItem } from './internal/items.js';
+import { describedBy, renderField } from './internal/field.js';
+import { attrsSuffix } from './internal/attrs.js';
+
+const XSS = '"><script>alert(1)</script>';
+
+function assertEscaped(html) {
+  assert.ok(!html.includes('<script>'), 'raw <script> leaked into markup');
+  assert.ok(!html.includes('"><script'), 'attribute breakout');
+  assert.ok(html.includes('&lt;script&gt;'), 'payload was not escaped');
+}
+
+function fakeContainer() {
+  const listeners = new Map();
+  return {
+    listeners,
+    addEventListener(type, fn) { listeners.set(type, fn); },
+    removeEventListener(type, fn) { if (listeners.get(type) === fn) listeners.delete(type); },
+    querySelectorAll() { return []; },
+  };
+}
 
 describe('Button', () => {
   it('renders a primary button', () => {
@@ -602,10 +628,9 @@ describe('Avatar — additional', () => {
 });
 
 describe('Badge — additional', () => {
-  it('escapes HTML in badge content', () => {
+  it('badge content is an HTML slot and renders markup', () => {
     const html = renderBadge('<b>bold</b>');
-    assert.ok(!html.includes('<b>'));
-    assert.ok(html.includes('&lt;b&gt;'));
+    assert.ok(html.includes('<b>bold</b>'));
   });
 
   it('renders default variant when none given', () => {
@@ -818,5 +843,1145 @@ describe('Pipeline', () => {
       cards: [{ id: 'c1', columnId: 'new', title: 'Lead', status: 'hot' }],
     });
     assert.ok(html.includes('data-status="hot"'));
+  });
+});
+
+describe('ids', () => {
+  it('nextId yields bn-<prefix>-<n> from a counter', () => {
+    resetIds();
+    assert.equal(nextId('dialog'), 'bn-dialog-1');
+    assert.equal(nextId('tabs'), 'bn-tabs-2');
+  });
+
+  it('resetIds restarts the counter', () => {
+    nextId('x');
+    resetIds();
+    assert.equal(nextId('x'), 'bn-x-1');
+  });
+
+  it('two renders after resetIds() produce identical markup', () => {
+    const page = () => [
+      renderDialog({ title: 'A' }),
+      renderTabs({ tabs: [{ id: 'a', label: 'A' }] }),
+      renderTree({ items: [{ label: 'root', children: [{ label: 'leaf' }] }] }),
+      renderAccordion({ items: [{ title: 'S' }] }),
+      renderDrawer({}),
+      renderTooltip({ content: 'c', trigger: 't' }),
+      renderDropdownMenu({ trigger: 'm', items: [] }),
+      renderCommandPalette({}),
+      renderCombobox({}),
+      renderMultiselect({}),
+      renderDataGrid({}),
+      renderTreeGrid({}),
+      renderVirtualList({}),
+      renderCalendar({ startDate: '2025-06-02' }),
+      renderPipeline({}),
+    ].join('');
+    resetIds();
+    const first = page();
+    resetIds();
+    const second = page();
+    assert.equal(first, second);
+    assert.ok(first.includes('id="bn-dialog-1"'));
+    assert.ok(!/[0-9a-z]{8,}/.test(first.match(/id="bn-[a-z]+-[^"]+"/)[0].slice(4, -1).replace(/bn-[a-z]+-/, '')));
+  });
+
+  it('every renderer honours an explicit id option', () => {
+    const renders = [
+      renderDialog({ id: 'custom' }),
+      renderDrawer({ id: 'custom' }),
+      renderTabs({ id: 'custom' }),
+      renderAccordion({ id: 'custom' }),
+      renderTooltip({ id: 'custom', content: '', trigger: '' }),
+      renderDropdownMenu({ id: 'custom', trigger: '' }),
+      renderCommandPalette({ id: 'custom' }),
+      renderCombobox({ id: 'custom', name: 'n' }),
+      renderMultiselect({ id: 'custom', name: 'n' }),
+      renderDataGrid({ id: 'custom' }),
+      renderTree({ id: 'custom' }),
+      renderTreeGrid({ id: 'custom' }),
+      renderVirtualList({ id: 'custom' }),
+      renderCalendar({ id: 'custom', startDate: '2025-06-02' }),
+      renderPipeline({ id: 'custom' }),
+      renderLayoutGrid({ id: 'custom' }),
+      renderInput({ id: 'custom', name: 'n' }),
+      renderTextarea({ id: 'custom', name: 'n' }),
+      renderSelect({ id: 'custom', name: 'n' }),
+      renderCheckbox({ id: 'custom', name: 'n' }),
+      renderToggle({ id: 'custom', name: 'n' }),
+    ];
+    for (const html of renders) {
+      assert.ok(html.includes('id="custom"'), html.slice(0, 80));
+      assert.ok(!/id="bn-/.test(html), 'generated id leaked despite explicit id');
+    }
+  });
+
+  it('is exported from the package index', () => {
+    assert.equal(typeof api.nextId, 'function');
+    assert.equal(typeof api.resetIds, 'function');
+  });
+});
+
+describe('internal helpers', () => {
+  it('attrsSuffix prefixes a space only when attrs is non-empty', () => {
+    assert.equal(attrsSuffix(''), '');
+    assert.equal(attrsSuffix(undefined), '');
+    assert.equal(attrsSuffix('data-x="1"'), ' data-x="1"');
+  });
+
+  it('normalizeItem treats a string as value and label', () => {
+    assert.deepEqual(normalizeItem('a'), { value: 'a', label: 'a', disabled: false });
+    assert.deepEqual(normalizeItem({ value: 'v', label: 'L', disabled: true }), { value: 'v', label: 'L', disabled: true });
+  });
+
+  it('describedBy lists help and error ids', () => {
+    assert.equal(describedBy('f', '', ''), '');
+    assert.equal(describedBy('f', 'h', ''), ' aria-describedby="f-help"');
+    assert.equal(describedBy('f', '', 'e'), ' aria-describedby="f-error"');
+    assert.equal(describedBy('f', 'h', 'e'), ' aria-describedby="f-help f-error"');
+  });
+
+  it('renderField escapes label, help and error', () => {
+    const html = renderField({ id: 'f', label: XSS, control: '<i></i>', helpText: XSS, error: XSS });
+    assertEscaped(html);
+    assert.ok(html.includes('<i></i>'));
+    assert.ok(html.includes('id="f-help"'));
+    assert.ok(html.includes('id="f-error"'));
+  });
+
+  it('bindDrag attaches only function handlers and destroy removes them', () => {
+    const el = fakeContainer();
+    const handle = bindDrag(el, { dragstart() {}, drop() {}, dragover: undefined });
+    assert.deepEqual([...el.listeners.keys()], ['dragstart', 'drop']);
+    handle.destroy();
+    assert.equal(el.listeners.size, 0);
+  });
+
+  it('no renderer leaks a stray space before the closing bracket', () => {
+    const renders = [
+      renderButton('x'),
+      renderDialog({}),
+      renderDrawer({}),
+      renderTabs({}),
+      renderAccordion({}),
+      renderBreadcrumb({}),
+      renderAvatar({}),
+      renderTooltip({}),
+      renderDropdownMenu({}),
+      renderCommandPalette({}),
+      renderCombobox({}),
+      renderMultiselect({}),
+      renderDataGrid({}),
+      renderTree({}),
+      renderTreeGrid({}),
+      renderVirtualList({}),
+      renderCalendar({ startDate: '2025-06-02' }),
+      renderPipelineBlock({ id: 'p', title: 't' }),
+      renderPipeline({}),
+    ];
+    for (const html of renders) {
+      assert.ok(!/" >/.test(html), html.slice(0, 80));
+    }
+  });
+});
+
+describe('Button — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderButton('Go');
+    assert.equal(html, '<button data-bn="button" data-variant="primary" data-size="default" type="button">Go</button>');
+  });
+
+  it('renders with all options', () => {
+    const html = renderButton('Go', { variant: 'ghost', size: 'sm', disabled: true, type: 'submit', attrs: 'data-x="1"' });
+    assert.ok(html.includes('data-variant="ghost"'));
+    assert.ok(html.includes('data-size="sm"'));
+    assert.ok(html.includes('type="submit" disabled data-x="1">'));
+  });
+
+  it('escapes attribute options', () => {
+    assertEscaped(renderButton('Go', { variant: XSS, size: XSS, type: XSS }));
+  });
+
+  it('content is an HTML slot', () => {
+    assert.ok(renderButton('<em>Go</em>').includes('<em>Go</em>'));
+  });
+});
+
+describe('Input — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderInput({ name: 'q' });
+    assert.ok(html.startsWith('<div data-bn="field"><input data-bn="input" type="text" id="q" name="q"'));
+    assert.ok(!html.includes('<label'));
+    assert.ok(!html.includes('aria-describedby'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderInput({
+      name: 'q', type: 'search', label: 'Q', placeholder: 'p', value: 'v', required: true, disabled: true,
+      helpText: 'h', error: 'e', id: 'qid', attrs: 'data-x="1"',
+    });
+    assert.ok(html.includes('<label for="qid">Q</label>'));
+    assert.ok(html.includes('type="search"'));
+    assert.ok(html.includes('value="v"'));
+    assert.ok(html.includes('placeholder="p"'));
+    assert.ok(html.includes(' required disabled'));
+    assert.ok(html.includes('aria-invalid="true" data-x="1" />'));
+  });
+
+  it('escapes attributes and text fields', () => {
+    assertEscaped(renderInput({ name: XSS, type: XSS, label: XSS, placeholder: XSS, value: XSS, helpText: XSS, error: XSS, id: XSS }));
+  });
+
+  it('help and error get distinct ids and aria-describedby lists both', () => {
+    const html = renderInput({ name: 'email', helpText: 'h', error: 'e' });
+    assert.ok(html.includes('id="email-help"'));
+    assert.ok(html.includes('id="email-error"'));
+    assert.ok(html.includes('aria-describedby="email-help email-error"'));
+  });
+
+  it('aria-describedby points only at the help span when there is no error', () => {
+    const html = renderInput({ name: 'email', helpText: 'h' });
+    assert.ok(html.includes('aria-describedby="email-help"'));
+    assert.ok(!html.includes('email-error'));
+  });
+
+  it('aria-describedby points only at the error span when there is no help', () => {
+    const html = renderInput({ name: 'email', error: 'e' });
+    assert.ok(html.includes('aria-describedby="email-error"'));
+    assert.ok(html.includes('role="alert"'));
+    assert.ok(!html.includes('email-help'));
+  });
+});
+
+describe('Textarea — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderTextarea({ name: 'bio' });
+    assert.ok(html.includes('<textarea data-bn="textarea" id="bio" name="bio" rows="3" placeholder=""></textarea>'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderTextarea({
+      name: 'bio', label: 'Bio', placeholder: 'p', value: 'v', rows: 8, required: true, disabled: true,
+      helpText: 'h', error: 'e', id: 'b', attrs: 'data-x="1"',
+    });
+    assert.ok(html.includes('<label for="b">Bio</label>'));
+    assert.ok(html.includes('rows="8"'));
+    assert.ok(html.includes(' required disabled aria-describedby="b-help b-error" aria-invalid="true" data-x="1">v</textarea>'));
+  });
+
+  it('escapes attributes and text fields', () => {
+    assertEscaped(renderTextarea({ name: XSS, label: XSS, placeholder: XSS, value: XSS, helpText: XSS, error: XSS }));
+  });
+
+  it('emits aria-describedby and an error id like renderInput', () => {
+    const html = renderTextarea({ name: 'bio', helpText: 'h', error: 'e' });
+    assert.ok(html.includes('aria-describedby="bio-help bio-error"'));
+    assert.ok(html.includes('<span data-bn="field-error" id="bio-error" role="alert">e</span>'));
+  });
+
+  it('escapes the value as text content', () => {
+    const html = renderTextarea({ name: 'bio', value: '</textarea><b>' });
+    assert.ok(html.includes('&lt;/textarea&gt;&lt;b&gt;'));
+  });
+});
+
+describe('Checkbox — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderCheckbox({ name: 'agree' });
+    assert.equal(html, '<label data-bn="checkbox-label"><input data-bn="checkbox" type="checkbox" id="agree" name="agree" /><span></span></label>');
+  });
+
+  it('renders with all options', () => {
+    const html = renderCheckbox({ name: 'agree', label: 'Yes', checked: true, disabled: true, value: 'on', id: 'a', attrs: 'data-x="1"' });
+    assert.ok(html.includes('<label data-bn="checkbox-label" data-x="1">'));
+    assert.ok(html.includes('id="a" name="agree" value="on" checked disabled'));
+    assert.ok(html.includes('<span>Yes</span>'));
+  });
+
+  it('escapes attributes and label, including < in the label', () => {
+    assertEscaped(renderCheckbox({ name: XSS, label: XSS, value: XSS, id: XSS }));
+    assert.ok(renderCheckbox({ name: 'a', label: '<b>' }).includes('&lt;b&gt;'));
+  });
+
+  it('associates the label by wrapping the input', () => {
+    const html = renderCheckbox({ name: 'a', label: 'L' });
+    assert.ok(/^<label[^>]*><input/.test(html));
+  });
+});
+
+describe('Radio — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderRadioGroup({ name: 'c' });
+    assert.equal(html, '<fieldset data-bn="radio-group"></fieldset>');
+  });
+
+  it('renders with all options', () => {
+    const html = renderRadioGroup({
+      name: 'c', label: 'Color', items: [{ value: 'r', label: 'Red', disabled: true }, 'blue'],
+      selected: 'blue', disabled: false, attrs: 'data-x="1"',
+    });
+    assert.ok(html.includes('<fieldset data-bn="radio-group" data-x="1">'));
+    assert.ok(html.includes('<legend>Color</legend>'));
+    assert.ok(html.includes('id="c-r" name="c" value="r" disabled'));
+    assert.ok(html.includes('id="c-blue" name="c" value="blue" checked'));
+  });
+
+  it('group disabled disables every item', () => {
+    const html = renderRadioGroup({ name: 'c', items: ['a', 'b'], disabled: true });
+    assert.equal((html.match(/ disabled/g) || []).length, 2);
+  });
+
+  it('escapes attributes and labels', () => {
+    assertEscaped(renderRadioGroup({ name: XSS, label: XSS, items: [{ value: XSS, label: XSS }] }));
+  });
+
+  it('string and object items render identically', () => {
+    const a = renderRadioGroup({ name: 'c', items: ['x'] });
+    const b = renderRadioGroup({ name: 'c', items: [{ value: 'x', label: 'x' }] });
+    assert.equal(a, b);
+  });
+});
+
+describe('Toggle — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderToggle({ name: 'dark' });
+    assert.equal(html, '<label data-bn="toggle-label"><input data-bn="toggle" type="checkbox" role="switch" id="dark" name="dark" /><span></span></label>');
+  });
+
+  it('renders with all options', () => {
+    const html = renderToggle({ name: 'dark', label: 'Dark', checked: true, disabled: true, id: 'd', attrs: 'data-x="1"' });
+    assert.ok(html.includes('<label data-bn="toggle-label" data-x="1">'));
+    assert.ok(html.includes('id="d" name="dark" checked disabled'));
+    assert.ok(html.includes('<span>Dark</span>'));
+  });
+
+  it('escapes attributes and label', () => {
+    assertEscaped(renderToggle({ name: XSS, label: XSS, id: XSS }));
+  });
+
+  it('keeps role="switch" on the checkbox', () => {
+    assert.ok(renderToggle({ name: 'x' }).includes('type="checkbox" role="switch"'));
+  });
+});
+
+describe('Select — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderSelect({ name: 's' });
+    assert.equal(html, '<div data-bn="field"><select data-bn="select" id="s" name="s"></select></div>');
+  });
+
+  it('renders with all options', () => {
+    const html = renderSelect({
+      name: 's', label: 'S', items: [{ value: 'a', label: 'A', disabled: true }, 'b'], selected: 'b', placeholder: 'Pick',
+      required: true, disabled: true, helpText: 'h', error: 'e', id: 'sid', attrs: 'data-x="1"',
+    });
+    assert.ok(html.includes('<label for="sid">S</label>'));
+    assert.ok(html.includes(' required disabled aria-describedby="sid-help sid-error" aria-invalid="true" data-x="1">'));
+    assert.ok(html.includes('<option value="" disabled>Pick</option>'));
+    assert.ok(html.includes('<option value="a" disabled>A</option>'));
+    assert.ok(html.includes('<option value="b" selected>b</option>'));
+    assert.ok(html.includes('id="sid-help"'));
+    assert.ok(html.includes('id="sid-error"'));
+  });
+
+  it('escapes attributes, options and text fields', () => {
+    assertEscaped(renderSelect({ name: XSS, label: XSS, placeholder: XSS, error: XSS, helpText: XSS, items: [{ value: XSS, label: XSS }] }));
+  });
+
+  it('error span has an id and aria-describedby references it', () => {
+    const html = renderSelect({ name: 's', error: 'Required' });
+    assert.ok(html.includes('aria-describedby="s-error"'));
+    assert.ok(html.includes('<span data-bn="field-error" id="s-error" role="alert">Required</span>'));
+  });
+
+  it('string and object items render identically', () => {
+    assert.equal(renderSelect({ name: 's', items: ['x'] }), renderSelect({ name: 's', items: [{ value: 'x', label: 'x' }] }));
+  });
+});
+
+describe('Alert — hardening', () => {
+  it('renders with minimal options', () => {
+    assert.equal(renderAlert('Hi'), '<div data-bn="alert" data-variant="info" role="status"><span data-bn="alert-content">Hi</span></div>');
+  });
+
+  it('escapes the variant attribute', () => {
+    assertEscaped(renderAlert('Hi', { variant: XSS }));
+  });
+
+  it('content is an HTML slot', () => {
+    assert.ok(renderAlert('<a href="/x">link</a>').includes('<a href="/x">link</a>'));
+  });
+});
+
+describe('Badge — hardening', () => {
+  it('renders with minimal options', () => {
+    assert.equal(renderBadge('New'), '<span data-bn="badge" data-variant="default">New</span>');
+  });
+
+  it('escapes the variant attribute', () => {
+    assertEscaped(renderBadge('New', { variant: XSS }));
+  });
+});
+
+describe('Card — hardening', () => {
+  it('renders with minimal options', () => {
+    assert.equal(renderCard(), '<article data-bn="card" data-variant="default"><div data-bn="card-body"></div></article>');
+  });
+
+  it('escapes the variant attribute', () => {
+    assertEscaped(renderCard({ variant: XSS }));
+  });
+
+  it('header, body and footer are HTML slots', () => {
+    const html = renderCard({ header: '<h2>H</h2>', body: '<p>B</p>', footer: '<button>F</button>' });
+    assert.ok(html.includes('<header data-bn="card-header"><h2>H</h2></header>'));
+    assert.ok(html.includes('<div data-bn="card-body"><p>B</p></div>'));
+    assert.ok(html.includes('<footer data-bn="card-footer"><button>F</button></footer>'));
+  });
+});
+
+describe('Table — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderTable();
+    assert.ok(html.includes('<td colspan="0" data-bn="table-empty">No data</td>'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderTable({
+      columns: [{ key: 'a', label: 'A', sortable: true }, { key: 'b', label: 'B' }],
+      rows: [{ a: 1, b: null }],
+      caption: 'Cap',
+      emptyMessage: 'none',
+    });
+    assert.ok(html.includes('<caption>Cap</caption>'));
+    assert.ok(html.includes('<th scope="col" data-sortable>A</th>'));
+    assert.ok(html.includes('<td>1</td><td></td>'));
+  });
+
+  it('escapes caption, labels, cells and empty message', () => {
+    assertEscaped(renderTable({ columns: [{ key: 'a', label: XSS }], rows: [{ a: XSS }], caption: XSS }));
+    assertEscaped(renderTable({ columns: [{ key: 'a', label: 'A' }], rows: [], emptyMessage: XSS }));
+  });
+
+  it('header cells carry scope="col"', () => {
+    assert.ok(renderTable({ columns: [{ key: 'a', label: 'A' }] }).includes('scope="col"'));
+  });
+});
+
+describe('Pagination — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderPagination({ totalPages: 2 });
+    assert.ok(html.includes('<a href="?page=1" aria-current="page" data-active>1</a>'));
+    assert.ok(html.includes('<a href="?page=2">2</a>'));
+  });
+
+  it('renders with all options and ellipses', () => {
+    const html = renderPagination({ currentPage: 10, totalPages: 20, baseUrl: '/p?x=1', window: 1 });
+    assert.ok(html.includes('href="/p?x=1&amp;page=9"'));
+    assert.ok(html.includes('data-bn="pagination-ellipsis"'));
+    assert.ok(html.includes('>20</a>'));
+  });
+
+  it('escapes the base url', () => {
+    assertEscaped(renderPagination({ currentPage: 1, totalPages: 3, baseUrl: XSS }));
+  });
+
+  it('labels prev/next links for assistive tech', () => {
+    const html = renderPagination({ currentPage: 2, totalPages: 3 });
+    assert.ok(html.includes('aria-label="Previous page"'));
+    assert.ok(html.includes('aria-label="Next page"'));
+    assert.ok(html.includes('aria-label="Pagination"'));
+  });
+});
+
+describe('Progress — hardening', () => {
+  it('renders with minimal options', () => {
+    assert.equal(renderProgress(), '<progress data-bn="progress" value="0" max="100">0%</progress>');
+  });
+
+  it('renders with all options', () => {
+    const html = renderProgress({ value: 1, max: 4, label: 'Upload', attrs: 'data-x="1"' });
+    assert.equal(html, '<progress data-bn="progress" value="1" max="4" aria-label="Upload" data-x="1">25%</progress>');
+  });
+
+  it('escapes the label and numeric attributes', () => {
+    assertEscaped(renderProgress({ label: XSS, value: XSS, max: 100 }));
+  });
+
+  it('guards division by zero when max is 0', () => {
+    const html = renderProgress({ value: 5, max: 0 });
+    assert.ok(html.includes('>0%</progress>'));
+    assert.ok(!html.includes('NaN'));
+  });
+});
+
+describe('Spinner — hardening', () => {
+  it('renders with minimal options', () => {
+    assert.equal(renderSpinner(), '<span data-bn="spinner" data-size="default" role="status" aria-label="Loading"><span aria-hidden="true"></span></span>');
+  });
+
+  it('escapes label and size', () => {
+    assertEscaped(renderSpinner({ label: XSS, size: XSS }));
+  });
+
+  it('has role="status" for live announcement', () => {
+    assert.ok(renderSpinner({ size: 'lg' }).includes('role="status"'));
+  });
+});
+
+describe('Skeleton — hardening', () => {
+  it('renders with minimal options', () => {
+    assert.equal(renderSkeleton(), '<div data-bn="skeleton" data-variant="text" style="width:100%;height:1rem" aria-hidden="true"></div>');
+  });
+
+  it('escapes width, height and variant', () => {
+    assertEscaped(renderSkeleton({ width: XSS, height: XSS, variant: XSS }));
+  });
+
+  it('count 1 and count 3 use the same markup per placeholder', () => {
+    const one = renderSkeleton({ width: '2rem' });
+    assert.equal(renderSkeleton({ width: '2rem', count: 3 }), one + one + one);
+  });
+});
+
+describe('Toast — hardening', () => {
+  it('escapes the container position', () => {
+    assertEscaped(renderToastContainer(XSS));
+  });
+
+  it('showToast returns a deterministic id and queues the toast', () => {
+    resetIds();
+    const toaster = createToaster({ duration: 0 });
+    const id = showToast(toaster, { message: 'hi', duration: 0 });
+    assert.equal(id, 'bn-toast-1');
+    assert.equal(toaster.toasts()[0].message, 'hi');
+  });
+
+  it('showToast honours an explicit id', () => {
+    const toaster = createToaster();
+    assert.equal(showToast(toaster, { id: 'mine', duration: 0 }), 'mine');
+  });
+
+  it('dismissToast removes a toast by id', () => {
+    const toaster = createToaster();
+    const id = showToast(toaster, { duration: 0 });
+    dismissToast(toaster, id);
+    assert.equal(toaster.toasts().length, 0);
+  });
+});
+
+describe('Dialog — hardening', () => {
+  it('renders with minimal options', () => {
+    resetIds();
+    const html = renderDialog();
+    assert.ok(html.startsWith('<dialog data-bn="dialog" data-size="default" id="bn-dialog-1" aria-modal="true" data-modal="true">'));
+    assert.ok(!html.includes('dialog-title'));
+    assert.ok(!html.includes('dialog-footer'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderDialog({ title: 'T', content: 'C', open: true, modal: false, closable: false, size: 'lg', footer: 'F', id: 'd', attrs: 'data-x="1"' });
+    assert.ok(html.includes('data-size="lg" id="d" open data-modal="false" data-x="1">'));
+    assert.ok(html.includes('<h2 data-bn="dialog-title">T</h2>'));
+    assert.ok(!html.includes('dialog-close'));
+    assert.ok(html.includes('<div data-bn="dialog-footer">F</div>'));
+  });
+
+  it('escapes title, size and id', () => {
+    assertEscaped(renderDialog({ title: XSS, size: XSS, id: XSS }));
+  });
+
+  it('content and footer are HTML slots', () => {
+    const html = renderDialog({ content: '<form></form>', footer: '<button>Ok</button>' });
+    assert.ok(html.includes('<div data-bn="dialog-body"><form></form></div>'));
+    assert.ok(html.includes('<button>Ok</button>'));
+  });
+
+  it('honours modal: true with aria-modal and modal: false without it', () => {
+    assert.ok(renderDialog({ modal: true }).includes('aria-modal="true" data-modal="true"'));
+    const nonModal = renderDialog({ modal: false });
+    assert.ok(nonModal.includes('data-modal="false"'));
+    assert.ok(!nonModal.includes('aria-modal'));
+  });
+
+  it('close button is labelled', () => {
+    assert.ok(renderDialog().includes('aria-label="Close" type="button"'));
+  });
+});
+
+describe('Drawer — hardening', () => {
+  it('renders closed with inert so the close button is not tabbable', () => {
+    resetIds();
+    const html = renderDrawer();
+    assert.ok(html.includes('id="bn-drawer-1" inert role="dialog"'));
+    assert.ok(!html.includes('data-open'));
+  });
+
+  it('renders open without inert', () => {
+    const html = renderDrawer({ open: true });
+    assert.ok(html.includes(' data-open role="dialog"'));
+    assert.ok(!html.includes('inert'));
+    assert.ok(html.includes('<div data-bn="drawer-overlay" data-open></div>'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderDrawer({ title: 'T', content: 'C', open: false, position: 'left', size: 'sm', closable: false, overlay: false, id: 'dr', attrs: 'data-x="1"' });
+    assert.ok(!html.includes('drawer-overlay'));
+    assert.ok(html.includes('data-position="left" data-size="sm" id="dr" inert role="dialog" aria-modal="true" data-x="1">'));
+    assert.ok(!html.includes('drawer-close'));
+    assert.ok(html.includes('<h2 data-bn="drawer-title">T</h2>'));
+  });
+
+  it('escapes title, position, size and id', () => {
+    assertEscaped(renderDrawer({ title: XSS, position: XSS, size: XSS, id: XSS }));
+  });
+
+  it('content is an HTML slot', () => {
+    assert.ok(renderDrawer({ content: '<nav>N</nav>' }).includes('<div data-bn="drawer-body"><nav>N</nav></div>'));
+  });
+});
+
+describe('Tabs — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderTabs({ id: 't' });
+    assert.ok(html.includes('<div data-bn="tabs" data-variant="default" id="t">'));
+    assert.ok(html.includes('<div data-bn="tab-list" role="tablist"></div>'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderTabs({ id: 't', variant: 'pills', activeTab: 'b', attrs: 'data-x="1"', tabs: [{ id: 'a', label: 'A', disabled: true }, { id: 'b', label: 'B', content: 'BB' }] });
+    assert.ok(html.includes('data-variant="pills" id="t" data-x="1">'));
+    assert.ok(html.includes('id="t-tab-a" aria-selected="false" aria-controls="t-panel-a" data-tab="a" disabled>A</button>'));
+    assert.ok(html.includes('id="t-panel-b" aria-labelledby="t-tab-b">BB</div>'));
+    assert.ok(html.includes('id="t-panel-a" aria-labelledby="t-tab-a" hidden></div>'));
+  });
+
+  it('escapes labels, ids and variant', () => {
+    assertEscaped(renderTabs({ id: XSS, variant: XSS, tabs: [{ id: XSS, label: XSS }] }));
+  });
+
+  it('tab buttons are type="button"', () => {
+    const html = renderTabs({ tabs: [{ id: 'a', label: 'A' }] });
+    assert.ok(html.includes('<button data-bn="tab" role="tab" type="button"'));
+  });
+
+  it('panel content is an HTML slot', () => {
+    assert.ok(renderTabs({ tabs: [{ id: 'a', label: 'A', content: '<p>x</p>' }] }).includes('<p>x</p>'));
+  });
+});
+
+describe('Accordion — hardening', () => {
+  it('renders with minimal options', () => {
+    assert.equal(renderAccordion({ id: 'acc' }), '<div data-bn="accordion" id="acc"></div>');
+  });
+
+  it('renders with all options', () => {
+    const html = renderAccordion({ id: 'acc', multiple: true, attrs: 'data-x="1"', items: [{ title: 'T', content: 'C', open: true }] });
+    assert.ok(html.includes('<div data-bn="accordion" id="acc" data-x="1">'));
+    assert.ok(html.includes('<details data-bn="accordion-item" open>'));
+    assert.ok(!html.includes('name="acc"'));
+  });
+
+  it('exclusive mode names every details after the accordion id', () => {
+    assert.ok(renderAccordion({ id: 'acc', items: [{ title: 'T' }] }).includes('<details data-bn="accordion-item" name="acc">'));
+  });
+
+  it('escapes titles and id', () => {
+    assertEscaped(renderAccordion({ id: XSS, items: [{ title: XSS }] }));
+  });
+
+  it('section content is an HTML slot', () => {
+    assert.ok(renderAccordion({ items: [{ title: 'T', content: '<ul><li>x</li></ul>' }] }).includes('<ul><li>x</li></ul>'));
+  });
+});
+
+describe('Breadcrumb — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderBreadcrumb();
+    assert.ok(html.startsWith('<nav data-bn="breadcrumb" aria-label="Breadcrumb">'));
+    assert.ok(html.includes('<ol data-bn="breadcrumb-list"></ol>'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderBreadcrumb({ separator: '<svg></svg>', attrs: 'data-x="1"', items: [{ label: 'Home', href: '/' }, { label: 'Here' }] });
+    assert.ok(html.includes('aria-label="Breadcrumb" data-x="1">'));
+    assert.ok(html.includes('<a href="/">Home</a><span data-bn="breadcrumb-separator" aria-hidden="true"><svg></svg></span>'));
+  });
+
+  it('escapes labels and hrefs', () => {
+    assertEscaped(renderBreadcrumb({ items: [{ label: XSS, href: XSS }, { label: XSS }] }));
+  });
+
+  it('marks the last item aria-current', () => {
+    assert.ok(renderBreadcrumb({ items: [{ label: 'X' }] }).includes('<li data-bn="breadcrumb-item" aria-current="page">X</li>'));
+  });
+});
+
+describe('Tooltip — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderTooltip({ id: 'tt' });
+    assert.ok(html.includes('popovertarget="tt" popovertargetaction="toggle"></span>'));
+    assert.ok(html.includes('<span data-bn="tooltip" id="tt" popover data-position="top" role="tooltip"></span>'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderTooltip({ id: 'tt', content: 'C', trigger: 'T', position: 'bottom', attrs: 'data-x="1"' });
+    assert.ok(html.includes('popovertargetaction="toggle" data-x="1">T</span>'));
+    assert.ok(html.includes('data-position="bottom" role="tooltip">C</span>'));
+  });
+
+  it('escapes content, id and position', () => {
+    assertEscaped(renderTooltip({ content: XSS, id: XSS, position: XSS, trigger: '' }));
+  });
+
+  it('trigger is an HTML slot', () => {
+    assert.ok(renderTooltip({ content: 'c', trigger: '<button>?</button>' }).includes('<button>?</button>'));
+  });
+});
+
+describe('DropdownMenu — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderDropdownMenu({ id: 'dd' });
+    assert.ok(html.includes('<button data-bn="dropdown-trigger" popovertarget="dd" type="button"></button>'));
+    assert.ok(html.includes('<div data-bn="dropdown-menu" id="dd" popover data-position="bottom-start" role="menu"></div>'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderDropdownMenu({
+      id: 'dd', trigger: 'Menu', position: 'top-end', attrs: 'data-x="1"',
+      items: [{ label: 'Edit', action: 'edit', icon: '<svg></svg>', shortcut: 'E', disabled: true }, { separator: true }],
+    });
+    assert.ok(html.includes('<div data-bn="dropdown" data-x="1">'));
+    assert.ok(html.includes('data-position="top-end"'));
+    assert.ok(html.includes('data-action="edit" aria-disabled="true" type="button"><span data-bn="dropdown-icon"><svg></svg></span>Edit<span data-bn="dropdown-shortcut">E</span></button>'));
+    assert.ok(html.includes('<hr data-bn="dropdown-separator" role="separator">'));
+  });
+
+  it('escapes labels, actions, shortcuts, id and position', () => {
+    assertEscaped(renderDropdownMenu({ id: XSS, position: XSS, trigger: '', items: [{ label: XSS, action: XSS, shortcut: XSS }] }));
+  });
+
+  it('trigger and icon are HTML slots', () => {
+    const html = renderDropdownMenu({ trigger: '<b>M</b>', items: [{ label: 'x', icon: '<i></i>' }] });
+    assert.ok(html.includes('<b>M</b>'));
+    assert.ok(html.includes('<i></i>'));
+  });
+
+  it('menu items have role="menuitem" and are type="button"', () => {
+    assert.ok(renderDropdownMenu({ trigger: '', items: [{ label: 'x' }] }).includes('role="menuitem" data-action="" type="button"'));
+  });
+});
+
+describe('CommandPalette — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderCommandPalette({ id: 'cp' });
+    assert.ok(html.startsWith('<dialog data-bn="command-palette" id="cp">'));
+    assert.ok(html.includes('<div data-bn="command-list" role="listbox"></div>'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderCommandPalette({
+      id: 'cp', open: true, placeholder: 'Go', attrs: 'data-x="1"',
+      commands: [{ label: 'Save', action: 'save', icon: '<svg></svg>', shortcut: 'S', group: 'File' }, { id: 'quit', label: 'Quit' }],
+    });
+    assert.ok(html.startsWith('<dialog data-bn="command-palette" id="cp" open data-x="1">'));
+    assert.ok(html.includes('placeholder="Go"'));
+    assert.ok(html.includes('role="group" aria-label="File"'));
+    assert.ok(html.includes('<div data-bn="command-group-label">Commands</div>'));
+    assert.ok(html.includes('data-action="quit"'));
+    assert.ok(html.includes('<span data-bn="command-icon"><svg></svg></span><span data-bn="command-label">Save</span><kbd data-bn="command-shortcut">S</kbd>'));
+  });
+
+  it('escapes labels, groups, shortcuts, actions, placeholder and id', () => {
+    assertEscaped(renderCommandPalette({ id: XSS, placeholder: XSS, commands: [{ label: XSS, action: XSS, shortcut: XSS, group: XSS }] }));
+  });
+
+  it('exposes combobox/listbox/option roles', () => {
+    const html = renderCommandPalette({ commands: [{ label: 'x' }] });
+    assert.ok(html.includes('role="combobox"'));
+    assert.ok(html.includes('role="listbox"'));
+    assert.ok(html.includes('role="option"'));
+  });
+});
+
+describe('Combobox — hardening', () => {
+  it('renders with minimal options', () => {
+    resetIds();
+    const html = renderCombobox();
+    assert.ok(html.includes('id="bn-combobox-1"'));
+    assert.ok(html.includes('<datalist id="bn-combobox-1-list"></datalist>'));
+  });
+
+  it('derives its id from the name', () => {
+    const html = renderCombobox({ name: 'fruit' });
+    assert.ok(html.includes('id="bn-combobox-fruit" name="fruit" list="bn-combobox-fruit-list"'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderCombobox({ name: 'f', label: 'Fruit', items: ['a', { value: 'b', label: 'B' }], placeholder: 'p', required: true, disabled: true, value: 'a', id: 'cb', attrs: 'data-x="1"' });
+    assert.ok(html.includes('<label for="cb" data-bn="label">Fruit</label>'));
+    assert.ok(html.includes('value="a" placeholder="p" required disabled'));
+    assert.ok(html.includes('aria-expanded="false" data-x="1">'));
+    assert.ok(html.includes('<option value="a">a</option><option value="b">B</option>'));
+  });
+
+  it('escapes attributes, label and options', () => {
+    assertEscaped(renderCombobox({ name: XSS, label: XSS, placeholder: XSS, value: XSS, id: XSS, items: [{ value: XSS, label: XSS }] }));
+  });
+
+  it('label is associated with the input', () => {
+    const html = renderCombobox({ name: 'f', label: 'L' });
+    assert.ok(html.includes('for="bn-combobox-f"'));
+    assert.ok(html.includes('role="combobox" aria-autocomplete="list"'));
+  });
+});
+
+describe('Multiselect — hardening', () => {
+  it('renders with minimal options', () => {
+    resetIds();
+    const html = renderMultiselect();
+    assert.ok(html.includes('<select id="bn-multiselect-1" name="undefined" multiple hidden></select>'));
+  });
+
+  it('derives its id from the name', () => {
+    assert.ok(renderMultiselect({ name: 'tags' }).includes('<select id="bn-multiselect-tags" name="tags"'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderMultiselect({ name: 't', label: 'Tags', items: ['a', { value: 'b', label: 'B' }], selected: ['b', 'zz'], placeholder: 'p', disabled: true, id: 'ms', attrs: 'data-x="1"' });
+    assert.ok(html.includes('<div data-bn="multiselect" data-disabled>'));
+    assert.ok(html.includes('<label for="ms" data-bn="label">Tags</label>'));
+    assert.ok(html.includes('<span data-bn="tag" data-value="b">B<button type="button" data-bn="tag-remove" aria-label="Remove B">&times;</button></span>'));
+    assert.ok(html.includes('data-value="zz">zz<'));
+    assert.ok(html.includes('placeholder="p" autocomplete="off" aria-label="Tags" data-x="1">'));
+    assert.ok(html.includes('<option value="b" selected>B</option>'));
+    assert.ok(html.includes('multiple hidden disabled>'));
+  });
+
+  it('escapes attributes, label, tags and options', () => {
+    assertEscaped(renderMultiselect({ name: XSS, label: XSS, placeholder: XSS, id: XSS, items: [{ value: XSS, label: XSS }], selected: [XSS] }));
+  });
+
+  it('search input falls back to a Search aria-label', () => {
+    assert.ok(renderMultiselect({ name: 't' }).includes('aria-label="Search"'));
+  });
+});
+
+describe('DataGrid — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderDataGrid({ id: 'g' });
+    assert.ok(html.includes('<div data-bn="datagrid" id="g">'));
+    assert.ok(html.includes('<td colspan="0" data-bn="datagrid-empty">No data</td>'));
+    assert.ok(html.includes('Showing 0–0 of 0'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderDataGrid({
+      id: 'g', attrs: 'data-x="1"', caption: 'People', page: 2, pageSize: 1, totalRows: 5, sortBy: 'n', sortDir: 'desc',
+      selectable: true, selectedRows: [7],
+      columns: [{ key: 'n', label: 'N', sortable: true, resizable: true, editable: true, width: '10rem' }],
+      rows: [{ id: 7, n: 'Ann' }],
+    });
+    assert.ok(html.includes('<div data-bn="datagrid" id="g" data-x="1">'));
+    assert.ok(html.includes('aria-label="People"'));
+    assert.ok(html.includes('<caption>People</caption>'));
+    assert.ok(html.includes('data-key="n" data-sortable data-sorted="desc" style="width:10rem" data-resizable scope="col">N ↓</th>'));
+    assert.ok(html.includes('<input type="checkbox" checked aria-label="Select row 7"'));
+    assert.ok(html.includes('contenteditable="true" data-editable>Ann</td>'));
+    assert.ok(html.includes('Showing 2–2 of 5'));
+  });
+
+  it('escapes labels, raw cell values, caption, empty message and ids', () => {
+    assertEscaped(renderDataGrid({ id: XSS, caption: XSS, columns: [{ key: XSS, label: XSS }], rows: [{ [XSS]: XSS, id: XSS }] }));
+    assertEscaped(renderDataGrid({ columns: [{ key: 'a', label: 'A' }], emptyMessage: XSS }));
+  });
+
+  it('column render() output is an HTML slot', () => {
+    const html = renderDataGrid({ columns: [{ key: 'a', label: 'A', render: v => `<b>${v}</b>` }], rows: [{ a: 'x' }] });
+    assert.ok(html.includes('<td data-bn="datagrid-td" data-key="a"><b>x</b></td>'));
+  });
+
+  it('scroll region is labelled and focusable', () => {
+    const html = renderDataGrid({ columns: [] });
+    assert.ok(html.includes('role="region" aria-label="Data grid" tabindex="0"'));
+    assert.ok(html.includes('role="grid"'));
+  });
+});
+
+describe('Tree — hardening', () => {
+  it('renders with minimal options', () => {
+    assert.equal(renderTree({ id: 't' }), '<ul data-bn="tree" id="t" role="tree"></ul>');
+  });
+
+  it('renders with all options', () => {
+    const html = renderTree({
+      id: 't', attrs: 'data-x="1"', selected: 'c', expanded: new Set(['p']),
+      items: [{ id: 'p', label: 'P', icon: '<svg></svg>', children: [{ id: 'c', label: 'C' }] }],
+    });
+    assert.ok(html.includes('<ul data-bn="tree" id="t" role="tree" data-x="1">'));
+    assert.ok(html.includes('role="treeitem" aria-expanded="true" aria-selected="false" data-node-id="p" data-level="0"'));
+    assert.ok(html.includes('aria-label="Collapse" type="button">▾</button><span data-bn="tree-icon"><svg></svg></span>'));
+    assert.ok(html.includes('<ul data-bn="tree-children" role="group"><li data-bn="tree-item" role="treeitem" aria-selected="true" data-node-id="c" data-level="1"><div data-bn="tree-item-content" data-selected>'));
+  });
+
+  it('escapes labels, node ids and tree id', () => {
+    assertEscaped(renderTree({ id: XSS, items: [{ id: XSS, label: XSS }] }));
+  });
+
+  it('leaf nodes omit aria-expanded; parents carry it', () => {
+    const html = renderTree({ items: [{ id: 'p', label: 'P', children: [{ id: 'c', label: 'C' }] }] });
+    assert.ok(!html.includes('aria-expanded="undefined"'));
+    assert.ok(html.includes('aria-expanded="false"'));
+    assert.ok(!renderTree({ items: [{ id: 'leaf', label: 'L' }] }).includes('aria-expanded'));
+  });
+
+  it('collapsed parents do not render their children', () => {
+    const html = renderTree({ items: [{ id: 'p', label: 'P', children: [{ id: 'c', label: 'Hidden' }] }] });
+    assert.ok(!html.includes('Hidden'));
+    assert.ok(html.includes('aria-label="Expand"'));
+  });
+});
+
+describe('TreeGrid — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderTreeGrid({ id: 'tg' });
+    assert.ok(html.startsWith('<table data-bn="treegrid" id="tg" role="treegrid">'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderTreeGrid({
+      id: 'tg', attrs: 'data-x="1"', expanded: new Set(['p']),
+      columns: [{ key: 'name', label: 'Name' }, { key: 'size', label: 'Size' }],
+      items: [{ id: 'p', name: 'Parent', size: 1, children: [{ id: 'c', name: 'Child', size: 2 }] }],
+    });
+    assert.ok(html.includes('role="treegrid" data-x="1">'));
+    assert.ok(html.includes('<th scope="col">Name</th><th scope="col">Size</th>'));
+    assert.ok(html.includes('data-node-id="p" aria-level="1" aria-expanded="true" role="row"><td><span data-level="0">▾ </span>Parent</td><td>1</td></tr>'));
+    assert.ok(html.includes('data-node-id="c" aria-level="2" role="row"><td><span data-level="1">    </span>Child</td><td>2</td></tr>'));
+  });
+
+  it('escapes column labels, cell values and ids', () => {
+    assertEscaped(renderTreeGrid({ id: XSS, columns: [{ key: 'n', label: XSS }], items: [{ id: XSS, n: XSS }] }));
+  });
+
+  it('leaf rows omit aria-expanded', () => {
+    const html = renderTreeGrid({ columns: [{ key: 'n', label: 'N' }], items: [{ n: 'leaf' }] });
+    assert.ok(!html.includes('aria-expanded'));
+    assert.ok(html.includes('aria-level="1"'));
+  });
+});
+
+describe('VirtualList — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderVirtualList({ id: 'v' });
+    assert.ok(html.includes('<div data-bn="virtualizer" id="v" style="height:400px;overflow:auto">'));
+    assert.ok(html.includes('data-item-height="40" data-total="0"'));
+  });
+
+  it('renders only the visible window plus overscan', () => {
+    const items = Array.from({ length: 100 }, (_, i) => `i${i}`);
+    const html = renderVirtualList({ items, itemHeight: 10, containerHeight: 50, overscan: 1 });
+    assert.equal((html.match(/data-bn="virtual-item"/g) || []).length, 7);
+  });
+
+  it('default renderItem escapes items', () => {
+    assertEscaped(renderVirtualList({ items: [XSS] }));
+    assertEscaped(renderVirtualList({ id: XSS }));
+  });
+
+  it('custom renderItem is an HTML slot', () => {
+    assert.ok(renderVirtualList({ items: ['a'], renderItem: i => `<li>${i}</li>` }).includes('<li>a</li>'));
+  });
+});
+
+describe('Avatar — hardening', () => {
+  it('with an image the wrapper has no role and the img carries alt', () => {
+    const html = renderAvatar({ src: '/a.png', name: 'Jane Doe' });
+    assert.equal(html, '<span data-bn="avatar" data-size="default" data-shape="circle"><img src="/a.png" alt="Jane Doe" data-bn="avatar-img"></span>');
+    assert.ok(!html.includes('role="img"'));
+  });
+
+  it('without an image the wrapper is role="img" with an aria-label', () => {
+    const html = renderAvatar({ name: 'Jane Doe' });
+    assert.ok(html.includes('role="img" aria-label="Jane Doe"'));
+    assert.ok(html.includes('<span data-bn="avatar-initials">JD</span>'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderAvatar({ src: '/a.png', alt: 'Alt', name: 'N', size: 'lg', shape: 'square', attrs: 'data-x="1"' });
+    assert.ok(html.includes('data-size="lg" data-shape="square" data-x="1"><img src="/a.png" alt="Alt"'));
+  });
+
+  it('escapes src, alt, name, size and shape', () => {
+    assertEscaped(renderAvatar({ src: XSS, alt: XSS, size: XSS, shape: XSS }));
+    assertEscaped(renderAvatar({ name: XSS, size: XSS }));
+  });
+
+  it('falls back to an Avatar label', () => {
+    assert.ok(renderAvatar().includes('aria-label="Avatar"'));
+  });
+});
+
+describe('Calendar — hardening', () => {
+  it('escapes event title, assignee, ids, status, color and empty message', () => {
+    assertEscaped(renderCalendar({
+      id: XSS, startDate: '2025-06-02',
+      events: [{ id: XSS, title: XSS, assignee: XSS, status: XSS, color: XSS, start: '2025-06-02T09:00', end: '2025-06-02T10:00' }],
+    }));
+    assertEscaped(renderCalendar({ startDate: '2025-06-02', emptyMessage: XSS }));
+  });
+
+  it('interprets a date-only startDate as local midnight in every timezone', () => {
+    const html = renderCalendar({ startDate: '2025-06-02T00:00' });
+    assert.ok(html.includes('data-date="2025-06-02">Mon 6/2</div>'));
+    assert.ok(html.includes('data-date="2025-06-08">Sun 6/8</div>'));
+    assert.equal(renderCalendar({ startDate: '2025-06-02', id: 'c' }), renderCalendar({ startDate: '2025-06-02T00:00', id: 'c' }));
+  });
+
+  it('places an event that crosses midnight in the column of its local start day', () => {
+    const html = renderCalendar({
+      startDate: '2025-06-02',
+      hours: { start: 0, end: 24 },
+      events: [{ id: 'late', title: 'Late', start: '2025-06-02T23:30', end: '2025-06-03T00:30' }],
+    });
+    const monday = html.slice(html.indexOf('data-bn="calendar-day-column" data-date="2025-06-02"'), html.indexOf('data-bn="calendar-day-column" data-date="2025-06-03"'));
+    assert.ok(monday.includes('data-event-id="late"'));
+    assert.ok(monday.includes('grid-row: 25.5 / span 1'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderCalendar({
+      id: 'cal', attrs: 'data-x="1"', startDate: '2025-06-02', hours: { start: 8, end: 10 }, emptyMessage: 'none',
+      events: [{ id: 'e', title: 'T', start: '2025-06-02T08:00', end: '2025-06-02T09:00', status: 'done', color: 'red', assignee: 'Ann' }],
+    });
+    assert.ok(html.includes('<div data-bn="calendar" id="cal" data-x="1">'));
+    assert.ok(html.includes('--bn-calendar-hours: 2;'));
+    assert.ok(html.includes('data-status="done" title="T" style="grid-row: 2 / span 1; --bn-calendar-event-color: red;"'));
+    assert.ok(html.includes('<span data-bn="calendar-event-assignee">Ann</span>'));
+    assert.ok(!html.includes('calendar-empty'));
+  });
+
+  it('uses a deterministic id', () => {
+    resetIds();
+    assert.ok(renderCalendar({ startDate: '2025-06-02' }).includes('id="bn-calendar-1"'));
+  });
+});
+
+describe('PipelineBlock — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderPipelineBlock({ id: 'b', title: 'T' });
+    assert.ok(html.startsWith('<div data-bn="pipeline-block" draggable="true" data-block-id="b">'));
+    assert.ok(!html.includes('subtitle'));
+  });
+
+  it('renders with all options without a stray space', () => {
+    const html = renderPipelineBlock({ id: 'b', title: 'T', subtitle: 'S', status: 'hot', attrs: 'data-x="1"' });
+    assert.ok(html.startsWith('<div data-bn="pipeline-block" draggable="true" data-block-id="b" data-status="hot" data-x="1">'));
+    assert.ok(html.includes('<span data-bn="pipeline-block-subtitle">S</span>'));
+  });
+
+  it('escapes id, title, subtitle and status', () => {
+    assertEscaped(renderPipelineBlock({ id: XSS, title: XSS, subtitle: XSS, status: XSS }));
+  });
+});
+
+describe('Pipeline — hardening', () => {
+  it('renders with minimal options', () => {
+    resetIds();
+    assert.ok(renderPipeline().startsWith('<div data-bn="pipeline" id="bn-pipeline-1">'));
+  });
+
+  it('escapes column and card fields', () => {
+    assertEscaped(renderPipeline({
+      id: XSS,
+      columns: [{ id: XSS, title: XSS }],
+      cards: [{ id: XSS, columnId: XSS, title: XSS, subtitle: XSS, description: XSS, status: XSS }],
+    }));
+    assertEscaped(renderPipeline({ columns: [{ id: 'a', title: 'A' }], emptyMessage: XSS }));
+  });
+
+  it('cards are draggable articles titled for hover', () => {
+    const html = renderPipeline({ columns: [{ id: 'a', title: 'A' }], cards: [{ id: 'c', columnId: 'a', title: 'Card' }] });
+    assert.ok(html.includes('<article data-bn="pipeline-card" data-card-id="c" draggable="true" title="Card">'));
+  });
+});
+
+describe('Drag and drop init', () => {
+  it('initCalendarDragDrop binds the five drag events and destroy unbinds them', () => {
+    const el = fakeContainer();
+    const handle = initCalendarDragDrop(el, {});
+    assert.deepEqual([...el.listeners.keys()].sort(), ['dragend', 'dragleave', 'dragover', 'dragstart', 'drop']);
+    handle.destroy();
+    assert.equal(el.listeners.size, 0);
+  });
+
+  it('initPipelineDragDrop binds the five drag events and destroy unbinds them', () => {
+    const el = fakeContainer();
+    const handle = initPipelineDragDrop(el, {});
+    assert.deepEqual([...el.listeners.keys()].sort(), ['dragend', 'dragleave', 'dragover', 'dragstart', 'drop']);
+    handle.destroy();
+    assert.equal(el.listeners.size, 0);
+  });
+
+  it('calendar drop reports the slot date/hour and drag payload', () => {
+    const el = fakeContainer();
+    const dropped = [];
+    initCalendarDragDrop(el, { onDrop: d => dropped.push(d) });
+    const slot = { removeAttribute() {}, dataset: { date: '2025-06-02', hour: '9' } };
+    el.listeners.get('drop')({
+      preventDefault() {},
+      target: { closest: sel => (sel === '[data-bn="calendar-slot"]' ? slot : null) },
+      dataTransfer: { getData: () => JSON.stringify({ type: 'event', id: 'e1' }) },
+    });
+    assert.deepEqual(dropped, [{ eventId: 'e1', date: '2025-06-02', hour: 9, sourceType: 'event' }]);
+  });
+
+  it('malformed drag data is ignored', () => {
+    const el = fakeContainer();
+    let calls = 0;
+    initPipelineDragDrop(el, { onCardMove: () => { calls += 1; } });
+    const cardArea = { removeAttribute() {}, closest: () => ({ dataset: { columnId: 'new' } }) };
+    el.listeners.get('drop')({
+      preventDefault() {},
+      target: { closest: sel => (sel === '[data-bn="pipeline-column-cards"]' ? cardArea : null) },
+      dataTransfer: { getData: () => 'not json' },
+    });
+    assert.equal(calls, 0);
+  });
+
+  it('pipeline drop reports card and target column', () => {
+    const el = fakeContainer();
+    const moves = [];
+    initPipelineDragDrop(el, { onCardMove: m => moves.push(m) });
+    const cardArea = { removeAttribute() {}, closest: () => ({ dataset: { columnId: 'won' } }) };
+    el.listeners.get('drop')({
+      preventDefault() {},
+      target: { closest: sel => (sel === '[data-bn="pipeline-column-cards"]' ? cardArea : null) },
+      dataTransfer: { getData: () => JSON.stringify({ type: 'pipeline-card', cardId: 'c1' }) },
+    });
+    assert.deepEqual(moves, [{ cardId: 'c1', targetColumnId: 'won', position: null }]);
+  });
+});
+
+describe('LayoutGrid — hardening', () => {
+  it('renders with minimal options', () => {
+    const html = renderLayoutGrid();
+    assert.ok(html.startsWith('<div data-bn="layout-grid" id="layout-grid" style="display:grid;grid-template-columns:repeat(12,1fr);gap:1rem">'));
+  });
+
+  it('renders with all options', () => {
+    const html = renderLayoutGrid({ id: 'g', columns: 4, gap: '2px', minCellHeight: '1rem', editable: true, cells: [{ id: 'c1', label: 'L', colSpan: 2, rowSpan: 3 }, { content: '<b>x</b>' }, {}] });
+    assert.ok(html.includes('repeat(4,1fr);gap:2px'));
+    assert.ok(html.includes('data-cell-id="c1" style="grid-column: span 2; grid-row: span 3; min-height: 1rem" draggable="true">L</div>'));
+    assert.ok(html.includes('data-cell-id="cell-1"'));
+    assert.ok(html.includes('>Cell 3</div>'));
+  });
+
+  it('escapes id, cell ids, labels and style values', () => {
+    assertEscaped(renderLayoutGrid({ id: XSS, gap: XSS, columns: XSS, minCellHeight: XSS, cells: [{ id: XSS, label: XSS }] }));
+  });
+
+  it('cell content is an HTML slot', () => {
+    assert.ok(renderLayoutGrid({ cells: [{ content: '<b>x</b>' }] }).includes('><b>x</b></div>'));
   });
 });

--- a/packages/components/src/datagrid.js
+++ b/packages/components/src/datagrid.js
@@ -1,6 +1,33 @@
 /**
  * Data grid — sortable, filterable, paginated table with virtual scrolling support.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { nextId } from './ids.js';
+import { attrsSuffix } from './internal/attrs.js';
+
+/**
+ * Data grid — sortable, filterable, paginated table with virtual scrolling support.
+ *
+ * Column labels, raw cell values, caption and emptyMessage are escaped text.
+ * A column's `render(value, row)` result is an HTML slot: not escaped; return
+ * trusted markup only.
+ *
+ * @param {object} [options]
+ * @param {Array<{key: string, label: string, sortable?: boolean, resizable?: boolean, editable?: boolean, width?: string, render?: (value: unknown, row: object) => string}>} [options.columns]
+ * @param {Array<object>} [options.rows]
+ * @param {string} [options.sortBy]
+ * @param {'asc'|'desc'} [options.sortDir='asc']
+ * @param {number} [options.page=1]
+ * @param {number} [options.pageSize=50]
+ * @param {number} [options.totalRows]
+ * @param {boolean} [options.selectable]
+ * @param {Array<string|number>} [options.selectedRows]
+ * @param {string} [options.emptyMessage='No data']
+ * @param {string} [options.caption]
+ * @param {string} [options.id]     Defaults to nextId('datagrid')
+ * @param {string} [options.attrs]  Raw attribute markup appended to the wrapper; not escaped
+ * @returns {string}
+ */
 export function renderDataGrid(options = {}) {
   const {
     columns = [],
@@ -14,7 +41,7 @@ export function renderDataGrid(options = {}) {
     selectedRows = [],
     emptyMessage = 'No data',
     caption,
-    id = `bn-datagrid-${Math.random().toString(36).slice(2)}`,
+    id = nextId('datagrid'),
     attrs = '',
   } = options;
 
@@ -23,10 +50,10 @@ export function renderDataGrid(options = {}) {
 
   const headerCells = columns.map(col => {
     const sortable = col.sortable ? ' data-sortable' : '';
-    const sorted = sortBy === col.key ? ` data-sorted="${sortDir}"` : '';
-    const width = col.width ? ` style="width:${col.width}"` : '';
+    const sorted = sortBy === col.key ? ` data-sorted="${escapeAttr(sortDir)}"` : '';
+    const width = col.width ? ` style="width:${escapeAttr(col.width)}"` : '';
     const resizable = col.resizable ? ' data-resizable' : '';
-    return `<th data-bn="datagrid-th" data-key="${col.key}"${sortable}${sorted}${width}${resizable} scope="col">${col.label}${sortBy === col.key ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''}</th>`;
+    return `<th data-bn="datagrid-th" data-key="${escapeAttr(col.key)}"${sortable}${sorted}${width}${resizable} scope="col">${escapeText(col.label ?? '')}${sortBy === col.key ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''}</th>`;
   }).join('');
 
   const selectAllHeader = selectable
@@ -36,24 +63,24 @@ export function renderDataGrid(options = {}) {
   const bodyRows = rows.map((row, i) => {
     const rowId = row.id ?? i;
     const cells = columns.map(col => {
-      const value = col.render ? col.render(row[col.key], row) : (row[col.key] ?? '');
+      const value = col.render ? col.render(row[col.key], row) : escapeText(row[col.key] ?? '');
       const editable = col.editable ? ' contenteditable="true" data-editable' : '';
-      return `<td data-bn="datagrid-td" data-key="${col.key}"${editable}>${value}</td>`;
+      return `<td data-bn="datagrid-td" data-key="${escapeAttr(col.key)}"${editable}>${value}</td>`;
     }).join('');
     const selectCell = selectable
-      ? `<td data-bn="datagrid-td-select"><input type="checkbox" ${selectedSet.has(rowId) ? 'checked ' : ''}aria-label="Select row ${rowId}" data-bn="datagrid-row-select" data-row-id="${rowId}"></td>`
+      ? `<td data-bn="datagrid-td-select"><input type="checkbox" ${selectedSet.has(rowId) ? 'checked ' : ''}aria-label="Select row ${escapeAttr(rowId)}" data-bn="datagrid-row-select" data-row-id="${escapeAttr(rowId)}"></td>`
       : '';
-    return `<tr data-bn="datagrid-row" data-row-id="${rowId}">${selectCell}${cells}</tr>`;
+    return `<tr data-bn="datagrid-row" data-row-id="${escapeAttr(rowId)}">${selectCell}${cells}</tr>`;
   }).join('');
 
   const emptyRow = rows.length === 0
-    ? `<tr><td colspan="${columns.length + (selectable ? 1 : 0)}" data-bn="datagrid-empty">${emptyMessage}</td></tr>`
+    ? `<tr><td colspan="${columns.length + (selectable ? 1 : 0)}" data-bn="datagrid-empty">${escapeText(emptyMessage)}</td></tr>`
     : '';
 
-  return `<div data-bn="datagrid" id="${id}" ${attrs}>
-  <div data-bn="datagrid-scroll" role="region" aria-label="${caption || 'Data grid'}" tabindex="0">
+  return `<div data-bn="datagrid" id="${escapeAttr(id)}"${attrsSuffix(attrs)}>
+  <div data-bn="datagrid-scroll" role="region" aria-label="${escapeAttr(caption || 'Data grid')}" tabindex="0">
     <table data-bn="datagrid-table" role="grid">
-      ${caption ? `<caption>${caption}</caption>` : ''}
+      ${caption ? `<caption>${escapeText(caption)}</caption>` : ''}
       <thead><tr>${selectAllHeader}${headerCells}</tr></thead>
       <tbody>${bodyRows || emptyRow}</tbody>
     </table>

--- a/packages/components/src/dialog.js
+++ b/packages/components/src/dialog.js
@@ -1,27 +1,51 @@
 /**
  * Dialog — modal/non-modal dialog using native <dialog> element.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { nextId } from './ids.js';
+import { attrsSuffix } from './internal/attrs.js';
+
+/**
+ * Dialog — modal/non-modal dialog using native <dialog> element.
+ *
+ * `modal` selects the semantics the client should apply: a modal dialog is
+ * rendered with aria-modal="true" and data-modal="true" (open it with
+ * showModal()); a non-modal one gets data-modal="false" (open it with show()).
+ *
+ * @param {object} [options]
+ * @param {string} [options.title]    Escaped text
+ * @param {string} [options.content]  HTML slot: not escaped; pass trusted markup only
+ * @param {boolean} [options.open]
+ * @param {boolean} [options.modal=true]
+ * @param {boolean} [options.closable=true]
+ * @param {string} [options.size='default']
+ * @param {string} [options.footer]   HTML slot: not escaped; pass trusted markup only
+ * @param {string} [options.id]       Defaults to nextId('dialog')
+ * @param {string} [options.attrs]    Raw attribute markup appended to the <dialog>; not escaped
+ * @returns {string}
+ */
 export function renderDialog(options = {}) {
   const {
     title,
     content = '',
     open = false,
-    modal: _modal = true,
+    modal = true,
     closable = true,
     size = 'default',
     footer = '',
-    id = `bn-dialog-${Math.random().toString(36).slice(2)}`,
+    id = nextId('dialog'),
     attrs = '',
   } = options;
 
   const openAttr = open ? ' open' : '';
+  const modalAttrs = modal ? ' aria-modal="true" data-modal="true"' : ' data-modal="false"';
   const closeBtn = closable
     ? `<button data-bn="dialog-close" aria-label="Close" type="button">&times;</button>`
     : '';
 
-  return `<dialog data-bn="dialog" data-size="${size}" id="${id}"${openAttr} ${attrs}>
+  return `<dialog data-bn="dialog" data-size="${escapeAttr(size)}" id="${escapeAttr(id)}"${openAttr}${modalAttrs}${attrsSuffix(attrs)}>
   <div data-bn="dialog-header">
-    ${title ? `<h2 data-bn="dialog-title">${title}</h2>` : ''}
+    ${title ? `<h2 data-bn="dialog-title">${escapeText(title)}</h2>` : ''}
     ${closeBtn}
   </div>
   <div data-bn="dialog-body">${content}</div>

--- a/packages/components/src/drawer.js
+++ b/packages/components/src/drawer.js
@@ -1,6 +1,29 @@
 /**
  * Drawer — side panel that slides in from the edge.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { nextId } from './ids.js';
+import { attrsSuffix } from './internal/attrs.js';
+
+/**
+ * Drawer — side panel that slides in from the edge.
+ *
+ * A closed drawer is rendered `inert`, so its close button and content are
+ * neither tabbable nor exposed to assistive technology while it is off-screen;
+ * the client removes `inert` when it adds `data-open`.
+ *
+ * @param {object} [options]
+ * @param {string} [options.title]    Escaped text
+ * @param {string} [options.content]  HTML slot: not escaped; pass trusted markup only
+ * @param {boolean} [options.open]
+ * @param {string} [options.position='right']
+ * @param {string} [options.size='default']
+ * @param {boolean} [options.closable=true]
+ * @param {boolean} [options.overlay=true]
+ * @param {string} [options.id]       Defaults to nextId('drawer')
+ * @param {string} [options.attrs]    Raw attribute markup appended to the <aside>; not escaped
+ * @returns {string}
+ */
 export function renderDrawer(options = {}) {
   const {
     title,
@@ -10,7 +33,7 @@ export function renderDrawer(options = {}) {
     size = 'default',
     closable = true,
     overlay = true,
-    id = `bn-drawer-${Math.random().toString(36).slice(2)}`,
+    id = nextId('drawer'),
     attrs = '',
   } = options;
 
@@ -18,10 +41,11 @@ export function renderDrawer(options = {}) {
     ? `<button data-bn="drawer-close" aria-label="Close" type="button">&times;</button>`
     : '';
   const overlayHtml = overlay ? `<div data-bn="drawer-overlay"${open ? ' data-open' : ''}></div>` : '';
+  const stateAttrs = open ? ' data-open' : ' inert';
 
-  return `${overlayHtml}<aside data-bn="drawer" data-position="${position}" data-size="${size}" id="${id}"${open ? ' data-open' : ''} role="dialog" aria-modal="true" ${attrs}>
+  return `${overlayHtml}<aside data-bn="drawer" data-position="${escapeAttr(position)}" data-size="${escapeAttr(size)}" id="${escapeAttr(id)}"${stateAttrs} role="dialog" aria-modal="true"${attrsSuffix(attrs)}>
   <div data-bn="drawer-header">
-    ${title ? `<h2 data-bn="drawer-title">${title}</h2>` : ''}
+    ${title ? `<h2 data-bn="drawer-title">${escapeText(title)}</h2>` : ''}
     ${closeBtn}
   </div>
   <div data-bn="drawer-body">${content}</div>

--- a/packages/components/src/dropdown-menu.js
+++ b/packages/components/src/dropdown-menu.js
@@ -1,12 +1,28 @@
 /**
  * Dropdown menu — popover-based menu.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { nextId } from './ids.js';
+import { attrsSuffix } from './internal/attrs.js';
+
+/**
+ * Dropdown menu — popover-based menu with role="menu" / "menuitem".
+ *
+ * @param {object} [options]
+ * @param {string} [options.trigger]  HTML slot: not escaped; pass trusted markup only
+ * @param {Array<{label?: string, action?: string, icon?: string, shortcut?: string, disabled?: boolean, separator?: boolean}>} [options.items]
+ *   label and shortcut are escaped text; action is an escaped attribute; icon is an HTML slot: not escaped; pass trusted markup only
+ * @param {string} [options.position='bottom-start']
+ * @param {string} [options.id]       Defaults to nextId('dropdown')
+ * @param {string} [options.attrs]    Raw attribute markup appended to the wrapper; not escaped
+ * @returns {string}
+ */
 export function renderDropdownMenu(options = {}) {
   const {
-    trigger,
+    trigger = '',
     items = [],
     position = 'bottom-start',
-    id = `bn-dropdown-${Math.random().toString(36).slice(2)}`,
+    id = nextId('dropdown'),
     attrs = '',
   } = options;
 
@@ -15,13 +31,13 @@ export function renderDropdownMenu(options = {}) {
       if (item.separator) return `<hr data-bn="dropdown-separator" role="separator">`;
       const dis = item.disabled ? ' aria-disabled="true"' : '';
       const icon = item.icon ? `<span data-bn="dropdown-icon">${item.icon}</span>` : '';
-      const shortcut = item.shortcut ? `<span data-bn="dropdown-shortcut">${item.shortcut}</span>` : '';
-      return `<button data-bn="dropdown-item" role="menuitem" data-action="${item.action ?? ''}"${dis} type="button">${icon}${item.label}${shortcut}</button>`;
+      const shortcut = item.shortcut ? `<span data-bn="dropdown-shortcut">${escapeText(item.shortcut)}</span>` : '';
+      return `<button data-bn="dropdown-item" role="menuitem" data-action="${escapeAttr(item.action ?? '')}"${dis} type="button">${icon}${escapeText(item.label ?? '')}${shortcut}</button>`;
     })
     .join('');
 
-  return `<div data-bn="dropdown" ${attrs}>
-  <button data-bn="dropdown-trigger" popovertarget="${id}" type="button">${trigger}</button>
-  <div data-bn="dropdown-menu" id="${id}" popover data-position="${position}" role="menu">${itemsHtml}</div>
+  return `<div data-bn="dropdown"${attrsSuffix(attrs)}>
+  <button data-bn="dropdown-trigger" popovertarget="${escapeAttr(id)}" type="button">${trigger}</button>
+  <div data-bn="dropdown-menu" id="${escapeAttr(id)}" popover data-position="${escapeAttr(position)}" role="menu">${itemsHtml}</div>
 </div>`;
 }

--- a/packages/components/src/ids.js
+++ b/packages/components/src/ids.js
@@ -1,0 +1,35 @@
+/**
+ * Deterministic element ids for server and client renders.
+ *
+ * Every renderer that needs a generated id calls `nextId(prefix)`, which draws
+ * from a module-level counter instead of `Math.random()`. Hydration matches
+ * server-rendered markup to client state by id, so a page must satisfy one of:
+ *
+ *   1. pass an explicit `id` option to every component that is hydrated, or
+ *   2. render the same components in the same order on server and client, and
+ *      call `resetIds()` at the start of every server request so the counter
+ *      restarts from zero for each response.
+ *
+ * Every renderer honours an explicit `id` option before falling back to nextId().
+ */
+let counter = 0;
+
+/**
+ * Return the next deterministic id, `bn-<prefix>-<n>`, from the module counter.
+ *
+ * @param {string} prefix  Component name, e.g. 'dialog' → 'bn-dialog-1'
+ * @returns {string}
+ */
+export function nextId(prefix) {
+  counter += 1;
+  return `bn-${prefix}-${counter}`;
+}
+
+/**
+ * Restart the id counter at zero. Call once per SSR request, before rendering,
+ * so two renders of the same page produce byte-identical markup and a client
+ * hydrating in the same render order derives the same ids.
+ */
+export function resetIds() {
+  counter = 0;
+}

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,3 +1,6 @@
+// Deterministic ids (hydration needs explicit ids or identical render order + resetIds() per request)
+export { nextId, resetIds } from './ids.js';
+
 // Button
 export { buttonVariants, renderButton } from './button.js';
 

--- a/packages/components/src/input.js
+++ b/packages/components/src/input.js
@@ -8,9 +8,30 @@
  *     <span data-bn="field-error"></span>
  *   </div>
  */
+import { escapeAttr } from '@basenative/runtime/shared/escape';
+import { attrsSuffix } from './internal/attrs.js';
+import { describedBy, renderField } from './internal/field.js';
 
 /**
  * Server-side render helper for an input field group.
+ *
+ * Every attribute (id, name, type, value, placeholder) and every text field
+ * (label, helpText, error) is escaped. Help text gets id `<id>-help`, the error
+ * gets `<id>-error`, and aria-describedby lists whichever are present.
+ *
+ * @param {object} options
+ * @param {string} options.name
+ * @param {string} [options.type='text']
+ * @param {string} [options.label]
+ * @param {string} [options.placeholder]
+ * @param {string} [options.value]
+ * @param {boolean} [options.required]
+ * @param {boolean} [options.disabled]
+ * @param {string} [options.helpText]
+ * @param {string} [options.error]
+ * @param {string} [options.id]     Defaults to name
+ * @param {string} [options.attrs]  Raw attribute markup appended to the <input>; not escaped
+ * @returns {string}
  */
 export function renderInput(options = {}) {
   const {
@@ -29,25 +50,9 @@ export function renderInput(options = {}) {
   const id = options.id || name;
   const requiredAttr = required ? ' required' : '';
   const disabledAttr = disabled ? ' disabled' : '';
-  const ariaDescribed = helpText || error ? ` aria-describedby="${id}-help"` : '';
   const ariaInvalid = error ? ' aria-invalid="true"' : '';
-  const extra = attrs ? ' ' + attrs : '';
 
-  let html = `<div data-bn="field">`;
-  if (label) {
-    html += `<label for="${id}">${label}</label>`;
-  }
-  html += `<input data-bn="input" type="${type}" id="${id}" name="${name}" value="${escapeAttr(value)}" placeholder="${escapeAttr(placeholder)}"${requiredAttr}${disabledAttr}${ariaDescribed}${ariaInvalid}${extra} />`;
-  if (helpText) {
-    html += `<span data-bn="field-help" id="${id}-help">${helpText}</span>`;
-  }
-  if (error) {
-    html += `<span data-bn="field-error" id="${id}-help" role="alert">${error}</span>`;
-  }
-  html += `</div>`;
-  return html;
-}
+  const control = `<input data-bn="input" type="${escapeAttr(type)}" id="${escapeAttr(id)}" name="${escapeAttr(name)}" value="${escapeAttr(value)}" placeholder="${escapeAttr(placeholder)}"${requiredAttr}${disabledAttr}${describedBy(id, helpText, error)}${ariaInvalid}${attrsSuffix(attrs)} />`;
 
-function escapeAttr(str) {
-  return String(str).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+  return renderField({ id, label, control, helpText, error });
 }

--- a/packages/components/src/internal/attrs.js
+++ b/packages/components/src/internal/attrs.js
@@ -1,0 +1,14 @@
+/**
+ * Append caller-supplied raw attribute markup to a tag.
+ *
+ * Returns ' ' + attrs when attrs is non-empty, otherwise '' — so call sites can
+ * write `<div${attrsSuffix(attrs)}>` without leaking a stray trailing space.
+ * `attrs` is a markup composition point and is inserted verbatim: pass trusted
+ * attribute markup only.
+ *
+ * @param {string} [attrs]
+ * @returns {string}
+ */
+export function attrsSuffix(attrs) {
+  return attrs ? ' ' + attrs : '';
+}

--- a/packages/components/src/internal/drag.js
+++ b/packages/components/src/internal/drag.js
@@ -1,0 +1,34 @@
+/**
+ * Attach a set of native drag-and-drop listeners to a container and return a
+ * destroy() that removes exactly those listeners.
+ *
+ * @param {HTMLElement} el
+ * @param {Partial<Record<'dragstart'|'dragover'|'dragleave'|'drop'|'dragend', (e: DragEvent) => void>>} handlers
+ * @returns {{ destroy: () => void }}
+ */
+export function bindDrag(el, handlers) {
+  const entries = Object.entries(handlers).filter(([, fn]) => typeof fn === 'function');
+  for (const [type, fn] of entries) el.addEventListener(type, fn);
+  return {
+    destroy() {
+      for (const [type, fn] of entries) el.removeEventListener(type, fn);
+    },
+  };
+}
+
+/** Remove data-dragging / data-drop-target from every descendant of container. */
+export function clearDragState(container) {
+  container.querySelectorAll('[data-dragging], [data-drop-target]').forEach(el => {
+    el.removeAttribute('data-dragging');
+    el.removeAttribute('data-drop-target');
+  });
+}
+
+/** Parse the JSON payload set on dragstart, or null when absent or malformed. */
+export function readDragData(e) {
+  try {
+    return JSON.parse(e.dataTransfer.getData('text/plain'));
+  } catch {
+    return null;
+  }
+}

--- a/packages/components/src/internal/field.js
+++ b/packages/components/src/internal/field.js
@@ -1,0 +1,44 @@
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+
+/**
+ * aria-describedby for a form control: lists `<id>-help` when helpText is set
+ * and `<id>-error` when error is set (both, space separated, when both are).
+ * Returns '' when neither is set so it can be interpolated directly.
+ *
+ * @param {string} id
+ * @param {string} [helpText]
+ * @param {string} [error]
+ * @returns {string}
+ */
+export function describedBy(id, helpText, error) {
+  const ids = [];
+  if (helpText) ids.push(`${id}-help`);
+  if (error) ids.push(`${id}-error`);
+  return ids.length ? ` aria-describedby="${escapeAttr(ids.join(' '))}"` : '';
+}
+
+/**
+ * Shared field wrapper for input, textarea and select: label, the control
+ * markup, then optional help and error spans whose ids match describedBy().
+ * label, helpText and error are escaped text; `control` is the already-built
+ * control markup and is inserted verbatim.
+ *
+ * @param {{id: string, label?: string, control: string, helpText?: string, error?: string}} field
+ * @returns {string}
+ */
+export function renderField({ id, label, control, helpText = '', error = '' }) {
+  const safeId = escapeAttr(id);
+  let html = `<div data-bn="field">`;
+  if (label) {
+    html += `<label for="${safeId}">${escapeText(label)}</label>`;
+  }
+  html += control;
+  if (helpText) {
+    html += `<span data-bn="field-help" id="${safeId}-help">${escapeText(helpText)}</span>`;
+  }
+  if (error) {
+    html += `<span data-bn="field-error" id="${safeId}-error" role="alert">${escapeText(error)}</span>`;
+  }
+  html += `</div>`;
+  return html;
+}

--- a/packages/components/src/internal/items.js
+++ b/packages/components/src/internal/items.js
@@ -1,0 +1,11 @@
+/**
+ * Normalise an option item that may be a bare string or a {value,label,disabled}
+ * object into the object form. A string is both its value and its label.
+ *
+ * @param {string | {value?: string, label?: string, disabled?: boolean}} item
+ * @returns {{value: string, label: string, disabled: boolean}}
+ */
+export function normalizeItem(item) {
+  if (typeof item === 'string') return { value: item, label: item, disabled: false };
+  return { value: item.value, label: item.label, disabled: Boolean(item.disabled) };
+}

--- a/packages/components/src/internal/tree.js
+++ b/packages/components/src/internal/tree.js
@@ -1,0 +1,28 @@
+/**
+ * Walk a list of tree nodes, computing the shared per-node state (id, whether
+ * it has children, whether it is expanded) and rendering expanded children
+ * before handing everything to `render`. Used by Tree and TreeGrid, which
+ * differ only in the markup each node produces.
+ *
+ * @param {Array<object>} items
+ * @param {{ getId: (node: object) => string, expanded: Set<string>, render: (state: {node: object, nodeId: string, hasChildren: boolean, isExpanded: boolean, level: number, children: string}) => string }} options
+ * @param {number} [level]
+ * @returns {string}
+ */
+export function renderNodes(items, options, level = 0) {
+  const { getId, expanded, render } = options;
+  return items
+    .map(node => {
+      const nodeId = getId(node);
+      const hasChildren = Boolean(node.children && node.children.length > 0);
+      const isExpanded = hasChildren && expanded.has(nodeId);
+      const children = isExpanded ? renderNodes(node.children, options, level + 1) : '';
+      return render({ node, nodeId, hasChildren, isExpanded, level, children });
+    })
+    .join('');
+}
+
+/** aria-expanded only makes sense on a node that can expand; leaves omit it. */
+export function ariaExpanded(hasChildren, isExpanded) {
+  return hasChildren ? ` aria-expanded="${isExpanded}"` : '';
+}

--- a/packages/components/src/layout-grid.js
+++ b/packages/components/src/layout-grid.js
@@ -1,4 +1,9 @@
 /**
+ * Layout grid — drag-and-drop CSS grid primitive for the visual builder.
+ */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+
+/**
  * renderLayoutGrid - A drag-and-drop CSS grid layout component.
  * Designed to hook into @basenative/visual-builder's canvas state.
  *
@@ -6,7 +11,8 @@
  * @param {number} [options.columns=12] - Grid columns
  * @param {number} [options.gap='1rem'] - Gap between cells
  * @param {string} [options.minCellHeight='4rem'] - Minimum cell height
- * @param {Array<{id: string, label?: string, content?: string, colSpan?: number, rowSpan?: number}>} [options.cells] - Grid cells
+ * @param {Array<{id: string, label?: string, content?: string, colSpan?: number, rowSpan?: number}>} [options.cells] - Grid cells.
+ *   `label` is escaped text; `content` is an HTML slot: not escaped; pass trusted markup only
  * @param {string} [options.id] - Unique ID for the grid
  * @param {boolean} [options.editable=false] - Whether cells are draggable/resizable
  * @returns {string} HTML string
@@ -24,19 +30,24 @@ export function renderLayoutGrid(options = {}) {
   const cellsHtml = cells.map((cell, i) => {
     const span = cell.colSpan || 1;
     const rowSpan = cell.rowSpan || 1;
-    const style = `grid-column: span ${span}; grid-row: span ${rowSpan}; min-height: ${minCellHeight}`;
+    const style = `grid-column: span ${escapeAttr(span)}; grid-row: span ${escapeAttr(rowSpan)}; min-height: ${escapeAttr(minCellHeight)}`;
     const draggable = editable ? ' draggable="true"' : '';
-    const content = cell.content || cell.label || `Cell ${i + 1}`;
-    return `<div data-bn="layout-cell" data-cell-id="${esc(cell.id || `cell-${i}`)}" style="${style}"${draggable}>${content}</div>`;
+    const content = cell.content || (cell.label ? escapeText(cell.label) : `Cell ${i + 1}`);
+    return `<div data-bn="layout-cell" data-cell-id="${escapeAttr(cell.id || `cell-${i}`)}" style="${style}"${draggable}>${content}</div>`;
   }).join('\n');
 
-  return `<div data-bn="layout-grid" id="${esc(id)}" style="display:grid;grid-template-columns:repeat(${columns},1fr);gap:${gap}">
+  return `<div data-bn="layout-grid" id="${escapeAttr(id)}" style="display:grid;grid-template-columns:repeat(${escapeAttr(columns)},1fr);gap:${escapeAttr(gap)}">
 ${cellsHtml}
 </div>`;
 }
 
 /**
  * CSS for layout grid components.
+ *
+ * @deprecated components.css already ships these rules under
+ * `[data-bn="layout-grid"]` / `[data-bn="layout-cell"]`; include
+ * `@basenative/components/components.css` instead. Kept only so the public
+ * export surface is unchanged.
  * @returns {string}
  */
 export function layoutGridStyles() {
@@ -73,8 +84,4 @@ export function layoutGridStyles() {
   border-color: var(--accent, hsl(210 100% 60%));
   box-shadow: inset 0 0 0 2px var(--accent, hsl(210 100% 60%));
 }`;
-}
-
-function esc(s) {
-  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }

--- a/packages/components/src/multiselect.js
+++ b/packages/components/src/multiselect.js
@@ -1,6 +1,26 @@
 /**
  * Multiselect — multiple value selection with tags/chips.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { nextId } from './ids.js';
+import { attrsSuffix } from './internal/attrs.js';
+import { normalizeItem } from './internal/items.js';
+
+/**
+ * Multiselect — multiple value selection with tags/chips over a hidden native
+ * <select multiple>. Attributes, label, tag text and option labels are escaped.
+ *
+ * @param {object} options
+ * @param {string} [options.name]
+ * @param {string} [options.label]   Escaped text
+ * @param {Array<string | {value: string, label: string}>} [options.items]
+ * @param {string[]} [options.selected]
+ * @param {string} [options.placeholder]
+ * @param {boolean} [options.disabled]
+ * @param {string} [options.id]      Defaults to `bn-multiselect-<name>`, or nextId() without a name
+ * @param {string} [options.attrs]   Raw attribute markup appended to the search <input>; not escaped
+ * @returns {string}
+ */
 export function renderMultiselect(options = {}) {
   const {
     name,
@@ -9,36 +29,35 @@ export function renderMultiselect(options = {}) {
     selected = [],
     placeholder = 'Select items...',
     disabled = false,
-    id = `bn-multiselect-${name || Math.random().toString(36).slice(2)}`,
+    id = name ? `bn-multiselect-${name}` : nextId('multiselect'),
     attrs = '',
   } = options;
 
   const dis = disabled ? ' disabled' : '';
   const selectedSet = new Set(selected);
+  const normalized = items.map(normalizeItem);
 
   const tagsHtml = selected
     .map(val => {
-      const item = items.find(i => (typeof i === 'string' ? i : i.value) === val);
-      const text = item ? (typeof item === 'string' ? item : item.label) : val;
-      return `<span data-bn="tag" data-value="${val}">${text}<button type="button" data-bn="tag-remove" aria-label="Remove ${text}">&times;</button></span>`;
+      const item = normalized.find(i => i.value === val);
+      const text = item ? item.label : val;
+      return `<span data-bn="tag" data-value="${escapeAttr(val)}">${escapeText(text)}<button type="button" data-bn="tag-remove" aria-label="Remove ${escapeAttr(text)}">&times;</button></span>`;
     })
     .join('');
 
-  const optionsHtml = items
+  const optionsHtml = normalized
     .map(item => {
-      const val = typeof item === 'string' ? item : item.value;
-      const text = typeof item === 'string' ? item : item.label;
-      const sel = selectedSet.has(val) ? ' selected' : '';
-      return `<option value="${val}"${sel}>${text}</option>`;
+      const sel = selectedSet.has(item.value) ? ' selected' : '';
+      return `<option value="${escapeAttr(item.value)}"${sel}>${escapeText(item.label)}</option>`;
     })
     .join('');
 
   return `<div data-bn="multiselect"${dis ? ' data-disabled' : ''}>
-  ${label ? `<label for="${id}" data-bn="label">${label}</label>` : ''}
+  ${label ? `<label for="${escapeAttr(id)}" data-bn="label">${escapeText(label)}</label>` : ''}
   <div data-bn="multiselect-container">
     <div data-bn="multiselect-tags">${tagsHtml}</div>
-    <input type="text" data-bn="multiselect-search" placeholder="${placeholder}" autocomplete="off" aria-label="${label || 'Search'}" ${attrs}>
+    <input type="text" data-bn="multiselect-search" placeholder="${escapeAttr(placeholder)}" autocomplete="off" aria-label="${escapeAttr(label || 'Search')}"${attrsSuffix(attrs)}>
   </div>
-  <select id="${id}" name="${name}" multiple hidden${dis}>${optionsHtml}</select>
+  <select id="${escapeAttr(id)}" name="${escapeAttr(name)}" multiple hidden${dis}>${optionsHtml}</select>
 </div>`;
 }

--- a/packages/components/src/pagination.js
+++ b/packages/components/src/pagination.js
@@ -2,9 +2,10 @@
  * Pagination component — server-friendly page navigation.
  * Renders as a <nav> with page links for progressive enhancement.
  */
+import { escapeAttr } from '@basenative/runtime/shared/escape';
 
 /**
- * Renders a pagination control.
+ * Renders a pagination control. Page link hrefs are escaped attributes.
  *
  * @param {object} options
  * @param {number} options.currentPage - Current page (1-indexed)
@@ -18,12 +19,13 @@ export function renderPagination(options = {}) {
   if (totalPages <= 1) return '';
 
   const pages = computePages(currentPage, totalPages, pageWindow);
+  const href = page => escapeAttr(pageUrl(baseUrl, page));
 
   let html = `<nav data-bn="pagination" aria-label="Pagination"><ul>`;
 
   // Previous
   if (currentPage > 1) {
-    html += `<li><a href="${pageUrl(baseUrl, currentPage - 1)}" rel="prev" aria-label="Previous page">&laquo;</a></li>`;
+    html += `<li><a href="${href(currentPage - 1)}" rel="prev" aria-label="Previous page">&laquo;</a></li>`;
   } else {
     html += `<li><span aria-disabled="true">&laquo;</span></li>`;
   }
@@ -32,15 +34,15 @@ export function renderPagination(options = {}) {
     if (page === '...') {
       html += `<li><span data-bn="pagination-ellipsis">&hellip;</span></li>`;
     } else if (page === currentPage) {
-      html += `<li><a href="${pageUrl(baseUrl, page)}" aria-current="page" data-active>${page}</a></li>`;
+      html += `<li><a href="${href(page)}" aria-current="page" data-active>${page}</a></li>`;
     } else {
-      html += `<li><a href="${pageUrl(baseUrl, page)}">${page}</a></li>`;
+      html += `<li><a href="${href(page)}">${page}</a></li>`;
     }
   }
 
   // Next
   if (currentPage < totalPages) {
-    html += `<li><a href="${pageUrl(baseUrl, currentPage + 1)}" rel="next" aria-label="Next page">&raquo;</a></li>`;
+    html += `<li><a href="${href(currentPage + 1)}" rel="next" aria-label="Next page">&raquo;</a></li>`;
   } else {
     html += `<li><span aria-disabled="true">&raquo;</span></li>`;
   }

--- a/packages/components/src/progress.js
+++ b/packages/components/src/progress.js
@@ -1,26 +1,37 @@
 /**
  * Progress and Spinner components.
  */
+import { escapeAttr } from '@basenative/runtime/shared/escape';
+import { attrsSuffix } from './internal/attrs.js';
 
 /**
- * Renders a determinate progress bar using native <progress>.
+ * Renders a determinate progress bar using native <progress>. The fallback
+ * percentage text is 0% when max is 0, rather than NaN%.
+ *
+ * @param {object} [options]
+ * @param {number} [options.value=0]
+ * @param {number} [options.max=100]
+ * @param {string} [options.label]  aria-label; escaped
+ * @param {string} [options.attrs]  Raw attribute markup appended to the <progress>; not escaped
+ * @returns {string}
  */
 export function renderProgress(options = {}) {
   const { value = 0, max = 100, label = '', attrs = '' } = options;
   const ariaLabel = label ? ` aria-label="${escapeAttr(label)}"` : '';
-  const extra = attrs ? ' ' + attrs : '';
-  return `<progress data-bn="progress" value="${value}" max="${max}"${ariaLabel}${extra}>${Math.round((value / max) * 100)}%</progress>`;
+  const percent = max > 0 ? Math.round((value / max) * 100) : 0;
+  return `<progress data-bn="progress" value="${escapeAttr(value)}" max="${escapeAttr(max)}"${ariaLabel}${attrsSuffix(attrs)}>${percent}%</progress>`;
 }
 
 /**
  * Renders an indeterminate spinner.
+ *
+ * @param {object} [options]
+ * @param {string} [options.size='default']
+ * @param {string} [options.label='Loading']  aria-label; escaped
+ * @returns {string}
  */
 export function renderSpinner(options = {}) {
   const size = options.size || 'default';
   const label = options.label || 'Loading';
-  return `<span data-bn="spinner" data-size="${size}" role="status" aria-label="${escapeAttr(label)}"><span aria-hidden="true"></span></span>`;
-}
-
-function escapeAttr(str) {
-  return String(str).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  return `<span data-bn="spinner" data-size="${escapeAttr(size)}" role="status" aria-label="${escapeAttr(label)}"><span aria-hidden="true"></span></span>`;
 }

--- a/packages/components/src/radio.js
+++ b/packages/components/src/radio.js
@@ -1,27 +1,36 @@
 /**
  * Radio component — native <input type="radio"> with group support.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { attrsSuffix } from './internal/attrs.js';
+import { normalizeItem } from './internal/items.js';
 
+/**
+ * Radio component — native <input type="radio"> group inside a <fieldset>.
+ *
+ * @param {object} options
+ * @param {string} options.name
+ * @param {string} [options.label]   Group legend; escaped text
+ * @param {Array<string | {value: string, label: string, disabled?: boolean}>} [options.items]
+ * @param {string} [options.selected]
+ * @param {boolean} [options.disabled]
+ * @param {string} [options.attrs]   Raw attribute markup appended to the <fieldset>; not escaped
+ * @returns {string}
+ */
 export function renderRadioGroup(options = {}) {
   const { name, label, items = [], selected = '', disabled = false, attrs = '' } = options;
-  const extra = attrs ? ' ' + attrs : '';
 
-  let html = `<fieldset data-bn="radio-group"${extra}>`;
+  let html = `<fieldset data-bn="radio-group"${attrsSuffix(attrs)}>`;
   if (label) {
-    html += `<legend>${label}</legend>`;
+    html += `<legend>${escapeText(label)}</legend>`;
   }
-  for (const item of items) {
-    const value = typeof item === 'string' ? item : item.value;
-    const itemLabel = typeof item === 'string' ? item : item.label;
-    const checkedAttr = value === selected ? ' checked' : '';
+  for (const raw of items) {
+    const item = normalizeItem(raw);
+    const checkedAttr = item.value === selected ? ' checked' : '';
     const disabledAttr = disabled || item.disabled ? ' disabled' : '';
-    const id = `${name}-${value}`;
-    html += `<label data-bn="radio-label"><input data-bn="radio" type="radio" id="${id}" name="${name}" value="${escapeAttr(value)}"${checkedAttr}${disabledAttr} /><span>${itemLabel}</span></label>`;
+    const id = `${name}-${item.value}`;
+    html += `<label data-bn="radio-label"><input data-bn="radio" type="radio" id="${escapeAttr(id)}" name="${escapeAttr(name)}" value="${escapeAttr(item.value)}"${checkedAttr}${disabledAttr} /><span>${escapeText(item.label)}</span></label>`;
   }
   html += `</fieldset>`;
   return html;
-}
-
-function escapeAttr(str) {
-  return String(str).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
 }

--- a/packages/components/src/select.js
+++ b/packages/components/src/select.js
@@ -2,7 +2,31 @@
  * Select component — native <select> with optional base-select enhancement.
  * Feature-detected styling via browserFeatures.baseSelect from runtime.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { attrsSuffix } from './internal/attrs.js';
+import { describedBy, renderField } from './internal/field.js';
+import { normalizeItem } from './internal/items.js';
 
+/**
+ * Server-side render helper for a select field group.
+ *
+ * Attributes, option values, option labels, placeholder, label, helpText and
+ * error are escaped. Help/error ids and aria-describedby follow renderInput.
+ *
+ * @param {object} options
+ * @param {string} options.name
+ * @param {string} [options.label]
+ * @param {Array<string | {value: string, label: string, disabled?: boolean}>} [options.items]
+ * @param {string} [options.selected]
+ * @param {string} [options.placeholder]  Rendered as a disabled first option
+ * @param {boolean} [options.required]
+ * @param {boolean} [options.disabled]
+ * @param {string} [options.helpText]
+ * @param {string} [options.error]
+ * @param {string} [options.id]     Defaults to name
+ * @param {string} [options.attrs]  Raw attribute markup appended to the <select>; not escaped
+ * @returns {string}
+ */
 export function renderSelect(options = {}) {
   const {
     name,
@@ -12,6 +36,7 @@ export function renderSelect(options = {}) {
     placeholder = '',
     required = false,
     disabled = false,
+    helpText = '',
     error = '',
     attrs = '',
   } = options;
@@ -20,35 +45,18 @@ export function renderSelect(options = {}) {
   const requiredAttr = required ? ' required' : '';
   const disabledAttr = disabled ? ' disabled' : '';
   const ariaInvalid = error ? ' aria-invalid="true"' : '';
-  const extra = attrs ? ' ' + attrs : '';
 
-  let html = `<div data-bn="field">`;
-  if (label) {
-    html += `<label for="${id}">${label}</label>`;
-  }
-  html += `<select data-bn="select" id="${id}" name="${name}"${requiredAttr}${disabledAttr}${ariaInvalid}${extra}>`;
+  let control = `<select data-bn="select" id="${escapeAttr(id)}" name="${escapeAttr(name)}"${requiredAttr}${disabledAttr}${describedBy(id, helpText, error)}${ariaInvalid}${attrsSuffix(attrs)}>`;
   if (placeholder) {
-    html += `<option value="" disabled${!selected ? ' selected' : ''}>${escapeHtml(placeholder)}</option>`;
+    control += `<option value="" disabled${!selected ? ' selected' : ''}>${escapeText(placeholder)}</option>`;
   }
-  for (const item of items) {
-    const value = typeof item === 'string' ? item : item.value;
-    const itemLabel = typeof item === 'string' ? item : item.label;
-    const selectedAttr = value === selected ? ' selected' : '';
+  for (const raw of items) {
+    const item = normalizeItem(raw);
+    const selectedAttr = item.value === selected ? ' selected' : '';
     const itemDisabled = item.disabled ? ' disabled' : '';
-    html += `<option value="${escapeAttr(value)}"${selectedAttr}${itemDisabled}>${escapeHtml(itemLabel)}</option>`;
+    control += `<option value="${escapeAttr(item.value)}"${selectedAttr}${itemDisabled}>${escapeText(item.label)}</option>`;
   }
-  html += `</select>`;
-  if (error) {
-    html += `<span data-bn="field-error" role="alert">${error}</span>`;
-  }
-  html += `</div>`;
-  return html;
-}
+  control += `</select>`;
 
-function escapeAttr(str) {
-  return String(str).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
-}
-
-function escapeHtml(str) {
-  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return renderField({ id, label, control, helpText, error });
 }

--- a/packages/components/src/skeleton.js
+++ b/packages/components/src/skeleton.js
@@ -1,20 +1,26 @@
 /**
  * Skeleton loading placeholder component.
  */
+import { escapeAttr } from '@basenative/runtime/shared/escape';
 
 /**
- * Renders a skeleton placeholder.
+ * Renders `count` skeleton placeholders.
+ *
+ * @param {object} [options]
+ * @param {string} [options.width='100%']
+ * @param {string} [options.height='1rem']
+ * @param {string} [options.variant='text']
+ * @param {number} [options.count=1]
+ * @returns {string}
  */
 export function renderSkeleton(options = {}) {
   const { width = '100%', height = '1rem', variant = 'text', count = 1 } = options;
 
-  if (count === 1) {
-    return `<div data-bn="skeleton" data-variant="${variant}" style="width:${width};height:${height}" aria-hidden="true"></div>`;
-  }
+  const one = `<div data-bn="skeleton" data-variant="${escapeAttr(variant)}" style="width:${escapeAttr(width)};height:${escapeAttr(height)}" aria-hidden="true"></div>`;
 
   let html = '';
   for (let i = 0; i < count; i++) {
-    html += `<div data-bn="skeleton" data-variant="${variant}" style="width:${width};height:${height}" aria-hidden="true"></div>`;
+    html += one;
   }
   return html;
 }

--- a/packages/components/src/table.js
+++ b/packages/components/src/table.js
@@ -2,9 +2,11 @@
  * Table component — semantic HTML table with sorting and empty state.
  * Designed for SSR — renders full table markup on the server.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
 
 /**
- * Renders a data table from columns and rows.
+ * Renders a data table from columns and rows. Column labels, cell values,
+ * caption and emptyMessage are escaped text.
  *
  * @param {object} options
  * @param {Array<{key: string, label: string, sortable?: boolean}>} options.columns
@@ -18,24 +20,24 @@ export function renderTable(options = {}) {
   let html = `<div data-bn="table-container">`;
   html += `<table data-bn="table">`;
   if (caption) {
-    html += `<caption>${escapeHtml(caption)}</caption>`;
+    html += `<caption>${escapeText(caption)}</caption>`;
   }
   html += `<thead><tr>`;
   for (const col of columns) {
     const sortAttr = col.sortable ? ' data-sortable' : '';
-    html += `<th scope="col"${sortAttr}>${escapeHtml(col.label)}</th>`;
+    html += `<th scope="col"${sortAttr}>${escapeText(col.label)}</th>`;
   }
   html += `</tr></thead>`;
   html += `<tbody>`;
 
   if (rows.length === 0) {
-    html += `<tr><td colspan="${columns.length}" data-bn="table-empty">${escapeHtml(emptyMessage)}</td></tr>`;
+    html += `<tr><td colspan="${escapeAttr(columns.length)}" data-bn="table-empty">${escapeText(emptyMessage)}</td></tr>`;
   } else {
     for (const row of rows) {
       html += `<tr>`;
       for (const col of columns) {
         const value = row[col.key];
-        html += `<td>${value != null ? escapeHtml(String(value)) : ''}</td>`;
+        html += `<td>${value != null ? escapeText(String(value)) : ''}</td>`;
       }
       html += `</tr>`;
     }
@@ -43,8 +45,4 @@ export function renderTable(options = {}) {
 
   html += `</tbody></table></div>`;
   return html;
-}
-
-function escapeHtml(str) {
-  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }

--- a/packages/components/src/tabs.js
+++ b/packages/components/src/tabs.js
@@ -1,12 +1,29 @@
 /**
  * Tabs — tab navigation with panels.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { nextId } from './ids.js';
+import { attrsSuffix } from './internal/attrs.js';
+
+/**
+ * Tabs — tab navigation with panels. Tab buttons are type="button" and wired
+ * to their panels with aria-controls / aria-labelledby.
+ *
+ * @param {object} [options]
+ * @param {Array<{id: string, label: string, content?: string, disabled?: boolean}>} [options.tabs]
+ *   label is escaped text; content is an HTML slot: not escaped; pass trusted markup only
+ * @param {string} [options.activeTab]  Defaults to the first tab
+ * @param {string} [options.variant='default']
+ * @param {string} [options.id]     Defaults to nextId('tabs')
+ * @param {string} [options.attrs]  Raw attribute markup appended to the wrapper; not escaped
+ * @returns {string}
+ */
 export function renderTabs(options = {}) {
   const {
     tabs = [],
     activeTab,
     variant = 'default',
-    id = `bn-tabs-${Math.random().toString(36).slice(2)}`,
+    id = nextId('tabs'),
     attrs = '',
   } = options;
 
@@ -15,18 +32,18 @@ export function renderTabs(options = {}) {
   const tabList = tabs
     .map(tab => {
       const isActive = tab.id === active;
-      return `<button data-bn="tab" role="tab" id="${id}-tab-${tab.id}" aria-selected="${isActive}" aria-controls="${id}-panel-${tab.id}" data-tab="${tab.id}"${tab.disabled ? ' disabled' : ''}>${tab.label}</button>`;
+      return `<button data-bn="tab" role="tab" type="button" id="${escapeAttr(`${id}-tab-${tab.id}`)}" aria-selected="${isActive}" aria-controls="${escapeAttr(`${id}-panel-${tab.id}`)}" data-tab="${escapeAttr(tab.id)}"${tab.disabled ? ' disabled' : ''}>${escapeText(tab.label ?? '')}</button>`;
     })
     .join('');
 
   const panels = tabs
     .map(tab => {
       const isActive = tab.id === active;
-      return `<div data-bn="tab-panel" role="tabpanel" id="${id}-panel-${tab.id}" aria-labelledby="${id}-tab-${tab.id}"${isActive ? '' : ' hidden'}>${tab.content ?? ''}</div>`;
+      return `<div data-bn="tab-panel" role="tabpanel" id="${escapeAttr(`${id}-panel-${tab.id}`)}" aria-labelledby="${escapeAttr(`${id}-tab-${tab.id}`)}"${isActive ? '' : ' hidden'}>${tab.content ?? ''}</div>`;
     })
     .join('');
 
-  return `<div data-bn="tabs" data-variant="${variant}" id="${id}" ${attrs}>
+  return `<div data-bn="tabs" data-variant="${escapeAttr(variant)}" id="${escapeAttr(id)}"${attrsSuffix(attrs)}>
   <div data-bn="tab-list" role="tablist">${tabList}</div>
   ${panels}
 </div>`;

--- a/packages/components/src/textarea.js
+++ b/packages/components/src/textarea.js
@@ -1,7 +1,31 @@
 /**
  * Textarea component — wraps native <textarea> with field system integration.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { attrsSuffix } from './internal/attrs.js';
+import { describedBy, renderField } from './internal/field.js';
 
+/**
+ * Server-side render helper for a textarea field group.
+ *
+ * Attributes and text fields are escaped. Help text gets id `<id>-help`, the
+ * error gets `<id>-error`, and aria-describedby lists whichever are present —
+ * the same policy as renderInput.
+ *
+ * @param {object} options
+ * @param {string} options.name
+ * @param {string} [options.label]
+ * @param {string} [options.placeholder]
+ * @param {string} [options.value]
+ * @param {number} [options.rows=3]
+ * @param {boolean} [options.required]
+ * @param {boolean} [options.disabled]
+ * @param {string} [options.helpText]
+ * @param {string} [options.error]
+ * @param {string} [options.id]     Defaults to name
+ * @param {string} [options.attrs]  Raw attribute markup appended to the <textarea>; not escaped
+ * @returns {string}
+ */
 export function renderTextarea(options = {}) {
   const {
     name,
@@ -20,27 +44,8 @@ export function renderTextarea(options = {}) {
   const requiredAttr = required ? ' required' : '';
   const disabledAttr = disabled ? ' disabled' : '';
   const ariaInvalid = error ? ' aria-invalid="true"' : '';
-  const extra = attrs ? ' ' + attrs : '';
 
-  let html = `<div data-bn="field">`;
-  if (label) {
-    html += `<label for="${id}">${label}</label>`;
-  }
-  html += `<textarea data-bn="textarea" id="${id}" name="${name}" rows="${rows}" placeholder="${escapeAttr(placeholder)}"${requiredAttr}${disabledAttr}${ariaInvalid}${extra}>${escapeHtml(value)}</textarea>`;
-  if (helpText) {
-    html += `<span data-bn="field-help" id="${id}-help">${helpText}</span>`;
-  }
-  if (error) {
-    html += `<span data-bn="field-error" role="alert">${error}</span>`;
-  }
-  html += `</div>`;
-  return html;
-}
+  const control = `<textarea data-bn="textarea" id="${escapeAttr(id)}" name="${escapeAttr(name)}" rows="${escapeAttr(rows)}" placeholder="${escapeAttr(placeholder)}"${requiredAttr}${disabledAttr}${describedBy(id, helpText, error)}${ariaInvalid}${attrsSuffix(attrs)}>${escapeText(value)}</textarea>`;
 
-function escapeAttr(str) {
-  return String(str).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
-}
-
-function escapeHtml(str) {
-  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return renderField({ id, label, control, helpText, error });
 }

--- a/packages/components/src/toast.js
+++ b/packages/components/src/toast.js
@@ -8,6 +8,8 @@
  *   showToast(toaster, { message: 'Saved!', variant: 'success' });
  */
 import { signal } from '@basenative/runtime';
+import { escapeAttr } from '@basenative/runtime/shared/escape';
+import { nextId } from './ids.js';
 
 /**
  * Creates a toast container and manages the toast queue.
@@ -21,11 +23,16 @@ export function createToaster(options = {}) {
 }
 
 /**
- * Shows a toast notification.
+ * Shows a toast notification and returns its id. The id is `options.id` when
+ * given, otherwise the next deterministic `bn-toast-<n>` id.
+ *
+ * @param {{position: string, duration: number, toasts: import('@basenative/runtime').Signal<Array<object>>}} toaster
+ * @param {{id?: string, message?: string, variant?: string, duration?: number}} [options]
+ * @returns {string}
  */
 export function showToast(toaster, options = {}) {
   const toast = {
-    id: Date.now() + Math.random(),
+    id: options.id ?? nextId('toast'),
     message: options.message || '',
     variant: options.variant || 'info',
     duration: options.duration || toaster.duration,
@@ -53,5 +60,5 @@ export function dismissToast(toaster, id) {
  * Server-side render helper for toast container.
  */
 export function renderToastContainer(position = 'top-right') {
-  return `<div data-bn="toast-container" data-position="${position}" role="region" aria-live="polite" aria-label="Notifications"></div>`;
+  return `<div data-bn="toast-container" data-position="${escapeAttr(position)}" role="region" aria-live="polite" aria-label="Notifications"></div>`;
 }

--- a/packages/components/src/toggle.js
+++ b/packages/components/src/toggle.js
@@ -2,13 +2,26 @@
  * Toggle/Switch component — <input type="checkbox" role="switch">.
  * Uses native semantic switch pattern.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { attrsSuffix } from './internal/attrs.js';
 
+/**
+ * Toggle/Switch component — <input type="checkbox" role="switch">.
+ *
+ * @param {object} options
+ * @param {string} options.name
+ * @param {string} [options.label]   Escaped text
+ * @param {boolean} [options.checked]
+ * @param {boolean} [options.disabled]
+ * @param {string} [options.id]      Defaults to name
+ * @param {string} [options.attrs]   Raw attribute markup appended to the <label>; not escaped
+ * @returns {string}
+ */
 export function renderToggle(options = {}) {
   const { name, label, checked = false, disabled = false, attrs = '' } = options;
   const id = options.id || name;
   const checkedAttr = checked ? ' checked' : '';
   const disabledAttr = disabled ? ' disabled' : '';
-  const extra = attrs ? ' ' + attrs : '';
 
-  return `<label data-bn="toggle-label"${extra}><input data-bn="toggle" type="checkbox" role="switch" id="${id}" name="${name}"${checkedAttr}${disabledAttr} /><span>${label || ''}</span></label>`;
+  return `<label data-bn="toggle-label"${attrsSuffix(attrs)}><input data-bn="toggle" type="checkbox" role="switch" id="${escapeAttr(id)}" name="${escapeAttr(name)}"${checkedAttr}${disabledAttr} /><span>${escapeText(label || '')}</span></label>`;
 }

--- a/packages/components/src/tooltip.js
+++ b/packages/components/src/tooltip.js
@@ -1,14 +1,29 @@
 /**
  * Tooltip — popover-based tooltip using the Popover API.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { nextId } from './ids.js';
+import { attrsSuffix } from './internal/attrs.js';
+
+/**
+ * Tooltip — popover-based tooltip using the Popover API.
+ *
+ * @param {object} [options]
+ * @param {string} [options.content]  Tooltip text; escaped
+ * @param {string} [options.trigger]  HTML slot: not escaped; pass trusted markup only
+ * @param {string} [options.position='top']
+ * @param {string} [options.id]       Defaults to nextId('tooltip')
+ * @param {string} [options.attrs]    Raw attribute markup appended to the trigger; not escaped
+ * @returns {string}
+ */
 export function renderTooltip(options = {}) {
   const {
-    content,
-    trigger,
+    content = '',
+    trigger = '',
     position = 'top',
-    id = `bn-tooltip-${Math.random().toString(36).slice(2)}`,
+    id = nextId('tooltip'),
     attrs = '',
   } = options;
 
-  return `<span data-bn="tooltip-trigger" popovertarget="${id}" popovertargetaction="toggle" ${attrs}>${trigger}</span><span data-bn="tooltip" id="${id}" popover data-position="${position}" role="tooltip">${content}</span>`;
+  return `<span data-bn="tooltip-trigger" popovertarget="${escapeAttr(id)}" popovertargetaction="toggle"${attrsSuffix(attrs)}>${trigger}</span><span data-bn="tooltip" id="${escapeAttr(id)}" popover data-position="${escapeAttr(position)}" role="tooltip">${escapeText(content)}</span>`;
 }

--- a/packages/components/src/tree.js
+++ b/packages/components/src/tree.js
@@ -1,92 +1,107 @@
 /**
  * Tree view — expandable hierarchical tree.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { nextId } from './ids.js';
+import { attrsSuffix } from './internal/attrs.js';
+import { ariaExpanded, renderNodes } from './internal/tree.js';
+
+/**
+ * Tree view — expandable hierarchical tree.
+ *
+ * Node labels are escaped text; a node's `icon` is an HTML slot: not escaped;
+ * pass trusted markup only. Leaf nodes carry no aria-expanded attribute.
+ *
+ * @param {object} [options]
+ * @param {Array<{id?: string, label: string, icon?: string, children?: Array<object>}>} [options.items]
+ * @param {Set<string>} [options.expanded]  Node ids that are expanded
+ * @param {string} [options.selected]       Selected node id
+ * @param {string} [options.id]             Defaults to nextId('tree')
+ * @param {string} [options.attrs]          Raw attribute markup appended to the <ul>; not escaped
+ * @returns {string}
+ */
 export function renderTree(options = {}) {
   const {
     items = [],
     expanded = new Set(),
     selected,
-    id = `bn-tree-${Math.random().toString(36).slice(2)}`,
+    id = nextId('tree'),
     attrs = '',
   } = options;
 
-  function renderNode(node, level = 0) {
-    const nodeId = node.id ?? node.label;
-    const hasChildren = node.children && node.children.length > 0;
-    const isExpanded = expanded.has(nodeId);
-    const isSelected = selected === nodeId;
-    const icon = node.icon ?? '';
+  const itemsHtml = renderNodes(items, {
+    getId: node => node.id ?? node.label,
+    expanded,
+    render({ node, nodeId, hasChildren, isExpanded, level, children }) {
+      const isSelected = selected === nodeId;
+      const icon = node.icon ?? '';
 
-    let html = `<li data-bn="tree-item" role="treeitem" aria-expanded="${hasChildren ? isExpanded : undefined}" aria-selected="${isSelected}" data-node-id="${nodeId}" data-level="${level}">`;
-    html += `<div data-bn="tree-item-content"${isSelected ? ' data-selected' : ''}>`;
-    if (hasChildren) {
-      html += `<button data-bn="tree-toggle" aria-label="${isExpanded ? 'Collapse' : 'Expand'}" type="button">${isExpanded ? '▾' : '▸'}</button>`;
-    } else {
-      html += `<span data-bn="tree-indent"></span>`;
-    }
-    if (icon) html += `<span data-bn="tree-icon">${icon}</span>`;
-    html += `<span data-bn="tree-label">${node.label}</span>`;
-    html += `</div>`;
-
-    if (hasChildren && isExpanded) {
-      html += `<ul data-bn="tree-children" role="group">`;
-      for (const child of node.children) {
-        html += renderNode(child, level + 1);
+      let html = `<li data-bn="tree-item" role="treeitem"${ariaExpanded(hasChildren, isExpanded)} aria-selected="${isSelected}" data-node-id="${escapeAttr(nodeId)}" data-level="${level}">`;
+      html += `<div data-bn="tree-item-content"${isSelected ? ' data-selected' : ''}>`;
+      if (hasChildren) {
+        html += `<button data-bn="tree-toggle" aria-label="${isExpanded ? 'Collapse' : 'Expand'}" type="button">${isExpanded ? '▾' : '▸'}</button>`;
+      } else {
+        html += `<span data-bn="tree-indent"></span>`;
       }
-      html += `</ul>`;
-    }
+      if (icon) html += `<span data-bn="tree-icon">${icon}</span>`;
+      html += `<span data-bn="tree-label">${escapeText(node.label ?? '')}</span>`;
+      html += `</div>`;
 
-    html += `</li>`;
-    return html;
-  }
+      if (isExpanded) {
+        html += `<ul data-bn="tree-children" role="group">${children}</ul>`;
+      }
 
-  const itemsHtml = items.map(item => renderNode(item)).join('');
+      html += `</li>`;
+      return html;
+    },
+  });
 
-  return `<ul data-bn="tree" id="${id}" role="tree" ${attrs}>${itemsHtml}</ul>`;
+  return `<ul data-bn="tree" id="${escapeAttr(id)}" role="tree"${attrsSuffix(attrs)}>${itemsHtml}</ul>`;
 }
 
 /**
  * TreeGrid — tree structure combined with table columns.
+ *
+ * Column labels and cell values are escaped text. Leaf rows carry no
+ * aria-expanded attribute.
+ *
+ * @param {object} [options]
+ * @param {Array<{key: string, label: string}>} [options.columns]
+ * @param {Array<object>} [options.items]   Rows keyed by column key, with optional `id` and `children`
+ * @param {Set<string>} [options.expanded]  Node ids that are expanded
+ * @param {string} [options.id]             Defaults to nextId('treegrid')
+ * @param {string} [options.attrs]          Raw attribute markup appended to the <table>; not escaped
+ * @returns {string}
  */
 export function renderTreeGrid(options = {}) {
   const {
     columns = [],
     items = [],
     expanded = new Set(),
-    id = `bn-treegrid-${Math.random().toString(36).slice(2)}`,
+    id = nextId('treegrid'),
     attrs = '',
   } = options;
 
-  const headerCells = columns.map(col => `<th scope="col">${col.label}</th>`).join('');
+  const headerCells = columns.map(col => `<th scope="col">${escapeText(col.label ?? '')}</th>`).join('');
 
-  function renderRow(node, level = 0) {
-    const nodeId = node.id ?? node[columns[0]?.key];
-    const hasChildren = node.children && node.children.length > 0;
-    const isExpanded = expanded.has(nodeId);
+  const bodyHtml = renderNodes(items, {
+    getId: node => node.id ?? node[columns[0]?.key],
+    expanded,
+    render({ node, nodeId, hasChildren, isExpanded, level, children }) {
+      const indent = '  '.repeat(level);
+      const toggle = hasChildren ? (isExpanded ? '▾ ' : '▸ ') : '  ';
 
-    const indent = '  '.repeat(level);
-    const toggle = hasChildren ? (isExpanded ? '▾ ' : '▸ ') : '  ';
+      const cells = columns.map((col, i) => {
+        const value = escapeText(node[col.key] ?? '');
+        const prefix = i === 0 ? `<span data-level="${level}">${indent}${toggle}</span>` : '';
+        return `<td>${prefix}${value}</td>`;
+      }).join('');
 
-    const cells = columns.map((col, i) => {
-      const value = node[col.key] ?? '';
-      const prefix = i === 0 ? `<span data-level="${level}">${indent}${toggle}</span>` : '';
-      return `<td>${prefix}${value}</td>`;
-    }).join('');
+      return `<tr data-bn="treegrid-row" data-node-id="${escapeAttr(nodeId)}" aria-level="${level + 1}"${ariaExpanded(hasChildren, isExpanded)} role="row">${cells}</tr>${children}`;
+    },
+  });
 
-    let html = `<tr data-bn="treegrid-row" data-node-id="${nodeId}" aria-level="${level + 1}" aria-expanded="${hasChildren ? isExpanded : undefined}" role="row">${cells}</tr>`;
-
-    if (hasChildren && isExpanded) {
-      for (const child of node.children) {
-        html += renderRow(child, level + 1);
-      }
-    }
-
-    return html;
-  }
-
-  const bodyHtml = items.map(item => renderRow(item)).join('');
-
-  return `<table data-bn="treegrid" id="${id}" role="treegrid" ${attrs}>
+  return `<table data-bn="treegrid" id="${escapeAttr(id)}" role="treegrid"${attrsSuffix(attrs)}>
   <thead><tr>${headerCells}</tr></thead>
   <tbody>${bodyHtml}</tbody>
 </table>`;

--- a/packages/components/src/virtualizer.js
+++ b/packages/components/src/virtualizer.js
@@ -3,14 +3,36 @@
  * Actual virtualization happens client-side via hydration.
  * Server renders a window of items + a spacer for total height.
  */
+import { escapeAttr, escapeText } from '@basenative/runtime/shared/escape';
+import { nextId } from './ids.js';
+import { attrsSuffix } from './internal/attrs.js';
+
+/**
+ * Virtualizer — renders a virtual scroll container placeholder: a window of
+ * items plus a spacer for total height; actual virtualization happens
+ * client-side via hydration.
+ *
+ * The default renderItem escapes each item as text. A custom `renderItem`
+ * result is an HTML slot: not escaped; return trusted markup only.
+ *
+ * @param {object} [options]
+ * @param {Array<unknown>} [options.items]
+ * @param {number} [options.itemHeight=40]
+ * @param {number} [options.containerHeight=400]
+ * @param {(item: unknown, index: number) => string} [options.renderItem]
+ * @param {number} [options.overscan=5]
+ * @param {string} [options.id]     Defaults to nextId('virtual')
+ * @param {string} [options.attrs]  Raw attribute markup appended to the container; not escaped
+ * @returns {string}
+ */
 export function renderVirtualList(options = {}) {
   const {
     items = [],
     itemHeight = 40,
     containerHeight = 400,
-    renderItem = (item, index) => `<div data-bn="virtual-item" data-index="${index}">${item}</div>`,
+    renderItem = (item, index) => `<div data-bn="virtual-item" data-index="${index}">${escapeText(item)}</div>`,
     overscan = 5,
-    id = `bn-virtual-${Math.random().toString(36).slice(2)}`,
+    id = nextId('virtual'),
     attrs = '',
   } = options;
 
@@ -20,9 +42,9 @@ export function renderVirtualList(options = {}) {
 
   const itemsHtml = visibleItems.map((item, i) => renderItem(item, i)).join('');
 
-  return `<div data-bn="virtualizer" id="${id}" style="height:${containerHeight}px;overflow:auto" ${attrs}>
-  <div data-bn="virtual-spacer" style="height:${totalHeight}px;position:relative">
-    <div data-bn="virtual-window" style="position:absolute;top:0;left:0;right:0" data-item-height="${itemHeight}" data-total="${items.length}">
+  return `<div data-bn="virtualizer" id="${escapeAttr(id)}" style="height:${Number(containerHeight)}px;overflow:auto"${attrsSuffix(attrs)}>
+  <div data-bn="virtual-spacer" style="height:${Number(totalHeight)}px;position:relative">
+    <div data-bn="virtual-window" style="position:absolute;top:0;left:0;right:0" data-item-height="${Number(itemHeight)}" data-total="${items.length}">
       ${itemsHtml}
     </div>
   </div>

--- a/packages/components/types/index.d.ts
+++ b/packages/components/types/index.d.ts
@@ -1,5 +1,10 @@
 import type { Signal } from '@basenative/runtime';
 
+// Deterministic ids. Hydration needs either explicit `id` options or an
+// identical render order on server and client with resetIds() per request.
+export function nextId(prefix: string): string;
+export function resetIds(): void;
+
 // Button
 export function buttonVariants(variant?: string, size?: string): string;
 export function renderButton(content: string, options?: {
@@ -75,6 +80,7 @@ export function renderSelect(options?: {
   placeholder?: string;
   required?: boolean;
   disabled?: boolean;
+  helpText?: string;
   error?: string;
   id?: string;
 }): string;
@@ -89,11 +95,11 @@ export function renderAlert(content: string, options?: {
 export interface Toaster {
   position: string;
   duration: number;
-  toasts: Signal<Array<{ id: number; message: string; variant: string; duration: number }>>;
+  toasts: Signal<Array<{ id: string; message: string; variant: string; duration: number }>>;
 }
 export function createToaster(options?: { position?: string; duration?: number }): Toaster;
-export function showToast(toaster: Toaster, options?: { message?: string; variant?: string; duration?: number }): number;
-export function dismissToast(toaster: Toaster, id: number): void;
+export function showToast(toaster: Toaster, options?: { id?: string; message?: string; variant?: string; duration?: number }): string;
+export function dismissToast(toaster: Toaster, id: string): void;
 export function renderToastContainer(position?: string): string;
 
 // Table


### PR DESCRIPTION
## What

Engineering hardening of `packages/components/src` from the components audit. Public API is additive only (two new exports: `nextId`, `resetIds`; `renderSelect` gains `helpText`; `showToast` gains `options.id`).

### 1. Escaping — one implementation
- Deleted the nine private `escapeHtml` / `escapeAttr` / `esc` helpers (input, textarea, checkbox — which missed `<` — radio, select, badge, table, progress, layout-grid) and import `escapeText` / `escapeAttr` from `@basenative/runtime/shared/escape` everywhere.
- **Escaped:** every attribute interpolation (`id`, `name`, `value`, `placeholder`, `alt`, `src`, `href`, `aria-*`, `data-*`, variant/size/position, style values) and every text-semantic field (`label`, `helpText`, `error`, `caption`, `emptyMessage`, item/option labels, tooltip content, breadcrumb labels, avatar name, table/grid/treegrid cell values, calendar & pipeline titles).
- **Not escaped (HTML slots, documented on each parameter as "HTML slot: not escaped; pass trusted markup only"):** button/badge/alert content, card header/body/footer, dialog/drawer body & footer, accordion/tab panel content, dropdown/tooltip trigger, icons, DataGrid `render()` result, custom `renderItem`, and every `attrs`.
- One existing test (`Badge — additional › escapes HTML in badge content`) asserted the opposite of the decided policy; it now asserts badge content is a slot. Flagged in the summary so it can be reverted if the badge decision changes.

### 2. Deterministic ids
- New `src/ids.js`: `nextId(prefix)` → `bn-<prefix>-<n>` from a module counter; `resetIds()` for per-request SSR. Replaces every `Math.random().toString(36)` id (accordion, datagrid, dialog, drawer, command-palette, tabs, calendar, pipeline, combobox, tooltip, dropdown-menu, multiselect, virtualizer, tree ×2) and toast's `Date.now()+Math.random()`.
- Every renderer honours an explicit `id` first; combobox/multiselect keep their `bn-<kind>-<name>` derivation when a name is given.
- Exported from `index.js`, typed in `types/index.d.ts`, documented (hydration needs explicit ids or identical render order + `resetIds()` per request).

### 3. Bug fixes
- `tree.js`: leaf nodes no longer emit `aria-expanded="undefined"` (attribute omitted) in both Tree and TreeGrid.
- `input.js`: help → `<id>-help`, error → `<id>-error`, `aria-describedby` lists both when present.
- `textarea.js` / `select.js`: now emit `aria-describedby` and an error span id (same policy as input, via one shared `renderField`).
- `dialog.js`: `modal` is honoured — `aria-modal="true" data-modal="true"` vs `data-modal="false"`.
- `tabs.js`: tab buttons are `type="button"`.
- `drawer.js`: closed drawer renders `inert`, so the close button is not tabbable (no CSS change needed — `inert` keeps the slide transition).
- `progress.js`: `max=0` renders `0%` instead of `NaN%`.
- `calendar.js`: all local time — a date-only `startDate` is parsed as local midnight, day columns are keyed by local `YYYY-MM-DD`, day headers no longer shift by a day in non-UTC zones.
- `avatar.js`: with an `<img>` the wrapper has no `role="img"` (single announcement); initials path keeps `role="img"` + `aria-label`.
- `toggle.js`: `role="switch"` kept as-is.

### 4. Dedup (behaviour-preserving) — `src/internal/*` (not exported)
- `attrs.js` `attrsSuffix()` — replaces both `const extra = attrs ? ' ' + attrs : ''` and the bare trailing `` ${attrs}`` that leaked a stray space (22 files).
- `items.js` `normalizeItem()` — radio, select, combobox, multiselect.
- `field.js` `renderField()` + `describedBy()` — input, textarea, select share one field markup and one `aria-describedby` policy.
- `drag.js` `bindDrag()`, `clearDragState()`, `readDragData()` — `initCalendarDragDrop` / `initPipelineDragDrop`.
- `tree.js` `renderNodes()` + `ariaExpanded()` — Tree `renderNode` / TreeGrid `renderRow`.
- `skeleton.js`: `count === 1` special case removed.

### 5. Tests
`components.test.js` 90 → 255 (package total 136 → 301). Every renderer now has minimal / all-options / escaping (`"><script>` cannot break out of an attribute or label) / a11y tests, and every slot has a "still renders markup" test. Plus: two renders after `resetIds()` are byte-identical; every renderer honours an explicit id; drag-drop init bind/destroy/drop/malformed-payload with a fake container; calendar day-boundary test.

## Why

Nine divergent escapers (one missing `<`), random ids that made SSR output non-deterministic and hydration fragile, and a set of small a11y defects flagged by the audit. Consolidating on the runtime's shared escaper keeps server and client reading from one implementation.

## Not done (stop conditions)

- `layoutGridStyles()` was **not** deleted: it is a public export from `index.js` and the hard rule forbids removed exports. Marked `@deprecated` (additive) pointing at `components.css`; removal needs an API decision.

## Verification

```
cd packages/components && node --test                       # 301 pass, 0 fail
node ../../node_modules/eslint/bin/eslint.js src/           # clean
TZ=Asia/Tokyo|America/Los_Angeles|Pacific/Kiritimati node --test src/components.test.js   # 255 pass each
cd packages/mcp && node ../../scripts/llms-txt.js --check   # current
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
