### PR TITLE
feat(evals): add hydration stage for scoring stateful (T3) templates

### DIFF
--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -26,9 +26,18 @@ Assertion *types* are infrastructure and live in `src/assertions.js`. Assertion
 prompts/ (hand-authored) → model runner → generated template
     → @basenative/validate   does it parse?
     → @basenative/server     does it render?
+    → @basenative/runtime    (stateful cases only) does it hydrate and react?
     → behavioural assertions does it do the thing?
     → score
 ```
+
+The hydrate stage only runs for a case that declares `state` or a hydrate-family
+assertion (`hydrated_contains`/`hydrated_excludes`/`after_set` — see
+`prompts/README.md`) — most cases are fully scored by SSR output alone. When it
+does run, it mounts the generated template — directives intact — into the same DOM
+shim `@basenative/runtime`'s own tests use, and runs the real client `hydrate()`
+against a context of real signals, which is the only way to score a signal,
+computed, or effect rather than just a template's static shape.
 
 Stages short-circuit: a template that does not parse cannot be meaningfully
 rendered, so `failedAt` tells you *where* a model went wrong, not just that it did.

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -13,6 +13,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@basenative/validate": "workspace:^0.1.1",
-    "@basenative/server": "workspace:^0.5.0"
+    "@basenative/server": "workspace:^0.5.0",
+    "@basenative/runtime": "workspace:^0.5.0"
   }
 }

--- a/packages/evals/prompts/README.md
+++ b/packages/evals/prompts/README.md
@@ -33,6 +33,33 @@ One JSON file per case:
 
 `id` must be unique. `tier` is one of `T1`–`T5`.
 
+### Scoring a stateful (T3) case: the `state` field
+
+`context` is what the template is server-rendered with — plain values (or, for a
+signal read like `count()`, a plain zero-arg function such as `count: () => 0`).
+It is **not** live: SSR evaluates every `{{ }}` once and discards the expression.
+
+A T3 case additionally needs its signal, computed, or effect exercised for real,
+which is what `state` is for. Add `"state": { "<name>": <initial value> }` and the
+harness wraps each entry in a real `@basenative/runtime` signal, mounts the
+*generated template itself* — directives intact, not the rendered HTML — into the
+same DOM shim `@basenative/runtime`'s own tests use, and runs the real client
+`hydrate()` against it before any hydrate-family assertion below is checked:
+
+```json
+{
+  "state": { "count": 0 },
+  "assertions": [
+    { "type": "hydrated_contains", "value": "0" },
+    { "type": "after_set", "signal": "count", "value": 5,
+      "then": { "type": "hydrated_contains", "value": "5" } }
+  ]
+}
+```
+
+A case needs `state` only if it has a hydrate-family assertion (or otherwise wants
+live signals mounted); T1/T2/T4/T5 cases are unaffected and never pay for hydration.
+
 ## Tiers
 
 | Tier | Content | Target |
@@ -57,5 +84,13 @@ the items" — to measure nearest-neighbour drift directly rather than inferring
 | `renders_equals` | `value` | Equal after collapsing whitespace |
 | `renders_count` | `value`, `count` | Exact number of occurrences |
 | `uses_directive` | `value` | The generated template used that directive |
+| `hydrated_contains` | `value` | The hydrated DOM contains the substring, right after `hydrate()` runs |
+| `hydrated_excludes` | `value` | The hydrated DOM does not contain it |
+| `after_set` | `signal`, `value`, `then` | Sets a live signal from `state` to `value`, then re-checks the nested `then` assertion (any registered type — typically `hydrated_contains`/`hydrated_excludes`) against the resulting DOM |
+
+The last three trigger the hydrate stage even without `state` on the case, but
+`after_set` then has no signal to find — it fails that assertion cleanly (naming
+the missing signal) rather than silently skipping the check. In practice, always
+pair a hydrate-family assertion with the `state` entry it needs.
 
 Assertion *types* are infrastructure. Assertion *values* are yours.

--- a/packages/evals/src/assertions.js
+++ b/packages/evals/src/assertions.js
@@ -4,7 +4,16 @@
  * The assertion *types* are infrastructure and live here. The assertion *values* —
  * what a correct answer looks like for a given prompt — are hand-authored in the
  * corpus and must never be generated.
+ *
+ * `renders_*` check the SSR output string. `hydrated_*` and `after_set` check a
+ * *live* DOM produced by the hydrate stage (see hydrate.js) — the only way to score
+ * a stateful (T3) case, because SSR evaluates every `{{ }}` to a static value and
+ * strips every `@`-prefixed directive from its output (see @basenative/server's
+ * render.js), so a rendered-HTML string can never exercise a signal, computed, or
+ * effect.
  */
+export const HYDRATE_ASSERTION_TYPES = new Set(['hydrated_contains', 'hydrated_excludes', 'after_set']);
+
 export const ASSERTION_TYPES = {
   /** Rendered HTML contains this substring. */
   renders_contains: (html, a) => ({
@@ -44,17 +53,65 @@ export const ASSERTION_TYPES = {
     const n = html.split(a.value).length - 1;
     return { pass: n === a.count, detail: `expected ${a.count} occurrence(s) of ${JSON.stringify(a.value)}, got ${n}` };
   },
+
+  /** The hydrated DOM contains this substring right after hydrate() runs. */
+  hydrated_contains: (dom, a) => ({
+    pass: dom.includes(a.value),
+    detail: `expected the hydrated DOM to contain ${JSON.stringify(a.value)}`,
+  }),
+
+  /** The hydrated DOM does NOT contain this substring right after hydrate() runs. */
+  hydrated_excludes: (dom, a) => ({
+    pass: !dom.includes(a.value),
+    detail: `expected the hydrated DOM NOT to contain ${JSON.stringify(a.value)}`,
+  }),
+
+  /**
+   * Set a live signal from the case's `state`, then re-check a nested assertion
+   * (`then` — typically `hydrated_contains`/`hydrated_excludes`, but any registered
+   * type works) against the DOM that results. This is the only way to score
+   * reactivity itself rather than just a template's initial hydrated shape.
+   */
+  after_set: (_dom, a, extra) => {
+    const { ctx, root } = extra ?? {};
+    if (!ctx || !root) {
+      return { pass: false, detail: 'after_set requires a hydrated context — add "state" to the case' };
+    }
+    const target = ctx[a.signal];
+    if (typeof target?.set !== 'function') {
+      return { pass: false, detail: `after_set: no signal named "${a.signal}" in the hydration context` };
+    }
+
+    target.set(a.value);
+
+    const thenRunner = ASSERTION_TYPES[a.then?.type];
+    if (!thenRunner) {
+      return { pass: false, detail: `after_set: unknown "then" assertion type ${JSON.stringify(a.then?.type)}` };
+    }
+    const { pass, detail } = thenRunner(root.innerHTML, a.then, extra);
+    return { pass, detail: `after setting ${a.signal} = ${JSON.stringify(a.value)}: ${detail}` };
+  },
 };
+
+/** True when a case's own declarations require the hydrate stage to run. */
+function needsHydration(testCase) {
+  return Boolean(testCase.state) || testCase.assertions.some((a) => HYDRATE_ASSERTION_TYPES.has(a.type));
+}
 
 /**
  * Score one generated template against a hand-authored case.
  *
  * The pipeline is staged, and an earlier stage failing short-circuits the rest:
  * a template that does not parse cannot be meaningfully rendered, and a template
- * that does not render cannot satisfy a behavioural assertion.
+ * that does not render cannot satisfy a behavioural assertion. Hydration is the one
+ * optional stage — it only runs when the case declares `state` or a hydrate-family
+ * assertion, since most cases (T1/T2/T4/T5) are fully scored by SSR output alone.
+ *
+ * `hydrate`, like `render`, is injected so tests can drive the pipeline without a
+ * real DOM; in production it defaults to mounting the DOM shim in hydrate.js.
  */
-export function scoreTemplate({ template, testCase, validate, render }) {
-  const stages = { parses: false, renders: false, assertions: [] };
+export function scoreTemplate({ template, testCase, validate, render, hydrate }) {
+  const stages = { parses: false, renders: false, hydrates: false, assertions: [] };
 
   const validation = validate(template, testCase.context ? { context: testCase.context } : undefined);
   stages.diagnostics = validation.diagnostics;
@@ -72,13 +129,29 @@ export function scoreTemplate({ template, testCase, validate, render }) {
     return { ...stages, passed: false, failedAt: 'render', error: err.message };
   }
 
+  let hydrated = null;
+  if (needsHydration(testCase)) {
+    if (typeof hydrate !== 'function') {
+      return { ...stages, passed: false, failedAt: 'hydrate', error: 'this case needs hydration but no hydrate function was provided' };
+    }
+    try {
+      hydrated = hydrate(template, testCase.state ?? {});
+      stages.hydrates = true;
+    } catch (err) {
+      return { ...stages, passed: false, failedAt: 'hydrate', error: err.message };
+    }
+  }
+
   for (const a of testCase.assertions) {
     const runner = ASSERTION_TYPES[a.type];
     if (!runner) {
       stages.assertions.push({ ...a, pass: false, detail: `unknown assertion type "${a.type}"` });
       continue;
     }
-    const { pass, detail } = runner(html, a, { template });
+    const isHydrateAssertion = HYDRATE_ASSERTION_TYPES.has(a.type);
+    const subject = isHydrateAssertion ? (hydrated?.root.innerHTML ?? '') : html;
+    const extra = { template, ctx: hydrated?.ctx, root: hydrated?.root };
+    const { pass, detail } = runner(subject, a, extra);
     stages.assertions.push({ ...a, pass, detail });
   }
 

--- a/packages/evals/src/evals.test.js
+++ b/packages/evals/src/evals.test.js
@@ -130,6 +130,77 @@ describe('scoring pipeline', () => {
   });
 });
 
+describe('hydrate stage', () => {
+  // A minimal stand-in for the DOM: tracks one string that "count.set()" rewrites,
+  // just enough to prove scoreTemplate's stage-gating and assertion wiring without
+  // spinning up the real DOM shim (covered separately by the end-to-end tests below).
+  const fakeHydrate = () => {
+    const root = { innerHTML: '<p>0</p>' };
+    const ctx = { count: { set: (v) => { root.innerHTML = `<p>${v}</p>`; } } };
+    return { root, ctx };
+  };
+
+  it('skips the hydrate stage for a case with neither "state" nor a hydrate assertion', () => {
+    const r = scoreTemplate({
+      template: '<template @if="user"><p>{{ user.name }}</p></template>',
+      testCase: CASE, validate: validateTemplate, render: fakeRender,
+    });
+    assert.equal(r.hydrates, false);
+    assert.equal(r.passed, true);
+  });
+
+  it('fails at "hydrate" when a case needs it but no hydrate function was injected', () => {
+    const r = scoreTemplate({
+      template: '<p>{{ count() }}</p>',
+      testCase: { ...CASE, state: { count: 0 }, assertions: [{ type: 'hydrated_contains', value: '0' }] },
+      validate: validateTemplate, render: fakeRender,
+    });
+    assert.equal(r.passed, false);
+    assert.equal(r.failedAt, 'hydrate');
+  });
+
+  it('checks hydrated_contains/hydrated_excludes against the hydrated DOM, not the SSR html', () => {
+    const r = scoreTemplate({
+      template: '<p>{{ count() }}</p>',
+      testCase: {
+        ...CASE, state: { count: 0 },
+        assertions: [
+          { type: 'hydrated_contains', value: '0' },
+          { type: 'hydrated_excludes', value: '99' },
+        ],
+      },
+      validate: validateTemplate, render: fakeRender, hydrate: fakeHydrate,
+    });
+    assert.equal(r.hydrates, true);
+    assert.equal(r.passed, true);
+  });
+
+  it('after_set mutates the live signal and re-checks the resulting DOM', () => {
+    const r = scoreTemplate({
+      template: '<p>{{ count() }}</p>',
+      testCase: {
+        ...CASE, state: { count: 0 },
+        assertions: [{ type: 'after_set', signal: 'count', value: 7, then: { type: 'hydrated_contains', value: '7' } }],
+      },
+      validate: validateTemplate, render: fakeRender, hydrate: fakeHydrate,
+    });
+    assert.equal(r.passed, true, JSON.stringify(r.assertions));
+  });
+
+  it('after_set fails cleanly against a signal name that is not in the hydration context', () => {
+    const r = scoreTemplate({
+      template: '<p>{{ count() }}</p>',
+      testCase: {
+        ...CASE, state: { count: 0 },
+        assertions: [{ type: 'after_set', signal: 'nope', value: 1, then: { type: 'hydrated_contains', value: '1' } }],
+      },
+      validate: validateTemplate, render: fakeRender, hydrate: fakeHydrate,
+    });
+    assert.equal(r.passed, false);
+    assert.match(r.assertions[0].detail, /no signal named "nope"/);
+  });
+});
+
 describe('prompt construction', () => {
   // If the two conditions differed by more than the tool sentence, the measured
   // delta would confound "has tools" with "was told more about the language".
@@ -174,6 +245,15 @@ describe('summary and deltas', () => {
 
   it('ignores a model that only ran one condition', () => {
     assert.deepEqual(computeDeltas([{ model: 'm', withMcp: false, summary: { passRate: 1, driftRate: 0 } }]), []);
+  });
+
+  it('buckets a hydrate-stage failure in "Where failures happen"', () => {
+    const s = summarise([{ id: 'z', tier: 'T3', passed: false, failedAt: 'hydrate', diagnostics: [] }]);
+    assert.equal(s.byStage.hydrate, 1);
+
+    const md = toMarkdown({ coverage: { T3: 1 }, runs: [{ model: 'stub', withMcp: false, summary: s }], deltas: [] });
+    assert.match(md, /## Where failures happen/);
+    assert.match(md, /\| hydrate \| 1 \|/);
   });
 });
 
@@ -308,5 +388,59 @@ describe('end to end', () => {
     assert.match(md, /# BaseNative eval results/);
     assert.match(md, /Corpus coverage/);
     assert.match(md, /50\.0%/);
+  });
+
+  // No injected `hydrate` here — this drives the real default hydrate stage, which
+  // mounts the generated template into @basenative/runtime's own DOM shim (happy-dom,
+  // see hydrate.js) and runs the real client hydrate() against it, so this is the
+  // one test in the file that proves a T3 (stateful) case can actually be scored.
+  it('scores a stateful (T3) case by hydrating it with live signals', async () => {
+    const STATEFUL_CASE = {
+      id: 't3-counter', tier: 'T3',
+      prompt: 'A counter that increments on click',
+      state: { count: 0 },
+      assertions: [
+        { type: 'hydrated_contains', value: '0' },
+        { type: 'after_set', signal: 'count', value: 5, then: { type: 'hydrated_contains', value: '5' } },
+      ],
+    };
+    const generate = async () => '<p>{{ count() }}</p><button @click="count.set(count() + 1)">+</button>';
+
+    const suite = await runSuite({
+      cases: [STATEFUL_CASE],
+      models: [{ id: 'stub' }],
+      generate,
+      render: fakeRender,
+      conditions: [false],
+    });
+
+    const [result] = suite.runs[0].results;
+    assert.equal(result.hydrates, true);
+    assert.equal(result.passed, true, JSON.stringify(result.assertions));
+    assert.equal(suite.runs[0].summary.passRate, 1);
+  });
+
+  it('fails a drifted stateful template at "assertions" when the signal never reaches the DOM', async () => {
+    const STATEFUL_CASE = {
+      id: 't3-static', tier: 'T3',
+      prompt: 'A counter that increments on click',
+      state: { count: 0 },
+      assertions: [{ type: 'after_set', signal: 'count', value: 5, then: { type: 'hydrated_contains', value: '5' } }],
+    };
+    // No {{ count() }} binding at all, so hydrate() has nothing to reattach.
+    const generate = async () => '<p>static</p>';
+
+    const suite = await runSuite({
+      cases: [STATEFUL_CASE],
+      models: [{ id: 'stub' }],
+      generate,
+      render: fakeRender,
+      conditions: [false],
+    });
+
+    const [result] = suite.runs[0].results;
+    assert.equal(result.hydrates, true);
+    assert.equal(result.passed, false);
+    assert.equal(result.failedAt, 'assertions');
   });
 });

--- a/packages/evals/src/hydrate.js
+++ b/packages/evals/src/hydrate.js
@@ -1,0 +1,57 @@
+/**
+ * Default hydrate stage.
+ *
+ * validate/render never execute a template's reactive behaviour. SSR replaces every
+ * `{{ }}` with its evaluated value and strips every `@`-prefixed directive from its
+ * output outright (see @basenative/server's render.js: `if (name.startsWith('@'))
+ * continue;`), so the rendered HTML string retains no signal, computed, or effect
+ * for a stateful (T3) case to be scored against — there is nothing left to hydrate.
+ *
+ * BaseNative is zero-build: the directive-laden *template* is what a real browser
+ * receives and hydrates in place, not a fully-evaluated SSR string. So this stage
+ * mounts the template itself — not `html` — into a DOM and runs the real client
+ * hydrate() against it with a live context, exactly mirroring
+ * packages/runtime/src/hydrate.test.js's own cases (which likewise mount raw
+ * directive markup, never rendered output).
+ *
+ * The DOM shim is happy-dom, already a workspace devDependency used by that same
+ * test file — nothing new is added here. Its `Window` stands in for a browser well
+ * enough for `document`/`Node` to be pinned onto `globalThis` for the duration of
+ * the (synchronous) hydrate() call, which is how the runtime's own tests do it.
+ *
+ * Pinning `document` onto `globalThis` is safe under runModel's concurrent workers
+ * only because every step from here through the assertion loop that reads it
+ * (mounting, hydrate(), and any `after_set` signal.set()) is synchronous — nothing
+ * awaits in between. If any of that ever becomes async, concurrent cases would
+ * stomp on each other's `document`.
+ */
+export async function defaultHydrate() {
+  const { Window } = await import('happy-dom');
+  const { hydrate, signal } = await import('@basenative/runtime');
+
+  /**
+   * @param {string} template - the generated template markup (directives intact).
+   * @param {Record<string, unknown>} state - case-declared initial values; each is
+   *   wrapped in a real signal so `after_set` assertions can mutate it afterwards.
+   * @returns {{ root: Element, ctx: Record<string, unknown> }}
+   */
+  return function domHydrate(template, state) {
+    const window = new Window({ url: 'http://localhost' });
+    const document = window.document;
+    globalThis.document = document;
+    globalThis.window = window;
+    globalThis.Node = window.Node;
+
+    const ctx = {};
+    for (const [key, value] of Object.entries(state ?? {})) {
+      ctx[key] = signal(value);
+    }
+
+    const root = document.createElement('div');
+    root.innerHTML = template;
+    document.body.append(root);
+    hydrate(root, ctx);
+
+    return { root, ctx };
+  };
+}

--- a/packages/evals/src/run.js
+++ b/packages/evals/src/run.js
@@ -1,5 +1,6 @@
 import { validateTemplate } from '@basenative/validate';
 import { scoreTemplate } from './assertions.js';
+import { defaultHydrate } from './hydrate.js';
 import { extractTemplate, resolveCredentials } from './providers.js';
 import { tierCoverage, TIERS } from './corpus.js';
 
@@ -34,8 +35,9 @@ export async function defaultRender() {
   return render;
 }
 
-export async function runModel({ model, cases, withMcp, generate, render, concurrency = 4 }) {
+export async function runModel({ model, cases, withMcp, generate, render, hydrate, concurrency = 4 }) {
   const renderFn = render ?? (await defaultRender());
+  const hydrateFn = hydrate ?? (await defaultHydrate());
   const results = [];
   const queue = [...cases];
 
@@ -52,7 +54,7 @@ export async function runModel({ model, cases, withMcp, generate, render, concur
         continue;
       }
       const template = extractTemplate(raw);
-      const score = scoreTemplate({ template, testCase, validate: validateTemplate, render: renderFn });
+      const score = scoreTemplate({ template, testCase, validate: validateTemplate, render: renderFn, hydrate: hydrateFn });
       results.push({ id: testCase.id, tier: testCase.tier, template, ...score });
     }
   }
@@ -99,14 +101,15 @@ export function summarise(results) {
  * Run every model under both conditions. The delta between them is the product
  * claim: does giving a model a validator actually make it write correct BaseNative?
  */
-export async function runSuite({ cases, models, generate, render, env = process.env, conditions = [false, true] }) {
+export async function runSuite({ cases, models, generate, render, hydrate, env = process.env, conditions = [false, true] }) {
   const resolved = generate ? models : resolveCredentials(models, env);
   const renderFn = render ?? (await defaultRender());
+  const hydrateFn = hydrate ?? (await defaultHydrate());
   const runs = [];
   for (const model of resolved) {
     for (const withMcp of conditions) {
       const gen = generate ?? ((prompt, m) => m.provider.generate(prompt, m));
-      runs.push(await runModel({ model, cases, withMcp, generate: gen, render: renderFn }));
+      runs.push(await runModel({ model, cases, withMcp, generate: gen, render: renderFn, hydrate: hydrateFn }));
     }
   }
   return { coverage: tierCoverage(cases), runs, deltas: computeDeltas(runs) };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
 
   packages/evals:
     dependencies:
+      '@basenative/runtime':
+        specifier: workspace:^0.5.0
+        version: link:../runtime
       '@basenative/server':
         specifier: workspace:^0.5.0
         version: link:../server


### PR DESCRIPTION
## Summary

- `@basenative/evals` validated and SSR-rendered generated templates but never hydrated, so signal/computed/effect (T3) behaviour went unscored — SSR evaluates every `{{ }}` to a static value and strips every `@`-prefixed directive from its output outright, leaving nothing reactive to check.
- Adds an optional hydrate stage to `scoreTemplate`, run only when a case declares `state` or a hydrate-family assertion. It mounts the *generated template itself* (directives intact — not the SSR output, which has none left) into the same happy-dom shim `@basenative/runtime`'s own tests already use, wraps each `state` entry in a real signal, and runs the real client `hydrate()` against it.
- New case field `state` (e.g. `{"count": 0}`) and assertion types `hydrated_contains` / `hydrated_excludes` (check the DOM right after `hydrate()`) and `after_set` (`{signal, value, then}` — mutate a live signal, then re-check a nested assertion against the resulting DOM; the only way to score reactivity itself).
- `scoreTemplate` gains an injectable `hydrate` (mirrors `render`, default lazily resolved from `@basenative/runtime`) and a `hydrates` stage flag, with `failedAt: 'hydrate'` on stage failure. `summarise`/`toMarkdown`'s "Where failures happen" already buckets by `failedAt` generically, so a hydrate-stage failure shows up there with no `report.js` changes needed (added a test proving it).
- Documented the new case field and assertion types in `packages/evals/prompts/README.md` (the only file under `prompts/` touched — schema snippet only, no new hand-authored example case) and updated `packages/evals/README.md`'s pipeline diagram.
- Infrastructure only: `packages/evals/prompts/` and `packages/evals/fixtures/` are untouched (both remain empty, as expected — hand-authored by the repo owner).
- No changeset: `@basenative/evals` is private (`"private": true`) and unpublished, so none is needed.

## Test plan

- [x] `cd packages/evals && node --test` — 38/38 passing (30 pre-existing + 8 new: 5 hydrate-stage wiring unit tests, 1 report-bucketing test, 2 end-to-end tests including the required stateful counter case using the real DOM shim)
- [x] `cd packages/evals && pnpm exec eslint src/` — clean
- [x] `cd packages/runtime && node --test` — 460/460 still passing (untouched)
- [x] `cd packages/mcp && node ../../scripts/llms-txt.js` — no diff (evals is a private package excluded from the detailed API reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)