### PR TITLE
fix(og-image,favicon): make wasm-backed PNG generation work under Node

### DIFF
--- a/.changeset/fix-favicon-resvg-and-manifest-names.md
+++ b/.changeset/fix-favicon-resvg-and-manifest-names.md
@@ -1,0 +1,5 @@
+---
+"@basenative/favicon": patch
+---
+
+PNG generation resolves resvg; clear message when missing; manifest names

--- a/.changeset/fix-og-image-node-wasm.md
+++ b/.changeset/fix-og-image-node-wasm.md
@@ -1,0 +1,5 @@
+---
+"@basenative/og-image": patch
+---
+
+renderPng works under Node

--- a/packages/favicon/README.md
+++ b/packages/favicon/README.md
@@ -6,8 +6,12 @@
 
 ```bash
 pnpm add -D @basenative/favicon
-# Optional — only needed for PNG fallbacks (apple-touch-icon, maskable):
-pnpm add -D @basenative/og-image
+```
+
+PNG fallbacks (`apple-touch-icon.png`, `maskable.png`, etc.) need `@resvg/resvg-wasm`, declared as an `optionalDependency` — most installs get it for free. If your install skips optional dependencies (`--no-optional` or similar) and you want PNGs, add it explicitly:
+
+```bash
+pnpm add -D @resvg/resvg-wasm
 ```
 
 ## The brand rule: SVG primary, raster only when iOS demands it
@@ -52,7 +56,9 @@ bn-favicon html --theme-color "#0C0B09"
 bn-favicon list
 ```
 
-If you have `@basenative/og-image` installed, `init` also writes `apple-touch-icon.png`, `icon-192.png`, `icon-512.png`, and `maskable.png`. Without it, you get the SVG-only set — which is fine for most sites until you decide you care about iOS home-screen icons.
+If `@resvg/resvg-wasm` is installed, `init` also writes `apple-touch-icon.png`, `icon-192.png`, `icon-512.png`, and `maskable.png`. Without it, you get the SVG-only set — which is fine for most sites until you decide you care about iOS home-screen icons — and the CLI prints one line telling you what's missing and how to install it.
+
+By default the manifest's `name`/`short_name` use the preset's display name (e.g. `basenative` → "BaseNative"). Pass `--name` to override, or use `defineFavicon(...).manifest({ name: ... })` programmatically.
 
 ## Programmatic API
 
@@ -139,7 +145,7 @@ The whole point is to look great as a browser tab favicon. Render the SVG into a
 | `@basenative/favicon/glyphs`      | Glyph library — `monogram`, `symbol`, `sigil`, `wordmark`. |
 | `@basenative/favicon/palette`     | Color helpers — `resolvePalette`, `mix`, `luminance`. |
 | `@basenative/favicon/manifest`    | Web App Manifest builder.                            |
-| `@basenative/favicon/png`         | Optional PNG rasterizer (peer: `@basenative/og-image`). |
+| `@basenative/favicon/png`         | Optional PNG rasterizer (optional dep: `@resvg/resvg-wasm`). |
 | `@basenative/favicon/presets`     | DuganLabs preset map.                                |
 
 ## License

--- a/packages/favicon/package.json
+++ b/packages/favicon/package.json
@@ -63,13 +63,8 @@
     "manifest",
     "duganlabs"
   ],
-  "peerDependencies": {
-    "@basenative/og-image": "workspace:*"
-  },
-  "peerDependenciesMeta": {
-    "@basenative/og-image": {
-      "optional": true
-    }
+  "optionalDependencies": {
+    "@resvg/resvg-wasm": "^2.6.2"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/favicon/src/cli.js
+++ b/packages/favicon/src/cli.js
@@ -6,8 +6,9 @@
  * Subcommands:
  *   - `bn-favicon init [preset]` — interactive (or non-interactive with
  *     `--preset`) generation. Writes `public/favicon.svg`,
- *     `public/manifest.json`, and (if `@basenative/og-image` is installed)
- *     a full PNG icon set. Idempotent — asks before overwriting.
+ *     `public/manifest.json`, and (if the optional `@resvg/resvg-wasm`
+ *     dependency is installed) a full PNG icon set. Idempotent — asks
+ *     before overwriting.
  *   - `bn-favicon render <preset>` — render a preset to stdout (SVG).
  *   - `bn-favicon html [--theme-color <hex>]` — print the recommended
  *     `<head>` tags.
@@ -30,7 +31,7 @@ import { defineFavicon, htmlTags, presets, presetList } from "./index.js";
 const HELP = `bn-favicon — SVG-first favicon generator
 
 Usage:
-  bn-favicon init [--preset <name>] [--out <dir>] [--force]
+  bn-favicon init [--preset <name>] [--out <dir>] [--force] [--name <name>]
   bn-favicon render <preset>
   bn-favicon html [--theme-color <hex>] [--svg-href <path>]
   bn-favicon list
@@ -38,6 +39,7 @@ Usage:
 Examples:
   bn-favicon init                  # interactive
   bn-favicon init --preset tabs    # one-shot, default output dir is ./public
+  bn-favicon init --preset tabs --name "T4BS"   # override manifest name/short_name
   bn-favicon render basenative     # SVG to stdout
   bn-favicon html --theme-color "#0C0B09"
 
@@ -78,6 +80,7 @@ async function cmdInit(argv) {
       preset: { type: "string" },
       out: { type: "string", default: "public" },
       force: { type: "boolean", default: false },
+      name: { type: "string" },
     },
     allowPositionals: false,
   });
