### PR TITLE
fix(server): keep static attribute values inside their quotes

### DIFF
--- a/.changeset/server-static-attr-quotes.md
+++ b/.changeset/server-static-attr-quotes.md
@@ -1,0 +1,5 @@
+---
+"@basenative/server": patch
+---
+
+Static attribute values in a template are re-emitted inside double quotes; a single-quoted value containing `"` could previously break out of them. Bare double quotes in static values are now written as `&quot;` (existing entities are left intact).

--- a/packages/server/src/render.js
+++ b/packages/server/src/render.js
@@ -159,7 +159,11 @@ function processNode(node, ctx, options) {
         continue;
       }
 
-      attrs.push({ name, value });
+      // Static attribute text is the template author's own markup, but the parser
+      // hands it back unquoted: a single-quoted value containing `"` would break
+      // out of the double quotes we re-emit. Neutralise bare quotes only — the
+      // value may legitimately contain entities already, so no full re-escape.
+      attrs.push({ name, value: value ? value.replace(/"/g, '&quot;') : value });
     }
 
     node.rawAttrs = attrs

--- a/packages/server/src/render.test.js
+++ b/packages/server/src/render.test.js
@@ -276,6 +276,17 @@ describe('render — additional edge cases', () => {
     assert.match(html, /data-name="test"/);
   });
 
+  it('static single-quoted attribute values cannot break out of the re-emitted double quotes', () => {
+    const html = render(`<a title='say "hi" onmouseover="alert(1)'>x</a>`, {});
+    assert.match(html, /title="say &quot;hi&quot; onmouseover=&quot;alert\(1\)"/);
+    assert.doesNotMatch(html, /onmouseover="/);
+  });
+
+  it('static attribute values keep existing entities intact', () => {
+    const html = render('<a title="a &amp; b &quot;c&quot;">x</a>', {});
+    assert.match(html, /title="a &amp; b &quot;c&quot;"/);
+  });
+
   it(':data-x dynamic data attribute', () => {
     const html = render('<span :data-value="val">', { val: 'hello' });
     assert.match(html, /data-value="hello"/);


### PR DESCRIPTION
## Why

CodeQL alert 140 (`js/incomplete-html-attribute-sanitization`, `packages/server/src/render.js`): `render()` re-serialises every attribute as `name="value"`, but static values come back from the parser unquoted, so a single-quoted template attribute such as `title='say "hi" onmouseover="alert(1)'` was re-emitted with its inner `"` intact and could break out of the attribute.

## What

Static attribute values have bare `"` written as `&quot;`; existing entities are not re-escaped (so `&amp;` stays `&amp;`). Dynamic (`:attr`) and interpolated values were already escaped through the shared `escapeAttr`.

Tests: two new cases (break-out attempt is neutralised; existing entities intact). Changeset: patch for `@basenative/server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)