### PR TITLE
fix(components): align calendar rows, accordion marker, mobile nav fade

### DIFF
--- a/.changeset/components-calendar-accordion.md
+++ b/.changeset/components-calendar-accordion.md
@@ -1,0 +1,9 @@
+---
+"@basenative/components": patch
+---
+
+Fix three visual defects surfaced by a screenshot QA pass of the showcase site:
+
+- Calendar: the hour-gutter labels used `grid-row: h - hourStart + 1` while the time slots and events used `+ 2`, so a label sat one row above the slot/event it described (an 11:00–12:00 event could visually appear to span the 12pm–2pm rows). Labels now use the same `+ 2` convention. Calendar events also get `overflow: hidden`, `min-height: 0`, and `align-self: stretch` so a card's content can never grow its grid row, and `calendar-event-title` is clamped to 2 lines with an ellipsis.
+- Accordion: `[data-bn="accordion-header"]` centred its `::before` disclosure triangle against the full header block, so a two-line summary put the marker between the lines instead of next to the first one. `align-items` is now `flex-start` with a small `margin-top` offset on the marker that keeps single-line headers pixel-identical.
+- Mobile nav: the horizontally-scrolling header `menu` had no scroll affordance and could clip an item mid-glyph at the viewport edge. Added a sticky right-edge fade (progressively faded out near the end of scroll via `animation-timeline: scroll()` behind `@supports`, a constant fade otherwise) plus `padding-inline-end`/`scroll-padding-inline-end` so the last item clears the fade.

--- a/examples/express/views/layout.html
+++ b/examples/express/views/layout.html
@@ -96,20 +96,59 @@
     text-decoration: none;
   }
   body > [data-bn-site-header] menu {
+    --bn-nav-fade-w: 2rem;
     list-style: none;
     display: flex;
     gap: var(--space-md, 1rem);
     margin: 0;
     padding: 0;
+    padding-inline-end: var(--bn-nav-fade-w);
     flex-wrap: nowrap;
     overflow-x: auto;
     scroll-snap-type: x mandatory;
+    scroll-padding-inline-end: var(--bn-nav-fade-w);
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
     min-inline-size: 0;
     max-inline-size: 100%;
   }
   body > [data-bn-site-header] menu::-webkit-scrollbar { display: none; }
