### PR TITLE
ci(release): publish with NPM_TOKEN — GITHUB_TOKEN cannot reach the basenative org

### DIFF
--- a/.github/workflows/publish-direct.yml
+++ b/.github/workflows/publish-direct.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Publish loop
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -e
           PUBLISHED=()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Changesets reads NODE_AUTH_TOKEN for the publish step. GITHUB_TOKEN
-          # has packages:write within this repo, which is exactly what we need
-          # for @basenative/* on GitHub Packages.
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Changesets reads NODE_AUTH_TOKEN for the publish step. The @basenative
+          # packages live under the basenative org, so this repo's GITHUB_TOKEN can
+          # neither read nor write them — NPM_TOKEN is a PAT with packages:write there.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`changeset publish` failed with **E403** on its registry lookup for `@basenative/auth`: the packages are owned by the `basenative` org on GitHub Packages, and this repo's `GITHUB_TOKEN` has no access there. `NPM_TOKEN` already exists as a repo secret; the publish step now uses it (falling back to `GITHUB_TOKEN`). Same change in `publish-direct.yml`.

Once merged, Release re-runs on `main` and publishes the versions already bumped by #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)