### PR TITLE
chore(release): regenerate generated docs when changesets bump versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "audit:ux": "node scripts/audit/laws-of-ux.mjs",
     "audit": "pnpm audit:axe && pnpm audit:ux",
     "bundle-size": "node scripts/bundle-size.js",
-    "version": "changeset version && pnpm install --lockfile-only --ignore-scripts"
+    "version": "changeset version && pnpm install --lockfile-only --ignore-scripts && node scripts/package-inventory.js && node scripts/llms-txt.js"
   },
   "devDependencies": {
     "@changesets/cli": "^3.0.2",


### PR DESCRIPTION
## Why

CI on `main` has been red since the 0.5.0 Version Packages PR (#150) merged: the version bump made `docs/package-inventory.md` stale, and the Changesets-authored PR runs no CI, so nothing caught it before merge.

## What

- `version` script now runs `node scripts/package-inventory.js && node scripts/llms-txt.js` after `changeset version` and the lockfile refresh, so future Version Packages PRs carry regenerated docs.
- Regenerates `docs/package-inventory.md`, `llms.txt` and `llms-full.txt` for the current tree (0.5.0 + #147's component description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)