+  /* Right-edge scroll affordance: a sticky pseudo-element pinned to the
+     visible edge of the scrollport (not the scrolled content), so it stays
+     in place while the menu scrolls under it. inset-inline-end is negative
+     by the container's own trailing padding — Chromium resolves a sticky
+     offset against the content edge, so without this the fade rests one
+     padding-width short of the edge it needs to cover. The margin cancels
+     the flex gap plus the fade's own width so it adds no extra scroll
+     distance of its own. Base opacity is a constant fade for browsers
+     without scroll-driven animations; the @supports block below fades it
+     out once scrolled to the end, and it never appears at all when the
+     menu doesn't overflow. */
+  body > [data-bn-site-header] menu::after {
+    content: '';
+    position: sticky;
+    inset-inline-end: calc(-1 * var(--bn-nav-fade-w));
+    align-self: stretch;
+    flex: 0 0 var(--bn-nav-fade-w);
+    margin-inline-start: calc(-1 * (var(--bn-nav-fade-w) + var(--space-md, 1rem)));
+    background: linear-gradient(to right, transparent, var(--surface-1, #151310));
+    pointer-events: none;
+    opacity: 1;
+  }
+  @supports (animation-timeline: scroll()) {
+    body > [data-bn-site-header] menu {
+      scroll-timeline: --bn-nav-scroll inline;
+    }
+    body > [data-bn-site-header] menu::after {
+      opacity: 0;
+      animation: bn-nav-fade linear both;
+      animation-timeline: --bn-nav-scroll;
+    }
+    @keyframes bn-nav-fade {
+      0%, 80% { opacity: 1; }
+      100% { opacity: 0; }
+    }
+  }
   body > [data-bn-site-header] menu li {
     list-style: none;
     scroll-snap-align: start;

--- a/packages/components/src/calendar.js
+++ b/packages/components/src/calendar.js
@@ -114,12 +114,16 @@ export function renderCalendar(options = {}) {
     `<div data-bn="calendar-day-header" data-date="${d}">${formatDay(d)}</div>`
   ).join('');
 
-  // Time gutter labels
+  // Time gutter labels. Row 1 of the grid is the day-header row (see
+  // `grid-template-rows: auto repeat(...)` in components.css), so hour rows
+  // start at row 2 — the same convention used by the slots and events below.
+  // Labels must share that convention or they land one row above the
+  // slot/event they describe.
   const timeLabels = [];
   for (let h = hourStart; h < hourEnd; h++) {
     const label = h <= 12 ? `${h}am` : `${h - 12}pm`;
     timeLabels.push(
-      `<div data-bn="calendar-time-label" data-hour="${h}" style="grid-row: ${h - hourStart + 1}">${h === 12 ? '12pm' : label}</div>`
+      `<div data-bn="calendar-time-label" data-hour="${h}" style="grid-row: ${h - hourStart + 2}">${h === 12 ? '12pm' : label}</div>`
     );
   }
 

--- a/packages/components/src/components.css
+++ b/packages/components/src/components.css
@@ -482,7 +482,7 @@
 [data-bn="accordion-item"]:only-child { border-radius: var(--bn-radius-container); }
 [data-bn="accordion-header"] {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--bn-space-2);
   padding: var(--bn-space-component-y) var(--bn-space-component-x);
   font-size: var(--bn-font-size-component);
@@ -501,6 +501,14 @@
   color: var(--bn-color-accent-600);
   transition: rotate var(--bn-transition-fast);
   flex-shrink: 0;
+  /* align-items is flex-start so multi-line summaries don't centre the
+     marker against the whole block; this offset re-centres it against the
+     first line only. Derived from the header's line-height (normal, 1.5)
+     and this marker's own font-size (0.75em of the header's): the gap
+     between the first line's box and this marker's own (smaller) box is
+     line-height / 6 of the marker's font-size — 0.25em at the current
+     tokens. A single-line header renders identically to before. */
+  margin-top: 0.25em;
 }
 [data-bn="accordion-header"]::-webkit-details-marker { display: none; }
 [data-bn="accordion-item"][open] > [data-bn="accordion-header"]::before { rotate: 90deg; }
@@ -1340,6 +1348,7 @@
 [data-bn="calendar-event"] {
   position: absolute;
   inset-inline: var(--bn-space-1);
+  inset-block: var(--bn-space-half);
   display: flex;
   flex-direction: column;
   gap: var(--bn-space-half);
@@ -1351,6 +1360,8 @@
   color: var(--bn-color-text);
   cursor: grab;
   overflow: hidden;
+  min-height: 0;
+  align-self: stretch;
   z-index: 1;
 }
 [data-bn="calendar-event"][data-dragging] { opacity: 0.5; cursor: grabbing; }
@@ -1371,10 +1382,17 @@
   overflow-wrap: anywhere;
   word-break: break-word;
   line-height: var(--bn-line-height-tight);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 [data-bn="calendar-event-assignee"],
 [data-bn="calendar-event-time"] {
   color: var(--bn-color-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Pipeline block (draggable card for sidebar dispatch) */

--- a/packages/components/src/components.test.js
+++ b/packages/components/src/components.test.js
@@ -732,6 +732,25 @@ describe('Calendar', () => {
     const html = renderCalendar({ startDate: '2025-06-02' });
     assert.ok(html.includes('data-bn="calendar-slot"'));
   });
+
+  it('aligns the hour label, slot, and event to the same grid row', () => {
+    const html = renderCalendar({
+      startDate: '2025-06-02',
+      hours: { start: 9, end: 17 },
+      events: [{ id: 'ev', title: 'Office hours', start: '2025-06-02T11:00', end: '2025-06-02T12:00' }],
+    });
+
+    const labelMatch = html.match(/data-bn="calendar-time-label" data-hour="11" style="grid-row: (\d+)"/);
+    const slotMatch = html.match(/data-bn="calendar-slot" data-date="2025-06-02" data-hour="11" style="grid-row: (\d+)"/);
+    const eventMatch = html.match(/data-event-id="ev"[^>]*style="grid-row: (\d+) \/ span/);
+
+    assert.ok(labelMatch, 'expected an 11 AM time label');
+    assert.ok(slotMatch, 'expected an 11 AM slot');
+    assert.ok(eventMatch, 'expected the 11:00-12:00 event');
+
+    assert.equal(labelMatch[1], slotMatch[1], 'label and slot should share a grid row');
+    assert.equal(labelMatch[1], eventMatch[1], 'label and event should share a grid row');
+  });
 });
 
 describe('PipelineBlock', () => {


### PR DESCRIPTION
## Summary

A screenshot QA pass of the live basenative.com showcase (post components design-system pass, DuganLabs/BaseNative main at `7c7e4e1` or later) found three visual defects. This PR fixes all three:

- **Calendar (HIGH) — misaligned week rows.** In `packages/components/src/calendar.js`, hour-gutter labels were placed with `grid-row: h - hourStart + 1` while the day-header row occupies grid row 1 and time slots/events use `+ 2`. That off-by-one put each label one row above the slot/event it names — visually, an 11:00–12:00 event appeared to span the 12pm–2pm rows. Labels now use the same `+2` convention as slots/events. `[data-bn="calendar-event"]` also gains `overflow: hidden`, `min-height: 0`, and `align-self: stretch` (plus `inset-block`), and `calendar-event-title` is clamped to 2 lines with an ellipsis, so a card's content can never grow past its own grid row. Added a `node:test` assertion (`components.test.js`) that an 11:00–12:00 event on a 9–17 hour grid shares its `grid-row` start with the 11 AM slot and label.
- **Accordion (MEDIUM) — disclosure marker off-center on wrap.** `[data-bn="accordion-header"]` used `align-items: center`, which centered the `::before` triangle against the *whole* header block — on a two-line summary the marker landed between the lines instead of beside the first one. Changed to `align-items: flex-start` with a small `margin-top` on the marker (derived from the header's line-height and the marker's own font-size) that keeps single-line headers pixel-identical to before.
- **Mobile nav (LOW) — no scroll affordance.** The site header's `menu` scrolls horizontally with the scrollbar hidden, so items clipped mid-glyph at the viewport edge (e.g. "Builder" → "B") with no hint that more content was reachable. Added a `position: sticky` right-edge fade pseudo-element pinned to the scrollport, driven by `animation-timeline: scroll()` behind `@supports` so it progressively disappears near the end of scroll (falls back to a constant fade otherwise, and never renders at all when the menu doesn't overflow); plus `padding-inline-end` / `scroll-padding-inline-end` so the last item always clears the fade. No JS, no structural/copy changes to the nav.

## Before / after (crops, not committed — see verification below)

Evidence crops were captured from the live site and from a local rebuild of `dist/` served over `python3 -m http.server`, using the same Playwright/chromium setup as the original QA pass (extracted `libnspr4`/`libnss3`/`libasound2t64` via `LD_LIBRARY_PATH`).

- **Calendar** — before: a 1-hour event ("Office hours", 11:00 AM–12:00 PM) visually spanned two hour-rows, starting at the 12pm gridline instead of 11am. After: every event starts flush with its own hour's gridline and the label beside it; a 2-line event title ("Customer call: …") now truncates instead of pushing into the next row.
- **Accordion** — before: the ▸ marker on the two-line "What about hydration?" header sat vertically centered between the two lines. After: the marker aligns with the top ("What about") line; single-line headers ("What is BaseNative?", "How does SSR work?") are visually unchanged.
- **Mobile nav** — before: the header link list clipped "Builder" to a bare "B" at the 390px viewport edge with a hard, affordance-free cutoff. After: a gradient fade covers the clipped edge (verified via pixel sampling — the glyph blends toward the header background instead of a hard cutoff), and the fade opacity animates to 0 once the list is scrolled to its end (verified via `getComputedStyle(...).opacity`), leaving the last item ("Roadmap") fully visible with breathing room.

## Test plan

- [x] `node --test` in `packages/components`: 305/305 passing (304 pre-existing + 1 new alignment assertion; note PR #162, in flight separately, touches `tooltip.js`/`tree.js`/`datagrid.js`/`internal/tree.js` and will raise this to 310 — not touched here)
- [x] `npx nx run @basenative/components:lint`: clean
- [x] Rebuilt the static site (`node scripts/build-pages.js` from `examples/express`), served `dist/` locally, and re-screenshotted all three defect areas plus a full-page dark 1440×900 showcase capture to confirm each fix visually; `dist/` was deleted afterward and is not part of this PR
- [x] Confirmed no drift in `llms.txt`/`llms-full.txt` (regenerated via `scripts/llms-txt.js`; no diff, since no public API doc text changed)
- [x] Added `.changeset/components-calendar-accordion.md` (patch, `@basenative/components`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)