@@ -102,16 +105,23 @@ async function cmdInit(argv) {
   const outDir = resolve(process.cwd(), values.out);
   await mkdir(outDir, { recursive: true });
 
+  // Manifest `name`/`short_name`: prefer an explicit `--name`, then the
+  // preset's display name (e.g. "BaseNative" for the `basenative` preset),
+  // falling back to the preset's lowercase id for presets/specs that don't
+  // carry a display name.
+  const manifestName = values.name || preset.displayName || preset.name;
+
   // Always-on writes.
   await writeIfAllowed(resolve(outDir, "favicon.svg"), fav.svg, values.force);
   await writeIfAllowed(
     resolve(outDir, "manifest.json"),
-    fav.manifest({ name: preset.name, themeColor: preset.themeColor }),
+    fav.manifest({ name: manifestName, themeColor: preset.themeColor }),
     values.force,
   );
 
-  // PNG fallbacks — best-effort. If the optional peer is missing we surface
-  // a clear note and keep going.
+  // PNG fallbacks — best-effort. If the optional `@resvg/resvg-wasm`
+  // dependency is missing, `png.js` throws one clear, actionable message —
+  // relay exactly that line and keep going rather than silently skipping.
   let pngsWritten = 0;
   try {
     const { toIconSet } = await import("./png.js");
@@ -122,8 +132,7 @@ async function cmdInit(argv) {
     }
   } catch (err) {
     process.stderr.write(
-      `\nbn-favicon: skipped PNG generation — install @basenative/og-image to enable.\n` +
-        `  ${err && /** @type {any} */ (err).message}\n\n`,
+      `\nbn-favicon: ${err && /** @type {any} */ (err).message ? /** @type {any} */ (err).message : err}\n\n`,
     );
   }
 

--- a/packages/favicon/src/index.js
+++ b/packages/favicon/src/index.js
@@ -6,7 +6,7 @@
  * (Chrome, Edge, Firefox, Safari ≥16) renders `<link rel="icon"
  * type="image/svg+xml">` natively, including in browser tabs. PNG is only
  * needed for iOS home-screen and Android adaptive icons — and we generate
- * those on demand via the optional `@basenative/og-image` peer.
+ * those on demand via the optional `@resvg/resvg-wasm` dependency.
  *
  * Public API:
  *   - {@link defineFavicon} — turn a glyph + palette + shape spec into a
@@ -19,7 +19,7 @@
  *   - `./glyphs`   — glyph library (`monogram`, `symbol`, `sigil`).
  *   - `./palette`  — color helpers.
  *   - `./manifest` — Web App Manifest builder.
- *   - `./png`      — optional PNG rasterizer (peer: `@basenative/og-image`).
+ *   - `./png`      — optional PNG rasterizer (optional dep: `@resvg/resvg-wasm`).
  *   - `./presets`  — DuganLabs project presets.
  *
  * @module

--- a/packages/favicon/src/png.js
+++ b/packages/favicon/src/png.js
@@ -28,13 +28,24 @@ let _resvgInit = null;
 async function loadResvg() {
   if (_resvgInit) return _resvgInit;
   _resvgInit = (async () => {
-    if (!isResvgAvailable()) {
-      throw new Error(
+    const missing = () =>
+      new Error(
         'PNG generation skipped — optional dependency "@resvg/resvg-wasm" is not installed. ' +
           "Install it with: pnpm add -D @resvg/resvg-wasm",
       );
+    if (!isResvgAvailable()) throw missing();
+    let mod;
+    try {
+      mod = await import("@resvg/resvg-wasm");
+    } catch (err) {
+      // Belt and braces: if resolution succeeded but the import still cannot
+      // find the package, report the same single clear line instead of
+      // Node's raw (multi-line) module-not-found message.
+      if (err && err.code === "ERR_MODULE_NOT_FOUND" && /@resvg\/resvg-wasm/.test(String(err.message))) {
+        throw missing();
+      }
+      throw err;
     }
-    const mod = await import("@resvg/resvg-wasm");
     await ensureResvg(mod);
     return { Resvg: mod.Resvg };
   })();

--- a/packages/favicon/src/png.js
+++ b/packages/favicon/src/png.js
@@ -5,56 +5,37 @@
  * maskable / Android adaptive icons (`maskable.png`, 512×512).
  *
  * This module deliberately defers loading `@resvg/resvg-wasm` until call
- * time so the SVG-only happy path stays dependency-free. We pull resvg in
- * via the optional peer `@basenative/og-image`, which already ships and
- * caches the wasm module; if that peer is not installed we fall back to a
- * direct `@resvg/resvg-wasm` import. If neither is available, the call
- * throws a clear error pointing the user at the install command.
+ * time so the SVG-only happy path stays dependency-free. `@resvg/resvg-wasm`
+ * is declared as an `optionalDependency` of this package (same version
+ * `@basenative/og-image` uses) — not pulled in transitively through
+ * og-image, which this package must not depend on. If it's genuinely not
+ * installed, the call throws one clear error naming it and how to install
+ * it, instead of silently skipping.
  *
  * @module
  */
 
+import { isResvgAvailable, ensureResvg } from "./wasm-node.js";
+
 let _resvgInit = null;
 
 /**
- * Resolve the Resvg constructor + wasm-init promise. Memoized per isolate.
+ * Resolve the Resvg constructor, initializing the WASM module on first
+ * call. Memoized for the life of the process.
  *
  * @returns {Promise<{ Resvg: any }>}
  */
 async function loadResvg() {
   if (_resvgInit) return _resvgInit;
   _resvgInit = (async () => {
-    let mod;
-    try {
-      mod = await import("@resvg/resvg-wasm");
-    } catch (err) {
+    if (!isResvgAvailable()) {
       throw new Error(
-        "@basenative/favicon: PNG conversion requires `@resvg/resvg-wasm`, " +
-          "shipped transitively via the optional peer `@basenative/og-image`. " +
-          "Install with: pnpm add @basenative/og-image\n" +
-          `Underlying error: ${err && /** @type {any} */ (err).message}`,
-        { cause: err },
+        'PNG generation skipped — optional dependency "@resvg/resvg-wasm" is not installed. ' +
+          "Install it with: pnpm add -D @resvg/resvg-wasm",
       );
     }
-    // resvg-wasm needs initWasm() called once per isolate. The `@basenative/
-    // og-image` package handles this via its own helper; if that's available
-    // we reuse it so we don't re-fetch the wasm bytes.
-    try {
-      const og = await import("@basenative/og-image");
-      if (typeof (/** @type {any} */ (og).ensureResvg) === "function") {
-        await (/** @type {any} */ (og).ensureResvg)();
-        return { Resvg: mod.Resvg };
-      }
-    } catch {
-      // og-image isn't installed — fall through to direct init.
-    }
-    if (typeof mod.initWasm === "function") {
-      // Direct init: pull bytes from the package's bundled wasm.
-      const wasm = await import("@resvg/resvg-wasm/index_bg.wasm").catch(() => null);
-      if (wasm && wasm.default) {
-        await mod.initWasm(wasm.default);
-      }
-    }
+    const mod = await import("@resvg/resvg-wasm");
+    await ensureResvg(mod);
     return { Resvg: mod.Resvg };
   })();
   return _resvgInit;

--- a/packages/favicon/src/presets/dl.js
+++ b/packages/favicon/src/presets/dl.js
@@ -17,6 +17,7 @@
 
 /** @typedef {import("../render.js").FaviconSpec & {
  *   name: string,
+ *   displayName: string,
  *   description: string,
  *   themeColor: string,
  * }} Preset */
@@ -24,6 +25,7 @@
 /** @type {Preset} */
 export const tabs = {
   name: "tabs",
+  displayName: "T4BS",
   description: "T4BS — '5 Things in 4 Tabs' word game",
   glyph: { kind: "monogram", text: "T", weight: 900, accentDot: true },
   palette: { bg: "#0C0B09", fg: "#FFF3E0", accent: "#E8920A" },
@@ -34,6 +36,7 @@ export const tabs = {
 /** @type {Preset} */
 export const basenative = {
   name: "basenative",
+  displayName: "BaseNative",
   description: "BaseNative — the org's foundation framework",
   glyph: { kind: "sigil", sigil: "signal-stack" },
   palette: { bg: "#0C0B09", fg: "#F0EDE4", accent: "#E8920A" },
@@ -44,6 +47,7 @@ export const basenative = {
 /** @type {Preset} */
 export const duganlabs = {
   name: "duganlabs",
+  displayName: "DuganLabs",
   description: "DuganLabs — the org mark",
   glyph: { kind: "monogram", text: "DL", weight: 900, letterSpacing: -36 },
   palette: { bg: "#0C0B09", fg: "#F0EDE4", accent: "#E8920A" },
@@ -54,6 +58,7 @@ export const duganlabs = {
 /** @type {Preset} */
 export const pendingbusiness = {
   name: "pendingbusiness",
+  displayName: "PendingBusiness",
   description: "PendingBusiness — task / pending-action tracker",
   glyph: { kind: "symbol", symbol: "clock" },
   palette: { bg: "#0F0E0C", fg: "#F0EDE4", accent: "#4EAF7C" },
@@ -64,6 +69,7 @@ export const pendingbusiness = {
 /** @type {Preset} */
 export const greenput = {
   name: "greenput",
+  displayName: "Greenput",
   description: "Greenput — sustainability + green-tech home",
   glyph: { kind: "symbol", symbol: "leaf" },
   palette: { bg: "#0F0E0C", fg: "#F0EDE4", accent: "#4EAF7C" },
@@ -74,6 +80,7 @@ export const greenput = {
 /** @type {Preset} */
 export const warrendugan = {
   name: "warrendugan",
+  displayName: "warrendugan.com",
   description: "warrendugan.com — personal site",
   glyph: { kind: "monogram", text: "WD", weight: 900, stack: true },
   palette: { bg: "#0C0B09", fg: "#F0EDE4", accent: "#E8920A" },
@@ -84,6 +91,7 @@ export const warrendugan = {
 /** @type {Preset} */
 export const ralphStation = {
   name: "ralph-station",
+  displayName: "Ralph Station",
   description: "Ralph Station — fixed point / signal station",
   glyph: { kind: "sigil", sigil: "station-mark" },
   palette: { bg: "#0C0B09", fg: "#F0EDE4", accent: "#5EA0E8" },
@@ -94,6 +102,7 @@ export const ralphStation = {
 /** @type {Preset} */
 export const warrenSys = {
   name: "warren-sys",
+  displayName: "warren.sys",
   description: "warren.sys — terminal-flavored personal system",
   glyph: { kind: "symbol", symbol: "terminal-prompt" },
   palette: { bg: "#0C0B09", fg: "#F0EDE4", accent: "#66E0A0" },

--- a/packages/favicon/src/wasm-node.js
+++ b/packages/favicon/src/wasm-node.js
@@ -42,9 +42,11 @@ export function isResvgAvailable() {
   // `import()`, and CommonJS `require.resolve` can disagree with it (global
   // NODE_PATH folders, `exports` conditions), which would report the package
   // as present and then fail at import time with Node's raw two-line error.
+  // (Assigned rather than used as a bare statement: an `import.meta` expression
+  // at statement start trips CodeQL's JavaScript parser.)
   try {
-    import.meta.resolve("@resvg/resvg-wasm");
-    return true;
+    const resolved = import.meta.resolve("@resvg/resvg-wasm");
+    return typeof resolved === "string";
   } catch {
     return false;
   }

--- a/packages/favicon/src/wasm-node.js
+++ b/packages/favicon/src/wasm-node.js
@@ -38,8 +38,12 @@ let _initPromise = null;
  * @returns {boolean}
  */
 export function isResvgAvailable() {
+  // Resolve with ESM semantics: `png.js` loads the module with a dynamic
+  // `import()`, and CommonJS `require.resolve` can disagree with it (global
+  // NODE_PATH folders, `exports` conditions), which would report the package
+  // as present and then fail at import time with Node's raw two-line error.
   try {
-    require.resolve("@resvg/resvg-wasm");
+    import.meta.resolve("@resvg/resvg-wasm");
     return true;
   } catch {
     return false;

--- a/packages/favicon/src/wasm-node.js
+++ b/packages/favicon/src/wasm-node.js
@@ -1,0 +1,80 @@
+// Built with BaseNative — basenative.dev
+/**
+ * Node-safe WASM bootstrap for the optional `@resvg/resvg-wasm` dependency.
+ *
+ * This mirrors `@basenative/og-image`'s `src/wasm.node.js` bootstrap — same
+ * technique, kept as a small internal copy rather than an import, because
+ * `@basenative/favicon` must not depend on `@basenative/og-image` just to
+ * get resvg working (see `src/png.js`). Both packages independently declare
+ * `@resvg/resvg-wasm` (og-image as a regular dependency, favicon as an
+ * optional one) and each carries its own tiny Node init helper.
+ *
+ * Why not a static or dynamic `import` of the `.wasm` file: the
+ * `@resvg/resvg-wasm` wasm-bindgen glue expects a synthetic `wbg` module
+ * specifier that only a wasm-aware bundler (wrangler's esbuild pass, under
+ * Workers) knows how to satisfy. Under plain Node — which is the only
+ * runtime this CLI targets — both `import ... from ".../index_bg.wasm"` and
+ * `import(".../index_bg.wasm")` fail at link time. Instead we resolve the
+ * `.wasm` file's path with `createRequire` and read its bytes ourselves,
+ * then hand them to `initWasm()` — the same call `@resvg/resvg-wasm`
+ * documents for any non-bundled environment.
+ *
+ * @module
+ */
+
+import { createRequire } from "node:module";
+import { readFile } from "node:fs/promises";
+
+const require = createRequire(import.meta.url);
+
+let _inited = false;
+let _initPromise = null;
+
+/**
+ * Check whether `@resvg/resvg-wasm` is resolvable from this package,
+ * without loading it. Synchronous and side-effect free — safe to call
+ * before deciding whether to attempt PNG generation at all.
+ *
+ * @returns {boolean}
+ */
+export function isResvgAvailable() {
+  try {
+    require.resolve("@resvg/resvg-wasm");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Initialize an already-imported `@resvg/resvg-wasm` module namespace.
+ * Idempotent across the process's lifetime; concurrent callers share the
+ * same in-flight promise so `initWasm` is never called twice (it throws on
+ * a second call).
+ *
+ * @param {{ initWasm: (input: any) => Promise<void> }} mod
+ *   The dynamically-imported `@resvg/resvg-wasm` module namespace.
+ * @returns {Promise<void>}
+ */
+export async function ensureResvg(mod) {
+  if (_inited) return;
+  if (_initPromise) return _initPromise;
+  _initPromise = (async () => {
+    const wasmPath = require.resolve("@resvg/resvg-wasm/index_bg.wasm");
+    const bytes = await readFile(wasmPath);
+    await mod.initWasm(bytes);
+    _inited = true;
+    _initPromise = null;
+  })();
+  return _initPromise;
+}
+
+/**
+ * Test hook: reset the init guard. Not part of the public API.
+ *
+ * @returns {void}
+ */
+export function _resetWasmForTest() {
+  _inited = false;
+  _initPromise = null;
+}

--- a/packages/favicon/test/cli.test.js
+++ b/packages/favicon/test/cli.test.js
@@ -1,0 +1,158 @@
+// Built with BaseNative — basenative.dev
+/**
+ * End-to-end tests for `bn-favicon init` — the CLI surface for both
+ * favicon defects fixed here:
+ *
+ *   1. PNG generation silently skipping instead of resolving
+ *      `@resvg/resvg-wasm` (now an `optionalDependency` of this package)
+ *      and producing correctly-sized PNGs.
+ *   2. `manifest.json`'s `name`/`short_name` using the lowercase preset id
+ *      instead of the preset's display name (or an explicit `--name`).
+ *
+ * We spawn the real CLI rather than calling its internals directly, since
+ * the defects are only visible end-to-end (module resolution, process
+ * stderr output, files actually written to disk).
+ *
+ * @module
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, cp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const CLI = fileURLToPath(new URL("../src/cli.js", import.meta.url));
+const SRC_DIR = fileURLToPath(new URL("../src", import.meta.url));
+const require = createRequire(import.meta.url);
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+function resvgAvailable() {
+  try {
+    require.resolve("@resvg/resvg-wasm");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {string} outDir
+ * @param {string[]} [extraArgs]
+ */
+function runInit(outDir, extraArgs = []) {
+  const result = spawnSync(
+    process.execPath,
+    [CLI, "init", "--preset", "basenative", "--out", outDir, "--force", ...extraArgs],
+    { encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, `CLI exited non-zero:\n${result.stderr}`);
+  return result;
+}
+
+describe("bn-favicon init (CLI)", () => {
+  it("writes favicon.svg and manifest.json with the preset's display name", async () => {
+    const outDir = await mkdtemp(join(tmpdir(), "bn-favicon-test-"));
+    try {
+      runInit(outDir);
+
+      const svg = await readFile(join(outDir, "favicon.svg"), "utf8");
+      assert.match(svg, /^<svg /);
+
+      const manifest = JSON.parse(await readFile(join(outDir, "manifest.json"), "utf8"));
+      // Preset id is "basenative" (lowercase); displayName is "BaseNative".
+      assert.equal(manifest.name, "BaseNative");
+      assert.equal(manifest.short_name, "BaseNative");
+    } finally {
+      await rm(outDir, { recursive: true, force: true });
+    }
+  });
+
+  it("--name overrides the manifest display name", async () => {
+    const outDir = await mkdtemp(join(tmpdir(), "bn-favicon-test-name-"));
+    try {
+      runInit(outDir, ["--name", "Custom Co"]);
+      const manifest = JSON.parse(await readFile(join(outDir, "manifest.json"), "utf8"));
+      assert.equal(manifest.name, "Custom Co");
+      assert.equal(manifest.short_name, "Custom Co");
+    } finally {
+      await rm(outDir, { recursive: true, force: true });
+    }
+  });
+
+  it("generates correctly-sized PNG fallbacks when @resvg/resvg-wasm is present", async (t) => {
+    if (!resvgAvailable()) {
+      t.skip(
+        "optional dependency @resvg/resvg-wasm is not installed in this environment " +
+          "(pnpm add -D @resvg/resvg-wasm to enable this assertion)",
+      );
+      return;
+    }
+
+    const outDir = await mkdtemp(join(tmpdir(), "bn-favicon-test-png-"));
+    try {
+      const { stdout } = runInit(outDir);
+      assert.match(stdout, /4 PNG fallbacks/);
+
+      const expectedSizes = {
+        "apple-touch-icon.png": 180,
+        "icon-192.png": 192,
+        "icon-512.png": 512,
+        "maskable.png": 512,
+      };
+      for (const [filename, size] of Object.entries(expectedSizes)) {
+        const buf = await readFile(join(outDir, filename));
+        assert.deepEqual(
+          Array.from(buf.subarray(0, 8)),
+          PNG_SIGNATURE,
+          `${filename} should start with the PNG magic bytes`,
+        );
+        assert.equal(buf.readUInt32BE(16), size, `${filename} width should be ${size}`);
+        assert.equal(buf.readUInt32BE(20), size, `${filename} height should be ${size}`);
+      }
+    } finally {
+      await rm(outDir, { recursive: true, force: true });
+    }
+  });
+
+  it("prints one clear line naming @resvg/resvg-wasm when it's genuinely unavailable", async () => {
+    // Copy `src/` into a directory with no ancestor `node_modules`, so
+    // `@resvg/resvg-wasm` — an optionalDependency, not guaranteed present in
+    // every install — is genuinely unresolvable. This exercises exactly the
+    // path a consumer who skipped optional deps would hit, regardless of
+    // whether this sandbox happens to have the dependency installed.
+    const isolatedRoot = await mkdtemp(join(tmpdir(), "bn-favicon-isolated-"));
+    const isolatedSrc = join(isolatedRoot, "src");
+    const outDir = join(isolatedRoot, "out");
+    try {
+      await cp(SRC_DIR, isolatedSrc, { recursive: true });
+
+      const result = spawnSync(
+        process.execPath,
+        [join(isolatedSrc, "cli.js"), "init", "--preset", "basenative", "--out", outDir, "--force"],
+        { encoding: "utf8" },
+      );
+
+      assert.equal(result.status, 0, `CLI exited non-zero:\n${result.stderr}`);
+      const lines = result.stderr.split("\n").filter((l) => l.trim().length > 0);
+      assert.equal(
+        lines.length,
+        1,
+        `expected exactly one clear line on stderr, got:\n${result.stderr}`,
+      );
+      assert.match(lines[0], /@resvg\/resvg-wasm/);
+      assert.match(lines[0], /pnpm add -D @resvg\/resvg-wasm/);
+      assert.doesNotMatch(lines[0], /og-image/, "should no longer blame the og-image peer");
+
+      // The SVG-only path must still succeed.
+      await readFile(join(outDir, "favicon.svg"), "utf8");
+      await readFile(join(outDir, "manifest.json"), "utf8");
+    } finally {
+      await rm(isolatedRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/og-image/package.json
+++ b/packages/og-image/package.json
@@ -18,6 +18,13 @@
     }
   },
   "types": "./types/index.d.ts",
+  "imports": {
+    "#wasm-init": {
+      "workerd": "./src/wasm.workerd.js",
+      "browser": "./src/wasm.workerd.js",
+      "default": "./src/wasm.node.js"
+    }
+  },
   "files": [
     "src",
     "types"

--- a/packages/og-image/src/fonts.js
+++ b/packages/og-image/src/fonts.js
@@ -15,7 +15,14 @@
 
 /** @typedef {{ name: string, data: ArrayBuffer, weight: number, style: "normal" | "italic" }} SatoriFont */
 
-/** @typedef {{ family?: string, weights?: number[], cdnVersion?: string, cacheBinding?: string, cacheKeyPrefix?: string }} FontConfig */
+/** @typedef {{
+ *   family?: string,
+ *   weights?: number[],
+ *   cdnVersion?: string,
+ *   cacheBinding?: string,
+ *   cacheKeyPrefix?: string,
+ *   buffers?: Record<number, ArrayBuffer | Uint8Array>,
+ * }} FontConfig */
 
 const DEFAULT_FAMILY = "Inter";
 const DEFAULT_WEIGHTS = [600, 700, 800];
@@ -54,6 +61,7 @@ export function defineFonts(cfg = {}) {
     cdnVersion: cfg.cdnVersion ?? DEFAULT_CDN_VERSION,
     cacheBinding: cfg.cacheBinding ?? DEFAULT_CACHE_BINDING,
     cacheKeyPrefix: cfg.cacheKeyPrefix ?? DEFAULT_CACHE_KEY_PREFIX,
+    buffers: cfg.buffers ?? undefined,
   };
 }
 
@@ -100,14 +108,22 @@ async function fetchAndCache(env, cacheBinding, cacheKey, url) {
 /**
  * Load the configured fonts and return them in satori's expected shape.
  *
+ * If `cfg.buffers[weight]` is supplied, that weight is served straight from
+ * the buffer — no KV lookup, no network fetch. This is the escape hatch for
+ * environments without `fetch` to `cdn.jsdelivr.net` (offline dev, sandboxed
+ * CI, tests): pre-load a `.ttf`/`.woff` yourself and hand the bytes in.
+ *
  * @param {Record<string, any>} env Worker env (must contain the KV binding).
  * @param {Required<FontConfig>} cfg Resolved font config from `defineFonts`.
  * @returns {Promise<SatoriFont[]>}
  */
 export async function loadFonts(env, cfg) {
-  const { family, weights, cdnVersion, cacheBinding, cacheKeyPrefix } = cfg;
+  const { family, weights, cdnVersion, cacheBinding, cacheKeyPrefix, buffers } = cfg;
   const out = await Promise.all(
     weights.map(async (weight) => {
+      if (buffers && buffers[weight] != null) {
+        return /** @type {SatoriFont} */ ({ name: family, data: buffers[weight], weight, style: "normal" });
+      }
       const key = `${cacheKeyPrefix}${family.toLowerCase().replace(/\s+/g, "-")}-${weight}`;
       const data = await fetchAndCache(env, cacheBinding, key, fontUrl(family, weight, cdnVersion));
       return /** @type {SatoriFont} */ ({ name: family, data, weight, style: "normal" });

--- a/packages/og-image/src/index.js
+++ b/packages/og-image/src/index.js
@@ -17,7 +17,7 @@
 import satori from "satori";
 import { Resvg } from "@resvg/resvg-wasm";
 
-import { ensureResvg } from "./wasm.js";
+import { ensureResvg } from "#wasm-init";
 import { defineFonts, loadFonts } from "./fonts.js";
 
 export { defineFonts } from "./fonts.js";
@@ -55,7 +55,8 @@ const _defaultFontCfg = defineFonts();
  * Render a satori-compatible scene to PNG bytes.
  *
  * Concurrency model: font + wasm init are deduped via module-scoped guards
- * in `./fonts.js` and `./wasm.js`. Warm isolates skip both entirely.
+ * in `./fonts.js` and the `#wasm-init` variant (`./wasm.workerd.js` under
+ * Workers, `./wasm.node.js` under Node). Warm isolates skip both entirely.
  *
  * @param {import("./scene.js").VNode} scene
  *   The scene tree (e.g. output of `defaultPreset(...)` or hand-built via

--- a/packages/og-image/src/wasm.node.js
+++ b/packages/og-image/src/wasm.node.js
@@ -1,0 +1,76 @@
+// Built with BaseNative — basenative.dev
+/**
+ * Node-safe WASM bootstrap for `@resvg/resvg-wasm` — the default/Node variant.
+ *
+ * `@resvg/resvg-wasm/index_bg.wasm`'s wasm-bindgen glue imports a synthetic
+ * `wbg` module specifier that only a wasm-aware bundler (wrangler's esbuild
+ * pass, in Workers) knows how to satisfy — a static `import ... from
+ * "*.wasm"` of it fails at link time under plain Node, even with
+ * `--experimental-wasm-modules`. So here we resolve the `.wasm` file's path
+ * with `createRequire` (works from an ESM module without needing import
+ * assertions or a loader), read its bytes with `fs/promises`, and hand them
+ * to `initWasm()` ourselves — the same call `@resvg/resvg-wasm` documents
+ * for any non-bundled environment.
+ *
+ * Selection: `src/index.js` imports the bootstrap via the internal
+ * `#wasm-init` subpath (see this package's `package.json` `imports` map).
+ * This file is the `"default"` condition target, so plain Node — including
+ * `node --test` — lands here. Workers land in `./wasm.workerd.js` instead,
+ * via the `workerd`/`browser` conditions. Keep both files' exports in
+ * lockstep.
+ *
+ * The module-scoped `_inited` flag mirrors the Workers variant: a single
+ * process/isolate only ever calls `initWasm` once.
+ *
+ * @module
+ */
+
+import { createRequire } from "node:module";
+import { readFile } from "node:fs/promises";
+
+import { initWasm } from "@resvg/resvg-wasm";
+
+const require = createRequire(import.meta.url);
+
+let _inited = false;
+let _initPromise = null;
+
+/**
+ * Initialize the resvg WASM module. Idempotent across the process's lifetime.
+ *
+ * Concurrent callers receive the same in-flight promise so we never call
+ * `initWasm` twice (which throws).
+ *
+ * @returns {Promise<void>}
+ */
+export async function ensureResvg() {
+  if (_inited) return;
+  if (_initPromise) return _initPromise;
+  _initPromise = (async () => {
+    const wasmPath = require.resolve("@resvg/resvg-wasm/index_bg.wasm");
+    const bytes = await readFile(wasmPath);
+    await initWasm(bytes);
+    _inited = true;
+    _initPromise = null;
+  })();
+  return _initPromise;
+}
+
+/**
+ * Test hook: reset the init guard. Not part of the public API.
+ *
+ * @returns {void}
+ */
+export function _resetWasmForTest() {
+  _inited = false;
+  _initPromise = null;
+}
+
+/**
+ * Inspect the init state. Useful for diagnostics.
+ *
+ * @returns {boolean}
+ */
+export function isResvgInited() {
+  return _inited;
+}

--- a/packages/og-image/src/wasm.workerd.js
+++ b/packages/og-image/src/wasm.workerd.js
@@ -1,12 +1,21 @@
 // Built with BaseNative — basenative.dev
 /**
- * Static WASM bootstrap for `@resvg/resvg-wasm`.
+ * Static WASM bootstrap for `@resvg/resvg-wasm` — the Workers/browser variant.
  *
  * Cloudflare Workers (and Pages Functions) require a static `import` of the
  * `.wasm` module so wrangler can bundle it as a `WebAssembly.Module` ahead
  * of time — dynamic instantiation from a buffer is disallowed by the
  * embedder. This file isolates that import + a single-init guard so the
  * rest of the package can stay platform-neutral.
+ *
+ * Selection: `src/index.js` imports the bootstrap via the internal
+ * `#wasm-init` subpath (see this package's `package.json` `imports` map).
+ * Bundlers that resolve with the `workerd` or `browser` condition — that's
+ * wrangler's esbuild pass, which sets `conditions: ["workerd", "worker",
+ * "browser"]` — land here. Everyone else (plain Node, `node --test`, etc.)
+ * falls through to `./wasm.node.js`, which has no static `.wasm` import and
+ * reads the module's bytes off disk at runtime instead. Keep both files'
+ * exports in lockstep.
  *
  * The module-scoped `_inited` flag is intentional: warm isolates reuse the
  * already-initialized resvg instance across requests, which is what gives

--- a/packages/og-image/test/render-png.test.js
+++ b/packages/og-image/test/render-png.test.js
@@ -1,0 +1,102 @@
+// Built with BaseNative — basenative.dev
+/**
+ * Node-runtime smoke test for `renderPng()`.
+ *
+ * `render.test.js` deliberately never touches satori/resvg — this file is
+ * where we do, specifically to prove the `#wasm-init` bootstrap (see
+ * `src/wasm.node.js`) actually links and initializes under plain Node.
+ * Before the fix, `import "../src/index.js"` failed at link time even with
+ * `node --experimental-wasm-modules`, because the static `.wasm` import in
+ * `src/wasm.workerd.js` only resolves under wrangler's esbuild pass.
+ *
+ * Fonts: the default loader (`src/fonts.js`) fetches Inter from
+ * cdn.jsdelivr.net. Rather than depend on that inside `renderPng` itself,
+ * we fetch once up front and inject the bytes via the `fonts.buffers`
+ * escape hatch, so the render call below never needs network access. If
+ * the one-time fetch fails — no egress in this sandbox/CI — the test skips
+ * with a clear reason instead of fabricating a pass.
+ *
+ * @module
+ */
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+
+import { renderPng, defaultPreset } from "../src/index.js";
+
+const FONT_URL =
+  "https://cdn.jsdelivr.net/npm/@fontsource/inter@5.0.16/files/inter-latin-700-normal.woff";
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/** @type {ArrayBuffer | null} */
+let fontBytes = null;
+/** @type {string | null} */
+let skipReason = null;
+
+before(async () => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+  try {
+    const res = await fetch(FONT_URL, { signal: controller.signal });
+    if (!res.ok) {
+      skipReason = `font fetch responded ${res.status} ${res.statusText}`;
+      return;
+    }
+    fontBytes = await res.arrayBuffer();
+  } catch (err) {
+    skipReason = `no network access to cdn.jsdelivr.net to fetch a test font (${
+      err && err.message ? err.message : err
+    })`;
+  } finally {
+    clearTimeout(timer);
+  }
+});
+
+/**
+ * @param {Uint8Array} buf
+ * @param {number} offset
+ * @returns {number}
+ */
+function readUInt32BE(buf, offset) {
+  return (
+    ((buf[offset] << 24) | (buf[offset + 1] << 16) | (buf[offset + 2] << 8) | buf[offset + 3]) >>>
+    0
+  );
+}
+
+describe("renderPng() under plain Node", () => {
+  it("renders a 1200x630 PNG via satori + Node-safe resvg wasm init", async (t) => {
+    if (!fontBytes) {
+      t.skip(skipReason ?? "font bytes unavailable for this run");
+      return;
+    }
+
+    const scene = defaultPreset({
+      title: "BaseNative",
+      subtitle: "Runs under plain Node too",
+      brand: "basenative.dev",
+    });
+
+    // No `env` (no KV binding) — every weight is served from the injected
+    // buffer, so `loadFonts` never touches `fetch` or KV.
+    const png = await renderPng(
+      scene,
+      {},
+      { fonts: { weights: [700], buffers: { 700: fontBytes } } },
+    );
+
+    assert.ok(png instanceof Uint8Array, "renderPng() should return a Uint8Array");
+    assert.deepEqual(
+      Array.from(png.subarray(0, 8)),
+      PNG_SIGNATURE,
+      "output should start with the PNG magic bytes",
+    );
+
+    // IHDR is always the first chunk: 4-byte length, 4-byte type "IHDR",
+    // then 4-byte width + 4-byte height (big-endian).
+    const ihdrType = String.fromCharCode(...png.subarray(12, 16));
+    assert.equal(ihdrType, "IHDR", "first chunk should be IHDR");
+    assert.equal(readUInt32BE(png, 16), 1200, "PNG width should be 1200");
+    assert.equal(readUInt32BE(png, 20), 630, "PNG height should be 630");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,10 +290,10 @@ importers:
         version: link:../validate
 
   packages/favicon:
-    dependencies:
-      '@basenative/og-image':
-        specifier: workspace:*
-        version: link:../og-image
+    optionalDependencies:
+      '@resvg/resvg-wasm':
+        specifier: ^2.6.2
+        version: 2.6.2
 
   packages/fetch:
     dependencies:

--- a/scripts/bundle-size.js
+++ b/scripts/bundle-size.js
@@ -35,7 +35,9 @@ const SHARED_EXTERNAL = [
 const packages = [
   { name: '@basenative/runtime', entry: 'packages/runtime/src/index.js', platform: 'browser' },
   { name: '@basenative/server', entry: 'packages/server/src/render.js', platform: 'node', external: ['node-html-parser'] },
-  { name: '@basenative/og-image', entry: 'packages/og-image/src/index.js', platform: 'neutral' },
+  // og-image ships a Workers build (static .wasm import, selected via the
+  // `#wasm-init` imports map) and a Node fallback; measure the Workers variant.
+  { name: '@basenative/og-image', entry: 'packages/og-image/src/index.js', platform: 'neutral', conditions: ['workerd', 'worker', 'browser'] },
   { name: '@basenative/keyboard', entry: 'packages/keyboard/src/index.js', platform: 'browser' },
   { name: '@basenative/auth-webauthn', entry: 'packages/auth-webauthn/src/server.js', platform: 'neutral' },
   { name: '@basenative/admin', entry: 'packages/admin/src/index.js', platform: 'neutral' },
@@ -61,6 +63,7 @@ for (const pkg of packages) {
       write: false,
       minify: true,
       external: [...SHARED_EXTERNAL, ...(pkg.external || [])],
+      ...(pkg.conditions ? { conditions: pkg.conditions } : {}),
     });
   } catch (err) {
     console.error(`${pkg.name}: build failed — ${err.message}`);


### PR DESCRIPTION
## Summary

- **`@basenative/og-image`**: `renderPng` failed to even import under plain Node (link-time failure on the static `.wasm` import, which only resolves under wrangler's esbuild pass). Split the resvg wasm bootstrap via the package's `imports` map (`#wasm-init`): `src/wasm.workerd.js` keeps the static import, selected by the `workerd`/`browser` conditions wrangler's esbuild sets; `src/wasm.node.js` is the new default — it resolves the `.wasm` file with `createRequire` and reads its bytes via `fs/promises`, then calls `initWasm(bytes)`. `renderPng`'s signature is unchanged. Also added a `fonts.buffers` escape hatch (`src/fonts.js`) so callers can inject pre-loaded font bytes instead of depending on a live fetch to `cdn.jsdelivr.net`.
- **`@basenative/favicon`**: `bn-favicon init` silently skipped PNG generation because `@resvg/resvg-wasm` was only ever a dependency of `og-image` and unreachable from favicon's own `node_modules` under pnpm's strict resolution — and even when reachable, a dynamic `import(".../index_bg.wasm")` fallback hit the same link-time failure as og-image, silently swallowed. Declared `@resvg/resvg-wasm` as an `optionalDependency` of favicon directly (same version og-image pins), resolved via `createRequire`, with a small internal Node-safe wasm-init copy (favicon does not depend on og-image). When genuinely unavailable, the CLI now prints one clear line naming the missing dependency and the install command. Also fixed `manifest.json`'s `name`/`short_name` defaulting to the lowercase preset id — presets now carry a `displayName`, and `init` accepts `--name` to override.

## Verification

- `packages/og-image`: `node --test` — 23/23 passing (was 22; added a real render test that exercises satori + resvg + the new Node wasm path, asserting PNG magic bytes and a parsed 1200×630 IHDR). `eslint src/` clean.
- `packages/favicon`: `node --test` — 32/32 passing (was 28; added CLI end-to-end tests: init writes `favicon.svg`/`manifest.json` with the display name, `--name` override, PNG fallbacks with correct dimensions when `@resvg/resvg-wasm` is present, and exactly one clear stderr line when it's genuinely unavailable — the last one runs the CLI from an isolated copy with no ancestor `node_modules` so it doesn't depend on the sandbox's install state). `eslint src/` clean.
- Confirmed via a real esbuild build (with `conditions: ["workerd", "worker", "browser"]`, matching wrangler's own esbuild config) that the Workers path still statically bundles `index_bg.wasm` — the fix doesn't touch that path at all.
- `pnpm-lock.yaml`: minimal diff — only the `packages/favicon` importer entry changes (drops the `@basenative/og-image` peer link, adds `@resvg/resvg-wasm@^2.6.2` as `optionalDependencies`); no new package/snapshot entries needed since `@resvg/resvg-wasm@2.6.2` is already resolved elsewhere in the lockfile via og-image.
- Added changesets: patch for `@basenative/og-image` ("renderPng works under Node") and `@basenative/favicon` ("PNG generation resolves resvg; clear message when missing; manifest names").
- Not verified: the new og-image font/render test depends on network access to `cdn.jsdelivr.net`; it's written to `t.skip` with a clear reason if that fetch fails, rather than fabricate a pass — it did run and pass in this sandbox.

## Test plan

- [ ] `cd packages/og-image && node --test`
- [ ] `cd packages/favicon && node --test`
- [ ] `pnpm nx run-many --target=lint --projects=@basenative/og-image,@basenative/favicon`
- [ ] Manually run `bn-favicon init --preset basenative` with `@resvg/resvg-wasm` installed and confirm PNGs + `"BaseNative"` manifest name; then without it, confirm the one-line message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)