### PR TITLE
fix: clear remaining CodeQL alerts; move notify onto the shared escape module

### DIFF
--- a/.changeset/claude-config-codeql-fixes.md
+++ b/.changeset/claude-config-codeql-fixes.md
@@ -1,0 +1,5 @@
+---
+"@basenative/claude-config": patch
+---
+
+Fix file-system TOCTOU races (CodeQL `js/file-system-race`) in the installer: template, `settings.json`, and `CLAUDE.md` writes now use an exclusive create or a read-based existence check instead of `existsSync` followed by a separate write, closing the window where a file created in between could be silently overwritten. Also fixes an incomplete sanitization (CodeQL `js/incomplete-sanitization`): the glob-to-extension conversion used `.replace('*', '')`, which only strips the first `*`; now uses `.replaceAll('*', '')`. No user-visible behavior change.

--- a/.changeset/cli-codeql-fixes.md
+++ b/.changeset/cli-codeql-fixes.md
@@ -1,0 +1,5 @@
+---
+"@basenative/cli": patch
+---
+
+Fix file-system TOCTOU races (CodeQL `js/file-system-race`) in `bn generate`, `bn prd init`, `bn speckit plan/tasks`, and the template renderer used by scaffolding commands: an `existsSync` check followed by a separate read/write let a file created in between the two calls be silently overwritten. Writes that must not clobber an existing file now use an exclusive create (`{ flag: 'wx' }`) and handle `EEXIST` instead, which is atomic. No user-visible behavior change.

--- a/.changeset/doppler-codeql-fix.md
+++ b/.changeset/doppler-codeql-fix.md
@@ -1,0 +1,5 @@
+---
+"@basenative/doppler": patch
+---
+
+Fix a file-system TOCTOU race (CodeQL `js/file-system-race`) in `bn doppler init`: the starter `doppler-required.json` write used an `existsSync` check followed by a separate write, which could silently clobber a file created in between. Now uses an exclusive create (`{ flag: 'wx' }`) and handles `EEXIST`. No user-visible behavior change.

--- a/.changeset/favicon-redos-fix.md
+++ b/.changeset/favicon-redos-fix.md
@@ -1,0 +1,5 @@
+---
+"@basenative/favicon": patch
+---
+
+Fix a polynomial ReDoS surface (CodeQL `js/polynomial-redos`) in `buildManifest`: trailing slashes on the caller-supplied `iconBaseUrl` were stripped with `/\/+$/`, which backtracks quadratically on input with many slashes. Replaced with a linear index scan; output is unchanged.

--- a/.changeset/forms-test-regex-cleanup.md
+++ b/.changeset/forms-test-regex-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@basenative/forms": patch
+---
+
+Remove a duplicate `/` in a test-fixture URL regex's character class (CodeQL `js/regex/duplicate-in-character-class`). Test-only; no package behavior change.

--- a/.changeset/i18n-proto-pollution-fix.md
+++ b/.changeset/i18n-proto-pollution-fix.md
@@ -1,0 +1,5 @@
+---
+"@basenative/i18n": patch
+---
+
+Fix a prototype-pollution surface (CodeQL `js/prototype-polluting-assignment`) in `createI18n`: `addMessages(locale, msgs)` stored per-locale message tables on a plain `{}` object keyed by `locale`, so a caller passing `locale: '__proto__'` would `Object.assign` `msgs` straight onto `Object.prototype`. The internal message store is now created with `Object.create(null)`. No change to `createI18n`'s public behavior. Also switches the loader tests' temp directories from a `Date.now()`-suffixed name to `fs.mkdtemp` (CodeQL `js/insecure-temporary-file`); test-only, no package behavior change.

--- a/.changeset/marketplace-dead-code-cleanup.md
+++ b/.changeset/marketplace-dead-code-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@basenative/marketplace": patch
+---
+
+Remove an unused `rm` import from `theme.js` and `installer.js` (CodeQL `js/unused-local-variable`). No behavior change.

--- a/.changeset/middleware-proto-pollution-fix.md
+++ b/.changeset/middleware-proto-pollution-fix.md
@@ -1,0 +1,5 @@
+---
+"@basenative/middleware": patch
+---
+
+Fix a prototype-pollution surface (CodeQL `js/remote-property-injection`) in the Express adapter's `Cookie` header parser: cookie names were written onto a plain `{}` object, so a crafted `__proto__` cookie name reached `Object.prototype`. The parsed cookie map is now created with `Object.create(null)`. No change to the shape returned as `ctx.request.cookies`.

--- a/.changeset/notify-shared-escaping.md
+++ b/.changeset/notify-shared-escaping.md
@@ -1,0 +1,5 @@
+---
+"@basenative/notify": patch
+---
+
+`renderEmail`'s `{{ variable }}` interpolation now escapes with `@basenative/runtime/shared/escape` (`escapeAttr`) instead of a local copy of the same logic, so HTML email templates and the SSR renderer can't drift apart. Behavior is unchanged for existing callers — every substituted value is still escaped by default — but a value wrapped in `raw()` (from `@basenative/runtime/shared/escape`) is now supported as an explicit, documented opt-out for trusted HTML, matching the SSR renderer's convention. Adds `@basenative/runtime` as a dependency.

--- a/.changeset/runtime-pure-browserfeatures.md
+++ b/.changeset/runtime-pure-browserfeatures.md
@@ -1,0 +1,5 @@
+---
+"@basenative/runtime": patch
+---
+
+Mark `browserFeatures`'s initializer (`detectBrowserFeatures()`) as `/* @__PURE__ */` in `src/features.js`. `detectBrowserFeatures` only reads feature flags off its `target` argument, so this lets bundlers drop the call when an entry point pulls in `@basenative/runtime` (e.g. for signals) without using `browserFeatures` — fixing a CodeQL `js/unused-local-variable` finding in one such downstream bundle. No change to `browserFeatures`'s value or behavior for existing consumers. Also removes a tautological assertion (CodeQL `js/unneeded-defensive-code`) from an expression-evaluator fuzz test; test-only.

--- a/.changeset/upload-proto-pollution-fix.md
+++ b/.changeset/upload-proto-pollution-fix.md
@@ -1,0 +1,5 @@
+---
+"@basenative/upload": patch
+---
+
+Fix a prototype-pollution surface (CodeQL `js/remote-property-injection`) in the built-in multipart parser: header names parsed from the request body were written onto a plain `{}` object, so a crafted `__proto__` header name reached `Object.prototype`. The per-part headers object is now created with `Object.create(null)`. No change to the parsed shape returned to callers.

--- a/.changeset/visual-builder-test-cleanup.md
+++ b/.changeset/visual-builder-test-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@basenative/visual-builder": patch
+---
+
+Remove an unused local variable in a `getTree` test (CodeQL `js/unused-local-variable`). Test-only; no package behavior change.

--- a/.changeset/wrangler-preset-redos-fix.md
+++ b/.changeset/wrangler-preset-redos-fix.md
@@ -1,0 +1,5 @@
+---
+"@basenative/wrangler-preset": patch
+---
+
+Fix a polynomial ReDoS surface (CodeQL `js/polynomial-redos`) in `toToml`: trailing newlines were stripped with `/\n+$/`, which backtracks quadratically on input with many newlines, and the input can come from config values outside this module's control. Replaced with a linear index scan; output is unchanged.

--- a/benchmarks/effect-dom-nodes.bench.js
+++ b/benchmarks/effect-dom-nodes.bench.js
@@ -27,7 +27,6 @@ function createDOMNode(id) {
 console.log('\n--- 10,000 DOM nodes, 1 signal each ---');
 
 bench('create 10k signal→effect pairs', () => {
-  const nodes = [];
   const effects = [];
   for (let i = 0; i < 10000; i++) {
     const s = signal(i);

--- a/benchmarks/router.bench.js
+++ b/benchmarks/router.bench.js
@@ -74,6 +74,10 @@ bench('matchRoute (nested params)', () => {
   matchRoute(nestedParamPattern, '/users/42/posts/99');
 });
 
+bench('matchRoute (deep static)', () => {
+  matchRoute(deepPattern, '/admin/reports');
+});
+
 bench('Full route table scan (20 routes, static)', () => {
   matchAll('/admin/reports');
 });

--- a/benchmarks/signal-comparison.bench.js
+++ b/benchmarks/signal-comparison.bench.js
@@ -30,10 +30,6 @@ function preactComputed(fn) {
   let cached = fn();
   return { get value() { return cached; } };
 }
-function preactEffect(fn) {
-  fn();
-  return { dispose() {} };
-}
 
 // ─── SolidJS createSignal-style implementation ────────────────────────────────
 // Pull-based with synchronous push on write. Getter/setter tuple API.
@@ -122,7 +118,7 @@ table('2. Signal read / write (100 r/w cycles)', [
   }),
   bench('Plain JS ref', () => {
     const s = makeRef(0);
-    for (let i = 0; i < 100; i++) { s.current = i; s.current; }
+    for (let i = 0; i < 100; i++) { s.current = i; const _ = s.current; }
   }),
 ]);
 
@@ -145,7 +141,7 @@ table('3. Computed derivation (a + b, 100 updates)', [
     for (let i = 0; i < 100; i++) { setA(i); sum(); }
   }),
   bench('Plain JS (no reactivity)', () => {
-    let a = 1; const b = 2;
+    let a; const b = 2;
     for (let i = 0; i < 100; i++) { a = i; const _ = a + b; }
   }),
 ]);
@@ -154,28 +150,28 @@ table('3. Computed derivation (a + b, 100 updates)', [
 table('4. Effect: create → 10 updates → dispose', [
   bench('BaseNative effect', () => {
     const s = bnSignal(0);
-    let n = 0;
-    const e = bnEffect(() => { n = s(); });
+    let _n = 0;
+    const e = bnEffect(() => { _n = s(); });
     for (let i = 0; i < 10; i++) s.set(i);
     e.dispose();
   }),
   bench('Preact-style effect', () => {
     const s = preactSignal(0);
-    let n = 0;
-    const unsub = s.subscribe(() => { n = s.value; });
+    let _n = 0;
+    const unsub = s.subscribe(() => { _n = s.value; });
     for (let i = 0; i < 10; i++) s.value = i;
     unsub();
   }),
   bench('Solid-style effect', () => {
     const [get, set] = solidSignal(0);
-    let n = 0;
-    const e = solidEffect(() => { n = get(); });
+    let _n = 0;
+    const e = solidEffect(() => { _n = get(); });
     for (let i = 0; i < 10; i++) set(i);
     e.dispose();
   }),
   bench('Plain JS callback', () => {
-    let s = 0, n = 0;
-    const cb = () => { n = s; };
+    let s = 0, _n = 0;
+    const cb = () => { _n = s; };
     for (let i = 0; i < 10; i++) { s = i; cb(); }
   }),
 ]);
@@ -204,9 +200,9 @@ table('5. Diamond dependency: a → {b, c} → d  (100 updates)', [
     for (let i = 0; i < 100; i++) { setA(i); d(); }
   }),
   bench('Plain JS', () => {
-    let a = 1;
+    let a;
     for (let i = 0; i < 100; i++) {
-      a = i; const b = a * 2, c = a * 3, d = b + c;
+      a = i; const b = a * 2, c = a * 3, _ = b + c;
     }
   }),
 ]);
@@ -216,7 +212,7 @@ table('6. Fan-out: 1 source → 50 subscribers (10 updates)', [
   bench('BaseNative', () => {
     const s = bnSignal(0);
     const es = Array.from({ length: 50 }, () => {
-      let n = 0; return bnEffect(() => { n = s(); });
+      let _n = 0; return bnEffect(() => { _n = s(); });
     });
     for (let i = 0; i < 10; i++) s.set(i);
     es.forEach(e => e.dispose());
@@ -234,9 +230,8 @@ table('6. Fan-out: 1 source → 50 subscribers (10 updates)', [
     ds.forEach(d => d.dispose());
   }),
   bench('Plain JS array notify', () => {
-    let s = 0;
     const cbs = Array.from({ length: 50 }, () => () => {});
-    for (let i = 0; i < 10; i++) { s = i; cbs.forEach(fn => fn()); }
+    for (let i = 0; i < 10; i++) { cbs.forEach(fn => fn()); }
   }),
 ]);
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,11 @@ export default [
       'node_modules/',
       '*.min.js',
       'examples/express/public/basenative.js',
+      // esbuild's own bundled output, same as basenative.js above: it
+      // escapes `</script>` in string literals as a safety measure for
+      // bundles that might be inlined into HTML, which no-useless-escape
+      // (correctly, for hand-written source) flags as unnecessary.
+      'examples/express/public/builder.js',
       // Scaffolding templates, not workspace members: their eslint.config.js
       // imports @basenative/eslint-config, which cannot resolve from in-repo.
       'packages/cli/templates/',

--- a/examples/cloudflare-workers/src/worker.js
+++ b/examples/cloudflare-workers/src/worker.js
@@ -6,10 +6,11 @@
  * - Client-side hydration script reference
  * - Routing with @basenative/router
  * - A simple form example
- * - ReadableStream response for streaming SSR
+ *
+ * For streaming SSR, see `@basenative/server`'s `renderToReadableStream`.
  */
 
-import { render, renderToReadableStream } from '@basenative/server';
+import { render } from '@basenative/server';
 import { resolveRoute } from '@basenative/router';
 
 // ── Route definitions ──────────────────────────────────────────────────────
@@ -116,7 +117,7 @@ const notFoundPage = (path) => render(`
 // ── Worker entry point ──────────────────────────────────────────────────────
 
 export default {
-  async fetch(request, env) {
+  async fetch(request, _env) {
     const url = new URL(request.url);
     const match = resolveRoute(routes, url.pathname);
 

--- a/examples/configurator/components/live-output.js
+++ b/examples/configurator/components/live-output.js
@@ -35,7 +35,7 @@ import {
  */
 export function createOutputComputed(computed, signals) {
   const {
-    footprint, ceilingHeight, latitude, windows,
+    footprint, latitude, windows,
     exteriorPanel, interiorPanel, studDepth, cavityInsulation,
   } = signals;
 

--- a/examples/configurator/index.html
+++ b/examples/configurator/index.html
@@ -303,7 +303,7 @@
 </main>
 
 <script type="module">
-import { signal, computed, effect, batch, hydrate } from '../../packages/runtime/src/index.js';
+import { signal, computed, batch, hydrate } from '../../packages/runtime/src/index.js';
 import { createState } from './configurator-state.js';
 
 const state = createState({ signal, computed, batch });

--- a/examples/enterprise-v2/server.js
+++ b/examples/enterprise-v2/server.js
@@ -6,22 +6,13 @@ import { fileURLToPath } from 'node:url';
 // -- BaseNative packages --
 import { render } from '@basenative/server';
 import {
-  renderButton,
-  renderInput,
-  renderTable,
-  renderBadge,
-  renderCard,
-  renderAlert,
-} from '@basenative/components';
-import {
   createPipeline,
   cors,
   rateLimit,
-  csrf,
   logger as loggerMiddleware,
   toExpressMiddleware,
 } from '@basenative/middleware';
-import { loadEnv, defineConfig, string, number, boolean, optional } from '@basenative/config';
+import { loadEnv, defineConfig, string, number, optional } from '@basenative/config';
 import { createLogger, requestLogger } from '@basenative/logger';
 import {
   createSessionManager,
@@ -29,18 +20,13 @@ import {
   hashPassword,
   verifyPassword,
   sessionMiddleware,
-  requireAuth,
-  login,
-  logout,
-  defineRoles,
-  createGuard,
 } from '@basenative/auth';
 import { createHeaderResolver, tenantMiddleware } from '@basenative/tenant';
 import { createI18n, i18nMiddleware } from '@basenative/i18n';
 import { createSSEServer } from '@basenative/realtime';
 import { createFlagManager, flagMiddleware, createMemoryProvider } from '@basenative/flags';
 import { createNotificationCenter } from '@basenative/notify';
-import { createUploadHandler, createLocalStorage } from '@basenative/upload';
+import { createLocalStorage } from '@basenative/upload';
 
 // ---------------------------------------------------------------------------
 // Setup
@@ -72,14 +58,6 @@ const i18n = createI18n({
   defaultLocale: config.DEFAULT_LOCALE ?? 'en',
   messages: { en: translations },
 });
-
-// -- RBAC --
-const rbac = defineRoles({
-  admin: { permissions: ['*'] },
-  editor: { permissions: ['read', 'write'], inherits: ['viewer'] },
-  viewer: { permissions: ['read'] },
-});
-const guard = createGuard(rbac);
 
 // -- Sessions --
 const sessionManager = createSessionManager({
@@ -151,6 +129,13 @@ pipeline
   .use(i18nMiddleware(i18n))
   .use(flagMiddleware(flagManager))
   .use(requestLogger(log));
+
+// The global 200/min limit above is sized for normal API traffic, not for a
+// credential-guessing endpoint. Login gets its own, much tighter limit so a
+// password-spraying attempt is throttled long before it hits the global cap.
+const loginRateLimit = toExpressMiddleware(
+  createPipeline().use(rateLimit({ windowMs: 60_000, max: 10 }))
+);
 
 // ---------------------------------------------------------------------------
 // Express app
@@ -255,7 +240,7 @@ app.get('/login', async (req, res) => {
   res.send(renderPage('login.html', ctx, i18n.t('login.title')));
 });
 
-app.post('/login', async (req, res) => {
+app.post('/login', loginRateLimit, async (req, res) => {
   const { username, password } = req.body ?? {};
   const dbUser = findUserByUsername(username);
 

--- a/examples/enterprise/server.js
+++ b/examples/enterprise/server.js
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { render } from '@basenative/server';
-import { resolveRoute } from '@basenative/router';
+import { escapeText } from '@basenative/runtime/shared/escape';
 import {
   renderButton,
   renderInput,
@@ -33,21 +33,16 @@ let users = [
   { id: 3, name: 'Carol Davis', email: 'carol@example.com', role: 'Viewer', status: 'inactive' },
 ];
 
-// -- Route definitions --
-const routes = [
-  { path: '/', name: 'dashboard' },
-  { path: '/users', name: 'users' },
-  { path: '/users/new', name: 'user-create' },
-  { path: '/users/:id', name: 'user-detail' },
-];
-
 // -- Layout --
 function renderPage(viewFile, ctx, title) {
   const layout = read('views/layout.html');
   const view = read(`views/${viewFile}`);
   const content = render(view, ctx);
   return layout
-    .replace('<!--TITLE-->', title)
+    // `title` can be user-controlled (e.g. a user's own name on
+    // /users/:id) and lands in the page unescaped otherwise — the same
+    // escaping @basenative/server applies to `{{ }}` interpolation.
+    .replace('<!--TITLE-->', escapeText(title))
     .replace('<!--CONTENT-->', content);
 }
 

--- a/examples/express/public/builder.js
+++ b/examples/express/public/builder.js
@@ -101,22 +101,6 @@ function effect(fn) {
   return execute;
 }
 
-// ../../packages/runtime/src/features.js
-function cssSupports(target, rule) {
-  return Boolean(target?.CSS?.supports?.(rule));
-}
-function detectBrowserFeatures(target = globalThis) {
-  const elementProto = target?.HTMLElement?.prototype;
-  const dialogProto = target?.HTMLDialogElement?.prototype;
-  return {
-    dialog: Boolean(dialogProto?.showModal),
-    popover: Boolean(elementProto?.showPopover),
-    anchorPositioning: cssSupports(target, "anchor-name: --bn-anchor") && cssSupports(target, "position-anchor: --bn-anchor"),
-    baseSelect: cssSupports(target, "appearance: base-select") || cssSupports(target, "-webkit-appearance: base-select")
-  };
-}
-var browserFeatures = detectBrowserFeatures();
-
 // ../../packages/builder/src/state.js
 var idCounter = 0;
 function nextId() {
@@ -1305,16 +1289,16 @@ if (typeof customElements !== "undefined" && !customElements.get(TAG2)) {
 
 // ../../packages/builder/src/inspector-element.js
 var TAG3 = "bn-builder-inspector";
-function coerce(prop, raw) {
+function coerce(prop, raw2) {
   if (prop.kind === "number") {
-    if (raw === "" || raw == null) return void 0;
-    const n = Number(raw);
+    if (raw2 === "" || raw2 == null) return void 0;
+    const n = Number(raw2);
     return Number.isNaN(n) ? void 0 : n;
   }
   if (prop.kind === "boolean") {
-    return Boolean(raw);
+    return Boolean(raw2);
   }
-  return raw === "" ? void 0 : raw;
+  return raw2 === "" ? void 0 : raw2;
 }
 var BnBuilderInspector = class extends HTMLElement {
   constructor() {
@@ -1387,8 +1371,8 @@ var BnBuilderInspector = class extends HTMLElement {
       this.state.setBinding(nodeId, propName, ref ? { ref } : null);
       return;
     }
-    const raw = target.type === "checkbox" ? target.checked : target.value;
-    const value = coerce(prop, raw);
+    const raw2 = target.type === "checkbox" ? target.checked : target.value;
+    const value = coerce(prop, raw2);
     this.state.updateProps(nodeId, { [propName]: value });
   }
 };

--- a/examples/starter/src/server.js
+++ b/examples/starter/src/server.js
@@ -1,7 +1,7 @@
 import { createServer } from 'node:http';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname, join, extname, resolve, sep } from 'node:path';
+import { dirname, join, extname, resolve, relative, sep } from 'node:path';
 import { render } from '@basenative/server';
 import { resolveRoute } from '@basenative/router';
 
@@ -18,12 +18,15 @@ function readPage(name) {
 /**
  * Read a file under PUBLIC_DIR, rejecting any request path that would
  * resolve outside it. `relPath` comes from the request URL, so `resolve()`
- * + a prefix check on the result — rather than trusting `join()` and the
- * caller's own `../` stripping — is what actually stops traversal.
+ * builds the candidate and `relative()` measures it against PUBLIC_DIR —
+ * a candidate that escapes shows up as a `..` segment (or exactly `..`) in
+ * that relative path, which is what actually stops traversal, checked on
+ * the same `resolved` value passed to `readFileSync` right below.
  */
 function readPublicFile(relPath) {
   const resolved = resolve(PUBLIC_DIR, `.${sep}${relPath}`);
-  if (resolved !== PUBLIC_DIR && !resolved.startsWith(PUBLIC_DIR + sep)) {
+  const rel = relative(PUBLIC_DIR, resolved);
+  if (rel === '..' || rel.startsWith(`..${sep}`)) {
     throw new Error('Refusing to read outside the public directory');
   }
   return readFileSync(resolved);

--- a/examples/starter/src/server.js
+++ b/examples/starter/src/server.js
@@ -1,12 +1,13 @@
 import { createServer } from 'node:http';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname, join, extname } from 'node:path';
+import { dirname, join, extname, resolve, sep } from 'node:path';
 import { render } from '@basenative/server';
 import { resolveRoute } from '@basenative/router';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
+const PUBLIC_DIR = join(ROOT, 'public');
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -14,8 +15,18 @@ function readPage(name) {
   return readFileSync(join(__dirname, 'pages', name), 'utf8');
 }
 
-function readFile(path) {
-  return readFileSync(join(ROOT, path));
+/**
+ * Read a file under PUBLIC_DIR, rejecting any request path that would
+ * resolve outside it. `relPath` comes from the request URL, so `resolve()`
+ * + a prefix check on the result — rather than trusting `join()` and the
+ * caller's own `../` stripping — is what actually stops traversal.
+ */
+function readPublicFile(relPath) {
+  const resolved = resolve(PUBLIC_DIR, `.${sep}${relPath}`);
+  if (resolved !== PUBLIC_DIR && !resolved.startsWith(PUBLIC_DIR + sep)) {
+    throw new Error('Refusing to read outside the public directory');
+  }
+  return readFileSync(resolved);
 }
 
 const MIME = {
@@ -149,7 +160,7 @@ function handleDeleteTodo(req, res, params) {
 function handleStaticFile(req, res) {
   try {
     const filePath = req.url.replace('/public/', '');
-    const data = readFile(`public/${filePath}`);
+    const data = readPublicFile(filePath);
     const ext = extname(filePath);
     res.writeHead(200, {
       'Content-Type': MIME[ext] ?? 'application/octet-stream',

--- a/examples/static/index.html
+++ b/examples/static/index.html
@@ -690,7 +690,7 @@
 </main>
 
 <script type="module">
-import { signal, computed, effect, hydrate } from '../../packages/runtime/src/index.js';
+import { signal, computed, hydrate } from '../../packages/runtime/src/index.js';
 
 const visible = signal(true);
 const message = signal('The template is alive.');

--- a/packages/claude-config/src/install.js
+++ b/packages/claude-config/src/install.js
@@ -42,7 +42,7 @@ function ensureDir(dir) {
 
 function listTemplateFiles(srcDir, glob) {
   if (!existsSync(srcDir)) return [];
-  const ext = glob.replace('*', '');
+  const ext = glob.replaceAll('*', '');
   return readdirSync(srcDir).filter((f) => f.endsWith(ext));
 }
 
@@ -72,10 +72,20 @@ export async function install({ projectRoot, force = false, dryRun = false, quie
     for (const f of files) {
       const srcPath = join(srcDir, f);
       const destPath = join(destDir, f);
-      const exists = existsSync(destPath);
+
+      // Read rather than `existsSync` + read: a check-then-read is racy
+      // (the file can change or disappear in between), so the read attempt
+      // itself is the existence check.
+      let destContent;
+      try {
+        destContent = readFileSync(destPath, 'utf8');
+      } catch (error) {
+        if (error.code !== 'ENOENT') throw error;
+      }
+      const exists = destContent !== undefined;
 
       if (exists && !force) {
-        const same = readFileSync(srcPath, 'utf8') === readFileSync(destPath, 'utf8');
+        const same = readFileSync(srcPath, 'utf8') === destContent;
         if (same) {
           summary.skipped++;
           if (!quiet) log(`    ${dim('=')} ${f} ${dim('(unchanged)')}`);
@@ -102,25 +112,51 @@ export async function install({ projectRoot, force = false, dryRun = false, quie
   }
 
   // settings.template.json → .claude/settings.json (only if missing — we never clobber settings).
+  // `dryRun` performs no filesystem write, so an `existsSync` there is a
+  // pure report with no follow-on action; the real write below uses
+  // exclusive create instead of a check, since settings.json existing is
+  // exactly the case we must never clobber.
   const settingsDest = join(claudeDir, 'settings.json');
   if (existsSync(SETTINGS_TEMPLATE)) {
-    if (!existsSync(settingsDest)) {
-      if (!dryRun) writeFileSync(settingsDest, readFileSync(SETTINGS_TEMPLATE));
-      summary.written++;
-      if (!quiet) log(`  ${green('+')} settings.json`);
-    } else if (!quiet) {
-      log(`  ${dim('=')} settings.json ${dim('(already present — not touched)')}`);
-      log(dim(`     diff against template: ${SETTINGS_TEMPLATE}`));
+    if (dryRun) {
+      if (!existsSync(settingsDest)) {
+        summary.written++;
+        if (!quiet) log(`  ${green('+')} settings.json`);
+      } else if (!quiet) {
+        log(`  ${dim('=')} settings.json ${dim('(already present — not touched)')}`);
+        log(dim(`     diff against template: ${SETTINGS_TEMPLATE}`));
+      }
+    } else {
+      try {
+        writeFileSync(settingsDest, readFileSync(SETTINGS_TEMPLATE), { flag: 'wx' });
+        summary.written++;
+        if (!quiet) log(`  ${green('+')} settings.json`);
+      } catch (error) {
+        if (error.code !== 'EEXIST') throw error;
+        if (!quiet) {
+          log(`  ${dim('=')} settings.json ${dim('(already present — not touched)')}`);
+          log(dim(`     diff against template: ${SETTINGS_TEMPLATE}`));
+        }
+      }
     }
   }
 
   // CLAUDE.md.tmpl → CLAUDE.md (only if missing).
   if (existsSync(CLAUDE_MD_TEMPLATE)) {
     const claudeMdDest = join(projectRoot, 'CLAUDE.md');
-    if (!existsSync(claudeMdDest)) {
-      if (!dryRun) writeFileSync(claudeMdDest, readFileSync(CLAUDE_MD_TEMPLATE));
-      summary.written++;
-      if (!quiet) log(`  ${green('+')} CLAUDE.md ${dim('(from template)')}`);
+    if (dryRun) {
+      if (!existsSync(claudeMdDest)) {
+        summary.written++;
+        if (!quiet) log(`  ${green('+')} CLAUDE.md ${dim('(from template)')}`);
+      }
+    } else {
+      try {
+        writeFileSync(claudeMdDest, readFileSync(CLAUDE_MD_TEMPLATE), { flag: 'wx' });
+        summary.written++;
+        if (!quiet) log(`  ${green('+')} CLAUDE.md ${dim('(from template)')}`);
+      } catch (error) {
+        if (error.code !== 'EEXIST') throw error;
+      }
     }
   }
 
@@ -167,7 +203,7 @@ export function list({ projectRoot } = {}) {
   for (const kind of TEMPLATE_KINDS) {
     const dir = join(claudeDir, kind.dest);
     if (!existsSync(dir)) { out[kind.name] = []; continue; }
-    out[kind.name] = readdirSync(dir).filter((f) => f.endsWith(kind.glob.replace('*', '')));
+    out[kind.name] = readdirSync(dir).filter((f) => f.endsWith(kind.glob.replaceAll('*', '')));
   }
   return out;
 }

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -1,5 +1,5 @@
 // Built with BaseNative — basenative.dev
-import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { parseArgs } from 'node:util';
 
@@ -8,6 +8,26 @@ const generators = {
   route: generateRoute,
   page: generatePage,
 };
+
+/**
+ * Create a new file, refusing to clobber one that already exists.
+ *
+ * Uses an exclusive-create write (`flag: 'wx'`) instead of an
+ * `existsSync` check followed by a separate `writeFileSync`: checking then
+ * acting on a path is racy (the file can be created in between), so the
+ * existence check and the write are done as one atomic filesystem call.
+ */
+function writeIfAbsent(filePath, content, alreadyExistsMessage) {
+  try {
+    writeFileSync(filePath, content, { flag: 'wx' });
+  } catch (err) {
+    if (err.code === 'EEXIST') {
+      console.error(alreadyExistsMessage);
+      process.exit(1);
+    }
+    throw err;
+  }
+}
 
 export async function run(args) {
   const { values, positionals } = parseArgs({
@@ -59,12 +79,9 @@ function generateComponent(name) {
   mkdirSync(dir, { recursive: true });
 
   const filePath = join(dir, `${kebab}.js`);
-  if (existsSync(filePath)) {
-    console.error(`Component already exists: ${filePath}`);
-    process.exit(1);
-  }
-
-  writeFileSync(filePath, `/**
+  writeIfAbsent(
+    filePath,
+    `/**
  * Render a ${name} component.
  * @param {object} props
  * @returns {string} HTML string
@@ -74,7 +91,9 @@ export function render${name}(props = {}) {
   <!-- ${name} component -->
 </div>\`;
 }
-`);
+`,
+    `Component already exists: ${filePath}`
+  );
 
   console.log(`Created component: src/components/${kebab}.js`);
 }
@@ -86,18 +105,17 @@ function generateRoute(path) {
   const name = path.replace(/^\//, '').replace(/\//g, '-') || 'index';
   const filePath = join(dir, `${name}.js`);
 
-  if (existsSync(filePath)) {
-    console.error(`Route already exists: ${filePath}`);
-    process.exit(1);
-  }
-
-  writeFileSync(filePath, `/**
+  writeIfAbsent(
+    filePath,
+    `/**
  * Route handler for ${path}
  */
 export function handler(req, res) {
   res.json({ path: '${path}' });
 }
-`);
+`,
+    `Route already exists: ${filePath}`
+  );
 
   console.log(`Created route: src/routes/${name}.js`);
 }
@@ -107,15 +125,14 @@ function generatePage(name) {
   mkdirSync(dir, { recursive: true });
 
   const filePath = join(dir, `${name}.html`);
-  if (existsSync(filePath)) {
-    console.error(`Page already exists: ${filePath}`);
-    process.exit(1);
-  }
-
-  writeFileSync(filePath, `<section aria-label="${name}">
+  writeIfAbsent(
+    filePath,
+    `<section aria-label="${name}">
   <h2>${name.charAt(0).toUpperCase() + name.slice(1)}</h2>
 </section>
-`);
+`,
+    `Page already exists: ${filePath}`
+  );
 
   console.log(`Created page: views/${name}.html`);
 }

--- a/packages/cli/src/commands/prd.js
+++ b/packages/cli/src/commands/prd.js
@@ -72,12 +72,9 @@ export async function run(args) {
 }
 
 function prdInit(prdPath, values) {
-  if (existsSync(prdPath) && !values.force) {
-    err(`${PRD_PATH} already exists.`);
-    hint('Use --force to overwrite, or `bn prd edit` to modify.');
-    process.exit(1);
-  }
-
+  // No existsSync pre-check: the write below uses an exclusive 'wx' flag
+  // (unless --force) and reports the same "already exists" error from the
+  // resulting EEXIST, so there's no separate check-then-act window.
   const projectName = values.name || basename(process.cwd());
   const owner = values.owner || process.env.USER || 'TBD';
   const today = new Date().toISOString().slice(0, 10);
@@ -186,9 +183,8 @@ _[secondary persona]_
 
   mkdirSync(dirname(prdPath), { recursive: true });
   try {
-    // Exclusive create unless --force: the existence check above and this
-    // write are two separate filesystem accesses, so a file created in
-    // between would otherwise be silently overwritten without --force.
+    // Exclusive create unless --force, so a concurrently-created file is
+    // reported via EEXIST below instead of silently overwritten.
     writeFileSync(prdPath, body, values.force ? undefined : { flag: 'wx' });
   } catch (error) {
     if (!values.force && error.code === 'EEXIST') {

--- a/packages/cli/src/commands/prd.js
+++ b/packages/cli/src/commands/prd.js
@@ -185,7 +185,19 @@ _[secondary persona]_
   }
 
   mkdirSync(dirname(prdPath), { recursive: true });
-  writeFileSync(prdPath, body);
+  try {
+    // Exclusive create unless --force: the existence check above and this
+    // write are two separate filesystem accesses, so a file created in
+    // between would otherwise be silently overwritten without --force.
+    writeFileSync(prdPath, body, values.force ? undefined : { flag: 'wx' });
+  } catch (error) {
+    if (!values.force && error.code === 'EEXIST') {
+      err(`${PRD_PATH} already exists.`);
+      hint('Use --force to overwrite, or `bn prd edit` to modify.');
+      process.exit(1);
+    }
+    throw error;
+  }
   banner();
   ok(`Wrote ${PRD_PATH}`);
   hint('Edit it: bn prd edit');

--- a/packages/cli/src/commands/speckit.js
+++ b/packages/cli/src/commands/speckit.js
@@ -283,7 +283,21 @@ function speckitPlan(specifyDir, values) {
     : '# Plan: {{title}}\n\n> Spec: {{id}}\n';
   const body = tpl.replace(/\{\{title\}\}/g, title).replace(/\{\{id\}\}/g, id);
 
-  if (!values['dry-run']) writeFileSync(planPath, body);
+  if (!values['dry-run']) {
+    try {
+      // Exclusive create unless --force: the existence check above and this
+      // write are two separate filesystem accesses, so a plan.md created in
+      // between would otherwise be silently overwritten without --force.
+      writeFileSync(planPath, body, values.force ? undefined : { flag: 'wx' });
+    } catch (error) {
+      if (!values.force && error.code === 'EEXIST') {
+        err(`plan.md already exists at ${planPath}`);
+        hint('Use --force to overwrite.');
+        process.exit(1);
+      }
+      throw error;
+    }
+  }
 
   ok(`Wrote plan: ${SPECIFY_DIR}/specs/${id}/plan.md`);
   info('LLM hand-off point: feed spec.md + constitution.md + plan.md to your model.');
@@ -300,8 +314,17 @@ function speckitTasks(specifyDir, cwd, values) {
   const tasksPath = join(dir, 'tasks.md');
   const tasks = [];
 
-  if (existsSync(tasksPath)) {
-    const content = readFileSync(tasksPath, 'utf-8');
+  // Read rather than `existsSync` + read: a check-then-read is racy (the
+  // file could be created or removed in between), so the read attempt
+  // itself is the existence check.
+  let content;
+  try {
+    content = readFileSync(tasksPath, 'utf-8');
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+  }
+
+  if (content !== undefined) {
     for (const line of content.split('\n')) {
       const m = line.match(/^- \[( |x|X)\]\s+(?:(T\d+)\s+)?(.+?)(\s+\[P\])?\s*$/);
       if (!m) continue;
@@ -316,7 +339,15 @@ function speckitTasks(specifyDir, cwd, values) {
     }
   } else {
     info(`No tasks.md found in ${SPECIFY_DIR}/specs/${id}/. Creating an empty one.`);
-    if (!values['dry-run']) writeFileSync(tasksPath, `# Tasks: ${id}\n\n- [ ] T01 _first task_\n`);
+    if (!values['dry-run']) {
+      try {
+        writeFileSync(tasksPath, `# Tasks: ${id}\n\n- [ ] T01 _first task_\n`, { flag: 'wx' });
+      } catch (error) {
+        if (error.code !== 'EEXIST') throw error;
+        // Another process created tasks.md between our read and this
+        // write; leave it alone rather than clobber it.
+      }
+    }
   }
 
   const output = {

--- a/packages/cli/src/commands/speckit.js
+++ b/packages/cli/src/commands/speckit.js
@@ -270,11 +270,9 @@ function speckitPlan(specifyDir, values) {
     process.exit(1);
   }
   const planPath = join(dir, 'plan.md');
-  if (existsSync(planPath) && !values.force) {
-    err(`plan.md already exists at ${planPath}`);
-    hint('Use --force to overwrite.');
-    process.exit(1);
-  }
+  // No existsSync pre-check: the write below uses an exclusive 'wx' flag
+  // (unless --force) and reports the same "already exists" error from the
+  // resulting EEXIST, so there's no separate check-then-act window.
   const id = dir.split('/').pop();
   const title = id.replace(/^\d{3}-/, '').replace(/-/g, ' ');
   const tplPath = join(specifyDir, 'templates', 'plan.md');
@@ -285,9 +283,8 @@ function speckitPlan(specifyDir, values) {
 
   if (!values['dry-run']) {
     try {
-      // Exclusive create unless --force: the existence check above and this
-      // write are two separate filesystem accesses, so a plan.md created in
-      // between would otherwise be silently overwritten without --force.
+      // Exclusive create unless --force, so a concurrently-created plan.md
+      // is reported via EEXIST below instead of silently overwritten.
       writeFileSync(planPath, body, values.force ? undefined : { flag: 'wx' });
     } catch (error) {
       if (!values.force && error.code === 'EEXIST') {

--- a/packages/cli/src/lib/template.js
+++ b/packages/cli/src/lib/template.js
@@ -55,8 +55,13 @@ export function renderTemplate(srcDir, destDir, vars, opts = {}) {
       throw new Error(`Refusing to write outside destination: ${outRel}`);
     }
 
-    if (existsSync(outPath) && !overwrite) {
-      skipped.push(outRel);
+    if (dryRun) {
+      if (existsSync(outPath) && !overwrite) {
+        skipped.push(outRel);
+        return;
+      }
+      written.push(outRel);
+      if (onFile) onFile(outRel);
       return;
     }
 
@@ -68,9 +73,18 @@ export function renderTemplate(srcDir, destDir, vars, opts = {}) {
       body = raw; // binary — copy verbatim
     }
 
-    if (!dryRun) {
-      mkdirSync(join(outPath, '..'), { recursive: true });
-      writeFileSync(outPath, body);
+    mkdirSync(join(outPath, '..'), { recursive: true });
+    try {
+      // Exclusive create when not overwriting: this is the check *and* the
+      // act in one atomic syscall, so a file that appears between an
+      // `existsSync` probe and the write can't be silently clobbered.
+      writeFileSync(outPath, body, overwrite ? undefined : { flag: 'wx' });
+    } catch (err) {
+      if (!overwrite && err.code === 'EEXIST') {
+        skipped.push(outRel);
+        return;
+      }
+      throw err;
     }
     written.push(outRel);
     if (onFile) onFile(outRel);

--- a/packages/doppler/src/cli.js
+++ b/packages/doppler/src/cli.js
@@ -5,7 +5,7 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import { spawn, spawnSync } from 'node:child_process';
-import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createInterface } from 'node:readline/promises';
@@ -182,15 +182,15 @@ async function cmdInit(args) {
   }
 
   // Drop a starter doppler-required.json next to package.json if missing.
+  // Exclusive create rather than `existsSync` + write: checking then acting
+  // on a path is racy, since the file can be created in between.
   const target = resolve(process.cwd(), 'doppler-required.json');
-  if (!existsSync(target)) {
-    const tmpl = readFileSync(
-      join(__dirname, '..', 'templates', 'doppler-required.json'),
-      'utf-8',
-    );
-    writeFileSync(target, tmpl);
+  const tmpl = readFileSync(join(__dirname, '..', 'templates', 'doppler-required.json'), 'utf-8');
+  try {
+    writeFileSync(target, tmpl, { flag: 'wx' });
     console.log(`\nCreated ${target}`);
-  } else {
+  } catch (error) {
+    if (error.code !== 'EEXIST') throw error;
     console.log(`\nKept existing ${target}`);
   }
 

--- a/packages/favicon/src/manifest.js
+++ b/packages/favicon/src/manifest.js
@@ -31,7 +31,13 @@
  * @returns {Record<string, any>}
  */
 export function buildManifest(opts) {
-  const base = (opts.iconBaseUrl || "/").replace(/\/+$/, "") + "/";
+  // Strip trailing slashes with an index scan rather than /\/+$/: that
+  // regex is quadratic on input with many trailing slashes, and
+  // `iconBaseUrl` is caller-supplied.
+  const rawBase = opts.iconBaseUrl || "/";
+  let baseEnd = rawBase.length;
+  while (baseEnd > 0 && rawBase[baseEnd - 1] === "/") baseEnd--;
+  const base = rawBase.slice(0, baseEnd) + "/";
   return {
     name: opts.name,
     short_name: opts.shortName || opts.name,

--- a/packages/forms/src/validation.test.js
+++ b/packages/forms/src/validation.test.js
@@ -780,7 +780,7 @@ describe('validators — comprehensive validation module coverage', () => {
 
     it('validates URL format', () => {
       const urlValidator = pattern(
-        /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)$/,
+        /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/=]*)$/,
         'Invalid URL'
       );
 

--- a/packages/i18n/src/i18n.js
+++ b/packages/i18n/src/i18n.js
@@ -51,7 +51,10 @@ export function createI18n(options = {}) {
   const { defaultLocale = 'en', messages: initialMessages = {} } = options;
 
   let currentLocale = defaultLocale;
-  const messages = {};
+  // `locale` reaches `addMessages` from library input; a null-prototype
+  // object means a crafted locale like `__proto__` becomes an inert own
+  // property instead of the `Object.assign` below reaching Object.prototype.
+  const messages = Object.create(null);
   const listeners = [];
 
   // Load initial messages

--- a/packages/i18n/src/i18n.test.js
+++ b/packages/i18n/src/i18n.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createI18n } from './i18n.js';
@@ -196,10 +196,11 @@ describe('i18nMiddleware', () => {
 });
 
 describe('loader', () => {
-  const tmpDir = join(tmpdir(), `i18n-test-${Date.now()}`);
-
+  // `mkdtemp` rather than a `Date.now()`-suffixed name: a predictable path
+  // under the shared OS temp dir can be pre-created (e.g. as a symlink) by
+  // another local process racing this test.
   it('loadMessages reads a JSON translation file', async () => {
-    await mkdir(tmpDir, { recursive: true });
+    const tmpDir = await mkdtemp(join(tmpdir(), 'i18n-test-'));
     await writeFile(
       join(tmpDir, 'en.json'),
       JSON.stringify({ hello: 'Hello' })
@@ -210,8 +211,7 @@ describe('loader', () => {
   });
 
   it('createLoader loads and registers messages', async () => {
-    const dir = join(tmpdir(), `i18n-loader-${Date.now()}`);
-    await mkdir(dir, { recursive: true });
+    const dir = await mkdtemp(join(tmpdir(), 'i18n-loader-'));
     await writeFile(
       join(dir, 'en.json'),
       JSON.stringify({ greet: 'Hi' })

--- a/packages/marketplace/src/installer.js
+++ b/packages/marketplace/src/installer.js
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir, rm } from 'node:fs/promises';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';

--- a/packages/marketplace/src/installer.test.js
+++ b/packages/marketplace/src/installer.test.js
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { createInstaller } from './installer.js';
-import { mkdtemp, rm, readFile, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -186,10 +186,6 @@ describe('createInstaller — comprehensive', () => {
     });
 
     it('uses npm install by default', async () => {
-      let capturedArgs;
-      let capturedCwd;
-
-      // Mock process-like behavior by checking that install is called
       const installer = createInstaller({
         targetDir: tmpDir,
         packageManager: 'echo',

--- a/packages/marketplace/src/theme.js
+++ b/packages/marketplace/src/theme.js
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir, rm } from 'node:fs/promises';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const THEMES_CONFIG = 'themes.json';

--- a/packages/middleware/src/adapters/express.js
+++ b/packages/middleware/src/adapters/express.js
@@ -75,7 +75,10 @@ function createExpressContext(req, _res) {
 
 function parseCookieHeader(header) {
   if (!header) return {};
-  const result = {};
+  // Cookie names come straight from the request header. A null-prototype
+  // object means a crafted name like `__proto__` becomes an inert own
+  // property instead of reaching Object.prototype.
+  const result = Object.create(null);
   for (const pair of header.split(';')) {
     const eqIndex = pair.indexOf('=');
     if (eqIndex === -1) continue;

--- a/packages/notify/README.md
+++ b/packages/notify/README.md
@@ -68,6 +68,32 @@ notifications.dismiss(all[0].id);
 - `renderEmail(template, data)` — Interpolates `{{ variable }}` placeholders in an HTML template. Returns `{ html, text }` where `text` is a plain-text version derived from the HTML.
 - `createEmailSender(transport)` — Creates a sender bound to a transport. Returns `{ send(options) }` where options are `{ to, from, subject, html, text? }`.
 
+#### Escaping
+
+Every `{{ variable }}` value is HTML-escaped by default, using the same
+`escapeAttr` helper `@basenative/server` uses for SSR templates
+(`@basenative/runtime/shared/escape`). A value that contains `<script>` or
+other markup is rendered as inert text, not executable HTML:
+
+```js
+renderEmail('<p>Hi {{ name }}</p>', { name: '<script>alert(1)</script>' });
+// => { html: '<p>Hi &lt;script&gt;alert(1)&lt;/script&gt;</p>', ... }
+```
+
+To insert trusted HTML without escaping it, wrap the value in `raw()`:
+
+```js
+import { raw } from '@basenative/runtime/shared/escape';
+
+renderEmail('<div>{{ body }}</div>', { body: raw('<strong>Bold</strong>') });
+// => { html: '<div><strong>Bold</strong></div>', ... }
+```
+
+Only pass `raw()` around HTML you trust — it disables escaping entirely for
+that value, in every position the placeholder appears (`{{ }}` interpolation
+here has no idea whether it landed in a text node or an attribute value, so
+opting out of escaping opts out of both).
+
 ### Transports
 
 - `createSmtpTransport(options)` — Sends email via SMTP. Options: `host`, `port`, `secure`, `auth: { user, pass }`.

--- a/packages/notify/package.json
+++ b/packages/notify/package.json
@@ -8,6 +8,9 @@
     ".": "./src/index.js"
   },
   "types": "./types/index.d.ts",
+  "dependencies": {
+    "@basenative/runtime": "workspace:^0.5.0"
+  },
   "files": [
     "src",
     "types"

--- a/packages/notify/src/email.js
+++ b/packages/notify/src/email.js
@@ -1,28 +1,24 @@
+import { escapeAttr, isRaw, unwrapRaw } from '@basenative/runtime/shared/escape';
+
 /**
- * Escape a value for safe insertion into an email template.
+ * `@basenative/runtime/shared/escape` is the canonical escaping shared by the
+ * SSR renderer and client runtime (see `packages/runtime/src/shared/escape.js`
+ * and its use in `packages/server/src/render.js`). This module used to carry
+ * its own local copy so notify wouldn't need the dependency; it now imports
+ * the shared one instead, so the two template languages can't drift apart.
  *
- * This package does not depend on `@basenative/runtime`, which owns the
- * canonical escaping used by the SSR renderer and client runtime
- * (`packages/runtime/src/shared/escape.js`). Adding that dependency here
- * would touch the workspace lockfile, which is out of scope for this fix, so
- * this is a deliberate, minimal local copy.
+ * Unlike the runtime's `escapeText`/`escapeAttr` split, every substitution
+ * here uses `escapeAttr`, which also escapes quotes. The runtime can tell
+ * apart a text-node interpolation from an attribute-value one because its
+ * renderer parses the template; this module's `{{ key }}` substitution is a
+ * plain string replace with no idea which context it lands in (`<img
+ * src="{{ src }}">` vs `<p>{{ name }}</p>`). A value safe only in text nodes
+ * would let `" onerror="alert(1)` break out of an attribute, so every
+ * substituted value gets the stricter escaping.
  *
- * Unlike the runtime's `escapeText`/`escapeAttr` split, this escapes quotes
- * too. The runtime can tell apart a text-node interpolation from an
- * attribute-value one because its renderer parses the template; this
- * module's `{{ key }}` substitution is a plain string replace with no idea
- * which context it lands in (`<img src="{{ src }}">` vs `<p>{{ name }}</p>`).
- * A value safe only in text nodes would let `" onerror="alert(1)` break out
- * of an attribute, so every substituted value gets the stricter escaping.
+ * A value wrapped in `raw()` (also exported by `@basenative/runtime/shared/escape`)
+ * is inserted verbatim as trusted markup, matching the SSR renderer's opt-out.
  */
-function escapeText(value) {
-  return String(value ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
 
 /** Named character references this module round-trips through `htmlToText`. */
 const NAMED_ENTITIES = {
@@ -155,7 +151,9 @@ function htmlToText(html) {
  */
 export function renderEmail(template, data) {
   const html = template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, key) => {
-    return key in data ? escapeText(data[key]) : '';
+    if (!(key in data)) return '';
+    const value = data[key];
+    return isRaw(value) ? unwrapRaw(value) : escapeAttr(value ?? '');
   });
 
   return { html, text: htmlToText(html) };

--- a/packages/notify/src/notify.test.js
+++ b/packages/notify/src/notify.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { createServer as createTlsServer } from 'node:tls';
+import { raw } from '@basenative/runtime/shared/escape';
 import { renderEmail, createEmailSender } from './email.js';
 import { createNotificationCenter } from './inapp.js';
 import { createSendGridTransport } from './transports/sendgrid.js';
@@ -61,6 +62,21 @@ describe('renderEmail', () => {
     // Only one real <img> tag exists; the payload's quote did not open a
     // second attribute.
     assert.equal((result.html.match(/<img/gi) || []).length, 1);
+  });
+
+  it('inserts a raw() value verbatim, opting out of escaping', () => {
+    const template = '<div>{{ body }}</div>';
+    const result = renderEmail(template, { body: raw('<strong>Bold</strong>') });
+    assert.equal(result.html, '<div><strong>Bold</strong></div>');
+    // The unescaped markup is real HTML now, so the text fallback should
+    // read it as tags rather than literal angle brackets.
+    assert.equal(result.text, 'Bold');
+  });
+
+  it('does not escape a raw() value even in an attribute position', () => {
+    const template = '<img src="{{ src }}">';
+    const result = renderEmail(template, { src: raw('trusted.png') });
+    assert.equal(result.html, '<img src="trusted.png">');
   });
 });
 

--- a/packages/runtime/src/expression.fuzz.test.js
+++ b/packages/runtime/src/expression.fuzz.test.js
@@ -222,11 +222,10 @@ describe('fuzz: evaluator result is always defined-safe', () => {
   for (const [expr, ctx] of inputs) {
     it(`returns undefined (not throws) for: ${expr}`, () => {
       clearExpressionCache();
-      let result;
+      // Any result is fine here — not throwing is the assertion that matters.
       assert.doesNotThrow(() => {
-        result = evaluateExpression(expr, ctx, { onDiagnostic: () => {} });
+        evaluateExpression(expr, ctx, { onDiagnostic: () => {} });
       });
-      assert.ok(result === undefined || result !== undefined); // any result is fine, as long as no throw
     });
   }
 });

--- a/packages/runtime/src/features.js
+++ b/packages/runtime/src/features.js
@@ -22,4 +22,9 @@ export function supportsFeature(name, target = globalThis) {
   return Boolean(detectBrowserFeatures(target)[name]);
 }
 
-export const browserFeatures = detectBrowserFeatures();
+// @__PURE__: detectBrowserFeatures only reads feature flags off `target`, so
+// a bundler that doesn't use this binding (e.g. an entry point that pulls in
+// @basenative/runtime for signals but never touches browserFeatures) can
+// drop the call outright instead of keeping it as a dead-but-side-effecting
+// assignment in the output.
+export const browserFeatures = /* @__PURE__ */ detectBrowserFeatures();

--- a/packages/upload/src/handler.js
+++ b/packages/upload/src/handler.js
@@ -15,7 +15,10 @@ export function parseMultipart(body, contentType) {
   return parts.map(part => {
     const [headerSection, ...bodyParts] = part.split('\r\n\r\n');
     const bodyContent = bodyParts.join('\r\n\r\n').replace(/\r\n$/, '');
-    const headers = {};
+    // Header names come straight from the request body. A null-prototype
+    // object means a crafted name like `__proto__` becomes an inert own
+    // property instead of reaching Object.prototype.
+    const headers = Object.create(null);
 
     for (const line of headerSection.split('\r\n')) {
       const match = line.match(/^([^:]+):\s*(.+)$/);

--- a/packages/visual-builder/src/visual-builder.test.js
+++ b/packages/visual-builder/src/visual-builder.test.js
@@ -88,7 +88,7 @@ describe('createCanvas', () => {
 describe('getTree', () => {
   test('builds parent-child hierarchy', () => {
     const canvas = createCanvas();
-    const parent = canvas.addNode({ type: 'container', id: 'parent' });
+    canvas.addNode({ type: 'container', id: 'parent' });
     canvas.addNode({ type: 'button', id: 'child1', parentId: 'parent' });
     canvas.addNode({ type: 'text', id: 'child2', parentId: 'parent' });
 

--- a/packages/wrangler-preset/src/index.js
+++ b/packages/wrangler-preset/src/index.js
@@ -142,7 +142,15 @@ export function toToml(config) {
   }
   const lines = [];
   emit(lines, config, []);
-  return lines.join('\n').replace(/\n+$/, '') + '\n';
+  const joined = lines.join('\n');
+  // Strip trailing newlines with an index scan rather than /\n+$/: that
+  // regex is quadratic on input with many trailing (or embedded, since the
+  // engine retries the match at every start position) newlines, and `obj`
+  // — and therefore every line — can come from config values outside this
+  // module's control.
+  let end = joined.length;
+  while (end > 0 && joined[end - 1] === '\n') end--;
+  return joined.slice(0, end) + '\n';
 }
 
 function emit(lines, obj, path) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,7 +351,11 @@ importers:
 
   packages/middleware: {}
 
-  packages/notify: {}
+  packages/notify:
+    dependencies:
+      '@basenative/runtime':
+        specifier: workspace:^0.5.0
+        version: link:../runtime
 
   packages/og-image:
     dependencies:

--- a/scripts/audit/axe.mjs
+++ b/scripts/audit/axe.mjs
@@ -7,7 +7,7 @@
 import { chromium } from '@playwright/test';
 import { createServer } from 'http';
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join, extname } from 'path';
+import { join, extname, resolve, sep } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -40,18 +40,39 @@ const MIME_TYPES = {
   '.woff2': 'font/woff2',
 };
 
+/**
+ * Resolve a request path against DIST_DIR and verify it doesn't escape that
+ * root. `req.url` is attacker-controllable input (`../../etc/passwd` etc.);
+ * `resolve()` collapses the `..` segments and the `startsWith` check rejects
+ * anything that lands outside DIST_DIR instead of trusting the join result.
+ */
+function safeDistPath(urlPath) {
+  const withoutQuery = urlPath.split(/[?#]/, 1)[0];
+  const candidate = resolve(DIST_DIR, `.${withoutQuery}`);
+  if (candidate !== DIST_DIR && !candidate.startsWith(DIST_DIR + sep)) return null;
+  return candidate;
+}
+
 function serve() {
   return createServer((req, res) => {
-    let filePath = join(DIST_DIR, req.url === '/' ? 'index.html' : req.url);
+    const filePath = safeDistPath(req.url === '/' ? '/index.html' : req.url);
+    if (!filePath) {
+      res.writeHead(403);
+      res.end();
+      return;
+    }
     try {
       const ext = extname(filePath);
       const content = readFileSync(filePath);
       res.writeHead(200, { 'Content-Type': MIME_TYPES[ext] ?? 'text/plain' });
       res.end(content);
     } catch {
-      // SPA fallback — try serving index.html from the requested directory
+      // SPA fallback — try serving index.html from the requested directory.
+      // `filePath` was already confirmed to stay under DIST_DIR above, and
+      // appending a fixed literal segment to a confined path can't escape
+      // it, so this does not need a second traversal check.
       try {
-        const indexPath = filePath.endsWith('/') ? join(filePath, 'index.html') : join(filePath, 'index.html');
+        const indexPath = join(filePath, 'index.html');
         const content = readFileSync(indexPath);
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(content);

--- a/scripts/audit/axe.mjs
+++ b/scripts/audit/axe.mjs
@@ -7,7 +7,7 @@
 import { chromium } from '@playwright/test';
 import { createServer } from 'http';
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join, extname, resolve, sep } from 'path';
+import { join, extname, resolve, relative, sep } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -41,22 +41,23 @@ const MIME_TYPES = {
 };
 
 /**
- * Resolve a request path against DIST_DIR and verify it doesn't escape that
- * root. `req.url` is attacker-controllable input (`../../etc/passwd` etc.);
- * `resolve()` collapses the `..` segments and the `startsWith` check rejects
- * anything that lands outside DIST_DIR instead of trusting the join result.
+ * Turn a request path into a candidate absolute path under DIST_DIR.
+ * `req.url` is attacker-controllable input (`../../etc/passwd` etc.), so
+ * this only builds the candidate — every caller below re-checks the
+ * specific path it is about to read (via `relative()` against DIST_DIR)
+ * immediately before the matching `readFileSync`, rather than trusting a
+ * check performed here and carried across the call boundary.
  */
-function safeDistPath(urlPath) {
+function toDistPath(urlPath) {
   const withoutQuery = urlPath.split(/[?#]/, 1)[0];
-  const candidate = resolve(DIST_DIR, `.${withoutQuery}`);
-  if (candidate !== DIST_DIR && !candidate.startsWith(DIST_DIR + sep)) return null;
-  return candidate;
+  return resolve(DIST_DIR, `.${withoutQuery}`);
 }
 
 function serve() {
   return createServer((req, res) => {
-    const filePath = safeDistPath(req.url === '/' ? '/index.html' : req.url);
-    if (!filePath) {
+    const filePath = toDistPath(req.url === '/' ? '/index.html' : req.url);
+    const filePathRel = relative(DIST_DIR, filePath);
+    if (filePathRel === '..' || filePathRel.startsWith(`..${sep}`)) {
       res.writeHead(403);
       res.end();
       return;
@@ -68,11 +69,12 @@ function serve() {
       res.end(content);
     } catch {
       // SPA fallback — try serving index.html from the requested directory.
-      // `filePath` was already confirmed to stay under DIST_DIR above, and
-      // appending a fixed literal segment to a confined path can't escape
-      // it, so this does not need a second traversal check.
       try {
         const indexPath = join(filePath, 'index.html');
+        const indexPathRel = relative(DIST_DIR, indexPath);
+        if (indexPathRel === '..' || indexPathRel.startsWith(`..${sep}`)) {
+          throw new Error('Refusing to read outside the dist directory');
+        }
         const content = readFileSync(indexPath);
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(content);

--- a/scripts/audit/laws-of-ux.mjs
+++ b/scripts/audit/laws-of-ux.mjs
@@ -17,7 +17,7 @@
 import { chromium } from '@playwright/test';
 import { createServer } from 'http';
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join, extname, resolve, sep } from 'path';
+import { join, extname, resolve, relative, sep } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -37,22 +37,23 @@ const MIME_TYPES = {
 };
 
 /**
- * Resolve a request path against DIST_DIR and verify it doesn't escape that
- * root. `req.url` is attacker-controllable input (`../../etc/passwd` etc.);
- * `resolve()` collapses the `..` segments and the `startsWith` check rejects
- * anything that lands outside DIST_DIR instead of trusting the join result.
+ * Turn a request path into a candidate absolute path under DIST_DIR.
+ * `req.url` is attacker-controllable input (`../../etc/passwd` etc.), so
+ * this only builds the candidate — every caller below re-checks the
+ * specific path it is about to read (via `relative()` against DIST_DIR)
+ * immediately before the matching `readFileSync`, rather than trusting a
+ * check performed here and carried across the call boundary.
  */
-function safeDistPath(urlPath) {
+function toDistPath(urlPath) {
   const withoutQuery = urlPath.split(/[?#]/, 1)[0];
-  const candidate = resolve(DIST_DIR, `.${withoutQuery}`);
-  if (candidate !== DIST_DIR && !candidate.startsWith(DIST_DIR + sep)) return null;
-  return candidate;
+  return resolve(DIST_DIR, `.${withoutQuery}`);
 }
 
 function serve() {
   return createServer((req, res) => {
-    const filePath = safeDistPath(req.url === '/' ? '/index.html' : req.url);
-    if (!filePath) {
+    const filePath = toDistPath(req.url === '/' ? '/index.html' : req.url);
+    const filePathRel = relative(DIST_DIR, filePath);
+    if (filePathRel === '..' || filePathRel.startsWith(`..${sep}`)) {
       res.writeHead(403);
       res.end();
       return;
@@ -62,12 +63,13 @@ function serve() {
       res.writeHead(200, { 'Content-Type': MIME_TYPES[extname(filePath)] ?? 'text/plain' });
       res.end(content);
     } catch {
-      // Try serving index.html from the requested directory. `filePath` was
-      // already confirmed to stay under DIST_DIR above, and appending a
-      // fixed literal segment to a confined path can't escape it, so this
-      // does not need a second traversal check.
+      // Try serving index.html from the requested directory.
       try {
         const indexPath = join(filePath, 'index.html');
+        const indexPathRel = relative(DIST_DIR, indexPath);
+        if (indexPathRel === '..' || indexPathRel.startsWith(`..${sep}`)) {
+          throw new Error('Refusing to read outside the dist directory');
+        }
         const content = readFileSync(indexPath);
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(content);

--- a/scripts/audit/laws-of-ux.mjs
+++ b/scripts/audit/laws-of-ux.mjs
@@ -17,7 +17,7 @@
 import { chromium } from '@playwright/test';
 import { createServer } from 'http';
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join, extname } from 'path';
+import { join, extname, resolve, sep } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -36,17 +36,38 @@ const MIME_TYPES = {
   '.woff2': 'font/woff2',
 };
 
+/**
+ * Resolve a request path against DIST_DIR and verify it doesn't escape that
+ * root. `req.url` is attacker-controllable input (`../../etc/passwd` etc.);
+ * `resolve()` collapses the `..` segments and the `startsWith` check rejects
+ * anything that lands outside DIST_DIR instead of trusting the join result.
+ */
+function safeDistPath(urlPath) {
+  const withoutQuery = urlPath.split(/[?#]/, 1)[0];
+  const candidate = resolve(DIST_DIR, `.${withoutQuery}`);
+  if (candidate !== DIST_DIR && !candidate.startsWith(DIST_DIR + sep)) return null;
+  return candidate;
+}
+
 function serve() {
   return createServer((req, res) => {
-    let filePath = join(DIST_DIR, req.url === '/' ? 'index.html' : req.url);
+    const filePath = safeDistPath(req.url === '/' ? '/index.html' : req.url);
+    if (!filePath) {
+      res.writeHead(403);
+      res.end();
+      return;
+    }
     try {
       const content = readFileSync(filePath);
       res.writeHead(200, { 'Content-Type': MIME_TYPES[extname(filePath)] ?? 'text/plain' });
       res.end(content);
     } catch {
-      // Try serving index.html from the requested directory
+      // Try serving index.html from the requested directory. `filePath` was
+      // already confirmed to stay under DIST_DIR above, and appending a
+      // fixed literal segment to a confined path can't escape it, so this
+      // does not need a second traversal check.
       try {
-        const indexPath = filePath.endsWith('/') ? join(filePath, 'index.html') : join(filePath, 'index.html');
+        const indexPath = join(filePath, 'index.html');
         const content = readFileSync(indexPath);
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(content);


### PR DESCRIPTION
## Summary

Clears every alert from the live CodeQL open-alert list captured at the start of this work (68 alerts, `state=open`) and brings `@basenative/notify`'s email templating onto the shared `@basenative/runtime/shared/escape` module (backlog item 6 in `CLAUDE.md`).

`packages/notify/src/email.js` (HTML escaping) and `packages/notify/src/transports/smtp.js` (`rejectUnauthorized`) and `packages/share/src/server.js`'s `shortId` modulo bias — called out in the task backlog — were verified against the live alert list and found already fixed on `main` (commit `26ec0ac`, from an earlier `fix/codeql-backlog` effort). No alert referenced them, and the notify `email.js` already had its own local escaping with tests for a `<script>` payload; this PR replaces that local copy with the shared module and adds `raw()` support (see the first commit).

### Fixed (57 alerts, by rule)

- **`js/file-system-race`** (11): #38 #39 #40 #41 #42 #43 #44 #45 #46 #47 #48 — `claude-config`, `cli`, `doppler` installers/scaffolding: `existsSync` + separate read/write races replaced with exclusive-create (`{ flag: 'wx' }`) + `EEXIST` handling, or a read-based existence check.
- **`js/path-injection`** (5): #11 #12 #13 #14 #15 — `examples/starter`'s static file handler and `scripts/audit`'s local preview server now resolve the request path and reject anything outside the intended root.
- **`js/incomplete-sanitization`** (2): #6 #7 — `claude-config`'s glob→extension conversion used `.replace('*', '')` (first occurrence only); now `.replaceAll`.
- **`js/polynomial-redos`** (2): #21 #26 — `favicon` and `wrangler-preset` trailing-character trims (`/\/+$/`, `/\n+$/`) replaced with a linear scan.
- **`js/prototype-polluting-assignment`** (1) / **`js/remote-property-injection`** (2): #16 #34 #35 — `i18n`, `middleware`, `upload` built attacker-influenced keys onto plain `{}` objects; now `Object.create(null)`.
- **`js/reflected-xss`** (1): #17 — `examples/enterprise` spliced an unescaped page title (user's own name) into HTML.
- **`js/missing-rate-limiting`** (1): #20 — `examples/enterprise-v2`'s login route gets its own tight limiter on top of the global one.
- **`js/insecure-temporary-file`** (3): #31 #32 #33 — `i18n` tests switched from a `Date.now()`-suffixed temp dir to `fs.mkdtemp`.
- **`js/regex/duplicate-in-character-class`** (1): #123 — duplicate `/` in a `forms` test regex.
- **`js/unneeded-defensive-code`** (1): #102 — tautological assertion in a `runtime` fuzz test.
- **`js/unused-local-variable`** (23), **`js/useless-assignment-to-local`** (3), **`js/useless-expression`** (1): #49-63, #67, #80, #82, #95, #97-99, #103, #115-117, #121 — dead imports/locals across `marketplace`, `visual-builder`, examples, and `benchmarks` (one case — `router.bench.js`'s `deepPattern` — was a missing benchmark case, added rather than deleted).

### Dismissed as false positive (11 alerts)

All in test files or by-design network calls to a fixed host — reasons posted on each alert via the API:

- **`js/incomplete-url-substring-sanitization`** (4): #8 #9 #10 #113 — test assertions (`url.includes(...)`) checking a mock/constructed URL, not a security host check.
- **`js/regex/missing-regexp-anchor`** (1): #36 — same, an `assert.match` in a test.
- **`js/http-to-file-access`** (1): #37 — an audit script persisting its own fetched scan result to a local report file nothing else reads.
- **`js/file-access-to-http`** (5): #27 #28 #29 #30 #138 — `bn deploy`/`bn env push`/`bn env pull` sending local config to a fixed, hardcoded API host (that's the feature), and a repo-maintenance script looking up this monorepo's own package names against a fixed registry host.

### Note

`main` advanced during this work (a components design-system pass merged, among other things) and CodeQL opened a new alert (#140, `packages/server/src/render.js`, unrelated to anything above) after this PR's scope was captured. That alert is out of scope here — this PR is scoped to the 68 alerts open at the start of the session.

## Test plan

- [x] `node --test` green in every touched package: `notify` 44/44 (was 42, +2 for `raw()`), `cli` 33/33, `claude-config` 0/0 (no tests), `doppler` 23/23, `upload` 51/51, `middleware` 65/65, `i18n` 49/49, `wrangler-preset` 17/17, `favicon` 28/28, `forms` 206/206, `visual-builder` 47/47, `marketplace` 232/232, `runtime` 460/460.
- [x] `eslint` clean across every changed file (one addition to `eslint.config.js`'s ignore list, mirroring the existing entry for `examples/express/public/basenative.js`: esbuild's own `</script>` escaping in the regenerated `builder.js` bundle trips `no-useless-escape`).
- [x] Manually verified `examples/starter`'s static file handler: normal file still serves (200), a `../../../../etc/passwd` traversal attempt now 404s.
- [x] `benchmarks/router.bench.js` and `benchmarks/signal-comparison.bench.js` run end-to-end after edits.
- [x] Changesets (patch) added for every published package touched: `notify`, `cli`, `claude-config`, `doppler`, `upload`, `middleware`, `i18n`, `wrangler-preset`, `favicon`, `runtime`, `marketplace`, `forms`, `visual-builder`. `share` needed no change (already fixed on `main`); examples/benchmarks are all `private: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)