### PR TITLE
Runtime type coverage + opt-in router navigation guards

### DIFF
--- a/.changeset/router-navigation-guards.md
+++ b/.changeset/router-navigation-guards.md
@@ -1,0 +1,5 @@
+---
+"@basenative/router": minor
+---
+
+Added navigation guards as an opt-in wrapper around `createRouter()`: `withGuards(router)` returns a router whose `navigate()` returns `Promise<boolean>` and adds `beforeEach(guard)` / `afterEach(handler)`. A guard can abort navigation (return `false`), redirect it (return a path string, `{ redirect, replace? }`, or throw via the new `redirect(to, replace?)` helper / `RedirectError`), or let it proceed. Guards run sequentially against a preview of the destination route and stop at the first abort; starting a new navigation aborts one still running guards. Available from the package root and from the new `@basenative/router/guards` subpath, both typed. `createRouter()`'s own return value is unchanged.

--- a/.changeset/runtime-types-public-surface.md
+++ b/.changeset/runtime-types-public-surface.md
@@ -1,0 +1,5 @@
+---
+"@basenative/runtime": patch
+---
+
+`types/index.d.ts` declared only 27 of the package's 47 runtime exports — `raw`, `batch`, `registerPlugin`, the error boundary, devtools, and debug-mode APIs had no type declarations at all, forcing consumers to hand-write module augmentation to use them from TypeScript. Added the missing declarations, and added `types` conditions to the `./shared/expression`, `./shared/escape`, and `./shared/directives` subpath exports (each backed by its own `.d.ts`, previously untyped). A new `types/exports.test.js` guards the package root and each subpath against future drift between declared and actual exports.

--- a/docs/api/router.md
+++ b/docs/api/router.md
@@ -57,3 +57,44 @@ const cleanup = interceptLinks(document.body, router);
 - `matchRoute(pattern, pathname)` — Match a URL against a pattern
 - `parseQuery(search)` — Parse query string to object
 - `buildQuery(params)` — Build query string from object
+
+## Navigation Guards — `@basenative/router/guards`
+
+Opt-in wrapper around a router instance; `createRouter()` itself is unchanged. Also re-exported from the package root.
+
+```js
+import { createRouter } from '@basenative/router';
+import { withGuards, redirect } from '@basenative/router/guards';
+
+const router = withGuards(createRouter(routes));
+
+router.beforeEach(({ to }) => {
+  if (to.name === 'dashboard' && !isAuthenticated()) return redirect('/login');
+});
+
+router.afterEach(({ to }) => {
+  document.title = to.matched?.title ?? 'App';
+});
+
+const ok = await router.navigate('/dashboard'); // Promise<boolean>
+```
+
+### `withGuards(router)`
+
+Returns a `GuardedRouter`: the same `pathname` / `query` / `currentRoute` / `back()` / `forward()` / `routes` as the wrapped router, plus:
+
+| Method | Description |
+|---|---|
+| `navigate(to, options?)` | Same as the wrapped router's, but returns `Promise<boolean>` — `true` once navigation and every `afterEach` handler have run, `false` if a guard aborted or redirected it. |
+| `beforeEach(guard)` | Registers a guard, run in registration order against a preview of the destination before the URL changes. Returns a disposer. |
+| `afterEach(handler)` | Registers a handler invoked with `{ to, from, options }` once navigation commits. Returns a disposer. |
+
+A `beforeEach` guard receives `{ to, from, options }` and may return `undefined` (proceed), `false` (abort), a path string or `{ redirect, replace? }` (abort + redirect), or throw `redirect(to, replace?)` for the same. Any other thrown error propagates and rejects the `navigate()` call instead of being treated as an abort. Guards run sequentially and stop at the first abort. A new `navigate()` call aborts a still-running previous one, which then resolves `false`.
+
+### `redirect(to, replace = true)`
+
+Throws a `RedirectError`, caught by `withGuards()`'s guard runner and turned into a redirect. Never returns.
+
+### `RedirectError`
+
+The error class thrown by `redirect()`. Has `to: string` and `replace: boolean`.

--- a/docs/package-inventory.md
+++ b/docs/package-inventory.md
@@ -18,46 +18,46 @@ the next changeset bump would collide and be skipped — realign the local versi
 | `@basenative/admin` | 1.0.0 | 1.0.0 | — | in sync |
 | `@basenative/auth` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
 | `@basenative/auth-webauthn` | 1.0.3 | 1.0.3 | — | in sync |
-| `@basenative/builder` | 0.1.3 | 0.1.2 | — | unreleased bump |
-| `@basenative/claude-config` | 0.2.1 | 0.2.0 | — | unreleased bump |
-| `@basenative/cli` | 0.4.1 | 0.4.0 | 0.2.0 | unreleased bump |
-| `@basenative/combobox` | 1.0.3 | 1.0.2 | — | unreleased bump |
-| `@basenative/components` | 0.6.1 | 0.6.0 | 0.3.0 | unreleased bump |
+| `@basenative/builder` | 0.1.3 | 0.1.3 | — | in sync |
+| `@basenative/claude-config` | 0.2.1 | 0.2.1 | — | in sync |
+| `@basenative/cli` | 0.4.1 | 0.4.1 | 0.2.0 | in sync |
+| `@basenative/combobox` | 1.0.3 | 1.0.3 | — | in sync |
+| `@basenative/components` | 0.6.1 | 0.6.1 | 0.3.0 | in sync |
 | `@basenative/config` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
 | `@basenative/date` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
 | `@basenative/db` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
-| `@basenative/doppler` | 0.2.1 | 0.2.0 | — | unreleased bump |
+| `@basenative/doppler` | 0.2.1 | 0.2.1 | — | in sync |
 | `@basenative/eslint-config` | 0.2.0 | 0.2.0 | — | in sync |
 | `@basenative/evals` | 0.1.0 | — | — | private |
-| `@basenative/favicon` | 1.0.2 | 1.0.1 | — | unreleased bump |
-| `@basenative/fetch` | 0.3.3 | 0.3.2 | 0.2.0 | unreleased bump |
+| `@basenative/favicon` | 1.0.2 | 1.0.2 | — | in sync |
+| `@basenative/fetch` | 0.3.3 | 0.3.3 | 0.2.0 | in sync |
 | `@basenative/flags` | 0.4.0 | 0.4.0 | 0.2.0 | in sync |
 | `@basenative/fonts` | 0.1.0 | — | — | private |
-| `@basenative/forms` | 1.0.2 | 1.0.1 | 0.3.0 | unreleased bump |
-| `@basenative/i18n` | 0.4.1 | 0.4.0 | 0.2.0 | unreleased bump |
+| `@basenative/forms` | 1.0.2 | 1.0.2 | 0.3.0 | in sync |
+| `@basenative/i18n` | 0.4.1 | 0.4.1 | 0.2.0 | in sync |
 | `@basenative/icons` | 0.1.0 | — | — | private |
 | `@basenative/integrations` | 0.1.0 | 0.1.0 | — | in sync |
-| `@basenative/keyboard` | 1.0.4 | 1.0.3 | — | unreleased bump |
+| `@basenative/keyboard` | 1.0.4 | 1.0.4 | — | in sync |
 | `@basenative/logger` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
 | `@basenative/markdown` | 0.1.0 | 0.1.0 | — | in sync |
-| `@basenative/marketplace` | 0.2.1 | 0.2.0 | 0.2.0 | unreleased bump |
+| `@basenative/marketplace` | 0.2.1 | 0.2.1 | 0.2.0 | in sync |
 | `@basenative/mcp` | 0.2.0 | 0.2.0 | — | in sync |
-| `@basenative/middleware` | 0.3.1 | 0.3.0 | 0.2.0 | unreleased bump |
-| `@basenative/notify` | 0.3.1 | 0.3.0 | 0.2.0 | unreleased bump |
+| `@basenative/middleware` | 0.3.1 | 0.3.1 | 0.2.0 | in sync |
+| `@basenative/notify` | 0.3.1 | 0.3.1 | 0.2.0 | in sync |
 | `@basenative/og-image` | 0.2.1 | 0.2.1 | — | in sync |
-| `@basenative/persist` | 1.0.3 | 1.0.2 | — | unreleased bump |
+| `@basenative/persist` | 1.0.3 | 1.0.3 | — | in sync |
 | `@basenative/realtime` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
-| `@basenative/router` | 0.4.4 | 0.4.3 | 0.3.0 | unreleased bump |
-| `@basenative/runtime` | 0.6.1 | 0.6.0 | 0.3.0 | unreleased bump |
-| `@basenative/server` | 0.6.1 | 0.6.0 | 0.3.0 | unreleased bump |
+| `@basenative/router` | 0.4.4 | 0.4.4 | 0.3.0 | in sync |
+| `@basenative/runtime` | 0.6.1 | 0.6.1 | 0.3.0 | in sync |
+| `@basenative/server` | 0.6.1 | 0.6.1 | 0.3.0 | in sync |
 | `@basenative/share` | 1.0.1 | 1.0.1 | — | in sync |
 | `@basenative/station` | 0.2.0 | 0.2.0 | — | in sync |
 | `@basenative/tenant` | 0.3.0 | 0.3.0 | 0.2.0 | in sync |
 | `@basenative/tsconfig` | 0.2.0 | 0.2.0 | — | in sync |
-| `@basenative/upload` | 0.3.1 | 0.3.0 | 0.2.0 | unreleased bump |
+| `@basenative/upload` | 0.3.1 | 0.3.1 | 0.2.0 | in sync |
 | `@basenative/validate` | 0.2.0 | 0.2.0 | — | in sync |
-| `@basenative/visual-builder` | 0.2.1 | 0.2.0 | 0.2.0 | unreleased bump |
-| `@basenative/wrangler-preset` | 0.2.1 | 0.2.0 | — | unreleased bump |
+| `@basenative/visual-builder` | 0.2.1 | 0.2.1 | 0.2.0 | in sync |
+| `@basenative/wrangler-preset` | 0.2.1 | 0.2.1 | — | in sync |
 
 ## Summary
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2120,6 +2120,31 @@ Intercepts internal link clicks for client-side navigation.
 const cleanup = interceptLinks(document.body, router);
 ```
 
+### Navigation Guards — `@basenative/router/guards`
+Opt-in wrapper around a router instance; `createRouter()` itself is unchanged. Also re-exported from the package root.
+```js
+import { createRouter } from '@basenative/router';
+import { withGuards, redirect } from '@basenative/router/guards';
+
+const router = withGuards(createRouter(routes));
+
+router.beforeEach(({ to }) => {
+  if (to.name === 'dashboard' && !isAuthenticated()) return redirect('/login');
+});
+
+router.afterEach(({ to }) => {
+…
+```
+
+#### `withGuards(router)`
+Returns a `GuardedRouter`: the same `pathname` / `query` / `currentRoute` / `back()` / `forward()` / `routes` as the wrapped router, plus: | Method | Description | |---|---| | `navigate(to, options?)` | Same as the wrapped router's, but re…
+
+#### `redirect(to, replace = true)`
+Throws a `RedirectError`, caught by `withGuards()`'s guard runner and turned into a redirect. Never returns.
+
+#### `RedirectError`
+The error class thrown by `redirect()`. Has `to: string` and `replace: boolean`.
+
 ### `@basenative/runtime` (v0.6.1)
 
 Signal-based web runtime over native HTML — zero build step, zero production dependencies

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -71,6 +71,55 @@ Parse a query string into an object, or serialize an object into a query string.
 
 Attaches a `click` listener to `document` that intercepts `<a href>` clicks and calls `router.navigate()` instead of triggering a full page load. Respects `target`, `download`, and external links.
 
+## Navigation Guards — `@basenative/router/guards`
+
+Opt-in — `createRouter()` and the router it returns are unaffected unless you wrap it. Import from the `/guards` subpath (also re-exported from the package root):
+
+```js
+import { createRouter } from '@basenative/router';
+import { withGuards, redirect } from '@basenative/router/guards';
+
+const router = withGuards(createRouter(routes));
+
+router.beforeEach(({ to, from }) => {
+  if (to.name === 'dashboard' && !isAuthenticated()) {
+    return redirect('/login'); // or: return '/login'; or: return false;
+  }
+});
+
+router.afterEach(({ to }) => {
+  document.title = to.matched?.title ?? 'App';
+});
+
+const ok = await router.navigate('/dashboard'); // Promise<boolean>
+```
+
+### `withGuards(router)`
+
+Wraps a router instance (from `createRouter()`) and returns a `GuardedRouter` with the same `pathname` / `query` / `currentRoute` / `back()` / `forward()` / `routes`, plus:
+
+- `navigate(to, options?)` — same as the wrapped router's, but returns `Promise<boolean>`: `true` once navigation and all `afterEach` handlers have run, `false` if a guard aborted or redirected it.
+- `beforeEach(guard)` — registers a guard, run in registration order against a preview of the destination route before the URL changes. Returns a disposer that unregisters it.
+- `afterEach(handler)` — registers a handler invoked (with `{ to, from, options }`) once navigation commits. Returns a disposer.
+
+A guard receives `{ to, from, options }` (`to`/`from` are `ResolvedRoute`s; `from` is `null` on the very first navigation) and may return:
+
+- `undefined` / nothing — let navigation proceed.
+- `false` — abort navigation with no redirect.
+- a path string, or `{ redirect, replace? }` — abort and redirect to that path.
+- throw `redirect(to, replace?)` (or a `RedirectError` directly) — same as above, usable from deep inside a guard.
+- throw anything else — propagates and rejects the `navigate()` call; it is not treated as an abort.
+
+Guards run sequentially; the first one that aborts stops the chain — later guards do not run. Starting a new `navigate()` call while a previous one's guards are still running aborts the in-flight call, which then resolves `false`.
+
+### `redirect(to, replace = true)`
+
+Throws a `RedirectError` that `withGuards()`'s guard runner catches and turns into a redirect. Never returns.
+
+### `RedirectError`
+
+The error class `redirect()` throws. Has `to: string` and `replace: boolean` properties; can also be thrown directly with `throw new RedirectError(to, replace)`.
+
 ## License
 
 MIT

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -7,6 +7,10 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
+    },
+    "./guards": {
+      "types": "./types/guards.d.ts",
+      "default": "./src/guards.js"
     }
   },
   "types": "./types/index.d.ts",

--- a/packages/router/src/guards.js
+++ b/packages/router/src/guards.js
@@ -1,0 +1,218 @@
+/**
+ * Navigation guards for `createRouter()`.
+ *
+ * Wraps a router instance so that navigation can be intercepted, redirected, or
+ * aborted before the URL changes. Guards run in registration order against a
+ * preview of the destination route — matched against the router's own compiled
+ * routes, without touching the History API — so an aborted or redirected
+ * navigation never partially applies.
+ *
+ * Opt-in: `createRouter()` and the router it returns are unchanged by importing
+ * this module. Call `withGuards(router)` to get a wrapped router with
+ * `beforeEach()` / `afterEach()` and a `navigate()` that returns
+ * `Promise<boolean>` instead of `void`.
+ *
+ *   import { createRouter } from '@basenative/router';
+ *   import { withGuards, redirect } from '@basenative/router/guards';
+ *
+ *   const router = withGuards(createRouter(routes));
+ *   router.beforeEach(({ to }) => {
+ *     if (to.name === 'dashboard' && !isAuthenticated()) return redirect('/login');
+ *   });
+ *
+ * @module
+ */
+
+/** Thrown by {@link redirect} to short-circuit a guard with a redirect. */
+export class RedirectError extends Error {
+  /**
+   * @param {string} to
+   * @param {boolean} [replace=true]
+   */
+  constructor(to, replace = true) {
+    super(`Navigation redirected to ${to}`);
+    this.name = 'RedirectError';
+    this.to = to;
+    this.replace = replace;
+  }
+}
+
+/**
+ * Aborts the current guard and redirects navigation to `to`. Throws a
+ * {@link RedirectError}, which `withGuards()`'s guard runner catches.
+ *
+ * @param {string} to
+ * @param {boolean} [replace=true]
+ * @returns {never}
+ */
+export function redirect(to, replace = true) {
+  throw new RedirectError(to, replace);
+}
+
+/**
+ * Normalizes a guard's return value into an abort/redirect decision.
+ * `false` aborts with no redirect; a string or `{ redirect }` aborts and
+ * redirects; anything else (including `undefined`) lets navigation proceed.
+ */
+function applyGuardOutcome(outcome) {
+  if (outcome === false) return { abort: true };
+  if (typeof outcome === 'string') {
+    return { abort: true, redirectTo: outcome, replace: true };
+  }
+  if (outcome && typeof outcome === 'object' && 'redirect' in outcome) {
+    return {
+      abort: true,
+      redirectTo: outcome.redirect,
+      replace: outcome.replace ?? true,
+    };
+  }
+  return { abort: false };
+}
+
+function parsePreviewQuery(search) {
+  const out = {};
+  const stripped = search.startsWith('?') ? search.slice(1) : search;
+  if (!stripped) return out;
+  for (const pair of stripped.split('&')) {
+    const [rawKey, rawValue] = pair.split('=');
+    if (!rawKey) continue;
+    out[decodeURIComponent(rawKey)] = rawValue ? decodeURIComponent(rawValue) : '';
+  }
+  return out;
+}
+
+/**
+ * Matches `to` against `router.routes` (the compiled routes createRouter()
+ * already built) without calling `navigate()` or touching history — this is
+ * what lets guards see the destination route before committing to it.
+ */
+function previewMatch(router, to) {
+  const [pathPart, searchPart = ''] = to.split('?');
+  const stripped = pathPart || '/';
+  for (const route of router.routes) {
+    const match = route.compiled.regex.exec(stripped);
+    if (!match) continue;
+    const params = {};
+    for (let i = 0; i < route.compiled.params.length; i++) {
+      params[route.compiled.params[i]] = decodeURIComponent(match[i + 1]);
+    }
+    return {
+      name: route.name ?? route.path,
+      path: route.path,
+      params,
+      query: parsePreviewQuery(searchPart),
+      matched: route,
+    };
+  }
+  return {
+    name: null,
+    path: stripped,
+    params: {},
+    query: parsePreviewQuery(searchPart),
+    matched: null,
+  };
+}
+
+/**
+ * Wraps a router instance (as returned by `createRouter()`) with
+ * `beforeEach()` / `afterEach()` hooks. The wrapped router's `navigate()`
+ * returns `Promise<boolean>`: `true` once navigation and all `afterEach`
+ * handlers have run, `false` if a guard aborted or redirected it.
+ *
+ * Guard order: `beforeEach` guards run sequentially, in registration order,
+ * against a single preview of the destination computed once up front (not
+ * re-matched per guard). The first guard whose outcome aborts — returns
+ * `false`, a path string, `{ redirect }`, or throws a `RedirectError` (via the
+ * `redirect()` helper or directly) — stops the chain immediately; later
+ * guards do not run. A redirect re-enters `navigate()` for the new
+ * destination; the original `navigate()` call still resolves `false`. Any
+ * other thrown error propagates: it rejects the `navigate()` promise rather
+ * than being treated as an abort.
+ *
+ * Starting a new `navigate()` call while guards for a previous one are still
+ * running aborts the in-flight call, whose promise then resolves `false`.
+ *
+ * @param {import('./router.js').Router} router
+ * @returns {GuardedRouter}
+ */
+export function withGuards(router) {
+  const beforeEachGuards = new Set();
+  const afterEachHandlers = new Set();
+  const originalNavigate = router.navigate.bind(router);
+
+  let inFlight = null;
+
+  async function guardedNavigate(to, options = {}) {
+    if (inFlight) inFlight.abort();
+    const controller = new AbortController();
+    inFlight = controller;
+
+    const fromMatch = router.currentRoute();
+    const toMatch = previewMatch(router, to);
+    const context = { to: toMatch, from: fromMatch, options };
+
+    for (const guard of beforeEachGuards) {
+      let outcome;
+      try {
+        outcome = await guard(context);
+      } catch (error) {
+        if (controller.signal.aborted) return false;
+        if (error instanceof RedirectError) {
+          inFlight = null;
+          await guardedNavigate(error.to, { replace: error.replace });
+          return false;
+        }
+        inFlight = null;
+        throw error;
+      }
+      if (controller.signal.aborted) return false;
+      const decision = applyGuardOutcome(outcome);
+      if (decision.abort) {
+        inFlight = null;
+        if (decision.redirectTo) {
+          await guardedNavigate(decision.redirectTo, { replace: decision.replace });
+        }
+        return false;
+      }
+    }
+
+    if (controller.signal.aborted) return false;
+    inFlight = null;
+    originalNavigate(to, options);
+
+    const settled = { to: router.currentRoute(), from: fromMatch, options };
+    for (const handler of afterEachHandlers) {
+      await handler(settled);
+    }
+    return true;
+  }
+
+  /**
+   * Registers a `beforeEach` guard. Returns a function that unregisters it.
+   */
+  function beforeEach(guard) {
+    beforeEachGuards.add(guard);
+    return () => beforeEachGuards.delete(guard);
+  }
+
+  /**
+   * Registers an `afterEach` handler, invoked once navigation succeeds.
+   * Returns a function that unregisters it.
+   */
+  function afterEach(handler) {
+    afterEachHandlers.add(handler);
+    return () => afterEachHandlers.delete(handler);
+  }
+
+  return {
+    pathname: router.pathname,
+    query: router.query,
+    currentRoute: router.currentRoute,
+    routes: router.routes,
+    back: router.back.bind(router),
+    forward: router.forward.bind(router),
+    navigate: guardedNavigate,
+    beforeEach,
+    afterEach,
+  };
+}

--- a/packages/router/src/guards.test.js
+++ b/packages/router/src/guards.test.js
@@ -1,0 +1,259 @@
+/**
+ * Ported from GreenPut's libs/basenative/router-guards/src/guards.spec.ts
+ * (vitest + jsdom) to node:test. Every assertion from that suite is kept;
+ * only the test/mock/DOM APIs differ.
+ *
+ * createRouter()/withGuards() read the `location`/`history`/`window` globals,
+ * which don't exist under plain node:test, so each test gets a fresh
+ * happy-dom Window installed as those globals (mirroring the pattern already
+ * used in packages/runtime/src/hydrate.test.js).
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { Window } from 'happy-dom';
+import { createRouter } from './router.js';
+import { withGuards, redirect, RedirectError } from './guards.js';
+
+let window;
+
+beforeEach(() => {
+  window = new Window({ url: 'http://localhost/' });
+  globalThis.window = window;
+  globalThis.history = window.history;
+  globalThis.location = window.location;
+});
+
+afterEach(() => {
+  delete globalThis.window;
+  delete globalThis.history;
+  delete globalThis.location;
+});
+
+function freshRouter() {
+  history.replaceState(null, '', '/');
+  const base = createRouter([
+    { path: '/', name: 'home' },
+    { path: '/dashboard', name: 'dashboard' },
+    { path: '/login', name: 'login' },
+    { path: '/leads/:id', name: 'lead-detail' },
+  ]);
+  return withGuards(base);
+}
+
+describe('withGuards', () => {
+  let router;
+
+  beforeEach(() => {
+    router = freshRouter();
+  });
+
+  it('navigates without guards', async () => {
+    const ok = await router.navigate('/dashboard');
+    assert.equal(ok, true);
+    assert.equal(router.pathname(), '/dashboard');
+    assert.equal(router.currentRoute().name, 'dashboard');
+  });
+
+  it('passes from/to context to beforeEach guards', async () => {
+    const seen = [];
+    router.beforeEach((ctx) => {
+      seen.push({ from: ctx.from?.path ?? null, to: ctx.to.path });
+    });
+
+    await router.navigate('/dashboard');
+    await router.navigate('/leads/abc');
+
+    assert.deepEqual(seen, [
+      { from: '/', to: '/dashboard' },
+      { from: '/dashboard', to: '/leads/:id' },
+    ]);
+  });
+
+  it('extracts route params for the destination preview', async (t) => {
+    const guard = t.mock.fn(() => undefined);
+    router.beforeEach(guard);
+
+    await router.navigate('/leads/lead-42?source=dashboard');
+
+    assert.equal(guard.mock.callCount(), 1);
+    const ctx = guard.mock.calls[0].arguments[0];
+    assert.deepEqual(ctx.to.params, { id: 'lead-42' });
+    assert.deepEqual(ctx.to.query, { source: 'dashboard' });
+  });
+
+  it('aborts navigation when a guard returns false', async () => {
+    router.beforeEach(() => false);
+    const ok = await router.navigate('/dashboard');
+    assert.equal(ok, false);
+    assert.equal(router.pathname(), '/');
+  });
+
+  it('redirects when a guard returns a string', async () => {
+    router.beforeEach((ctx) => (ctx.to.path === '/dashboard' ? '/login' : undefined));
+
+    const ok = await router.navigate('/dashboard');
+
+    assert.equal(ok, false);
+    assert.equal(router.pathname(), '/login');
+  });
+
+  it('redirects when a guard returns { redirect }', async () => {
+    router.beforeEach((ctx) =>
+      ctx.to.path === '/dashboard' ? { redirect: '/login', replace: false } : undefined,
+    );
+
+    await router.navigate('/dashboard');
+    assert.equal(router.pathname(), '/login');
+  });
+
+  it('redirects when a guard throws RedirectError via redirect() helper', async () => {
+    router.beforeEach((ctx) => {
+      if (ctx.to.path === '/dashboard') redirect('/login');
+    });
+
+    const ok = await router.navigate('/dashboard');
+    assert.equal(ok, false);
+    assert.equal(router.pathname(), '/login');
+  });
+
+  it('rethrows non-RedirectError exceptions from guards', async () => {
+    router.beforeEach(() => {
+      throw new Error('boom');
+    });
+
+    await assert.rejects(() => router.navigate('/dashboard'), /boom/);
+    assert.equal(router.pathname(), '/');
+  });
+
+  it('runs guards sequentially and stops at the first abort', async () => {
+    const calls = [];
+    router.beforeEach(async () => {
+      calls.push('first');
+    });
+    router.beforeEach(() => {
+      calls.push('second');
+      return false;
+    });
+    router.beforeEach(() => {
+      calls.push('third');
+    });
+
+    await router.navigate('/dashboard');
+    assert.deepEqual(calls, ['first', 'second']);
+  });
+
+  it('invokes afterEach handlers after successful navigation', async (t) => {
+    const handler = t.mock.fn();
+    router.afterEach(handler);
+
+    await router.navigate('/dashboard');
+
+    assert.equal(handler.mock.callCount(), 1);
+    const ctx = handler.mock.calls[0].arguments[0];
+    assert.equal(ctx.to.name, 'dashboard');
+    assert.equal(ctx.from?.name, 'home');
+  });
+
+  it('does not invoke afterEach when navigation is aborted', async (t) => {
+    const handler = t.mock.fn();
+    router.beforeEach(() => false);
+    router.afterEach(handler);
+
+    await router.navigate('/dashboard');
+
+    assert.equal(handler.mock.callCount(), 0);
+  });
+
+  it('returns disposers that unregister hooks', async (t) => {
+    const guard = t.mock.fn();
+    const dispose = router.beforeEach(guard);
+
+    await router.navigate('/dashboard');
+    assert.equal(guard.mock.callCount(), 1);
+
+    dispose();
+    await router.navigate('/');
+    assert.equal(guard.mock.callCount(), 1);
+  });
+
+  it('returns disposers for afterEach', async (t) => {
+    const handler = t.mock.fn();
+    const dispose = router.afterEach(handler);
+
+    await router.navigate('/dashboard');
+    assert.equal(handler.mock.callCount(), 1);
+
+    dispose();
+    await router.navigate('/');
+    assert.equal(handler.mock.callCount(), 1);
+  });
+
+  it('aborts an in-flight navigation when a new one starts', async () => {
+    const releases = [];
+    router.beforeEach(
+      () =>
+        new Promise((resolve) => {
+          releases.push(resolve);
+        }),
+    );
+
+    const first = router.navigate('/dashboard');
+    const second = router.navigate('/login');
+    // Resolve in reverse so the second navigation finishes first.
+    releases[1]();
+    releases[0]();
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    assert.equal(firstResult, false);
+    assert.equal(secondResult, true);
+    assert.equal(router.pathname(), '/login');
+  });
+
+  it('replace flag from RedirectError reaches history', async (t) => {
+    const replaceSpy = t.mock.method(history, 'replaceState');
+    const pushSpy = t.mock.method(history, 'pushState');
+
+    router.beforeEach((ctx) => {
+      if (ctx.to.path === '/dashboard') throw new RedirectError('/login', true);
+    });
+
+    await router.navigate('/dashboard');
+
+    assert.ok(replaceSpy.mock.callCount() > 0);
+    assert.ok(pushSpy.mock.callCount() >= 0);
+  });
+
+  it('exposes router signals untouched', () => {
+    assert.equal(typeof router.pathname, 'function');
+    assert.equal(typeof router.currentRoute, 'function');
+    assert.equal(typeof router.query, 'function');
+  });
+});
+
+describe('redirect()', () => {
+  it('throws a RedirectError', () => {
+    assert.throws(() => redirect('/somewhere'), RedirectError);
+  });
+
+  it('preserves the destination path', () => {
+    assert.throws(
+      () => redirect('/login', false),
+      (error) => {
+        assert.ok(error instanceof RedirectError);
+        assert.equal(error.to, '/login');
+        assert.equal(error.replace, false);
+        return true;
+      },
+    );
+  });
+
+  it('defaults replace to true', () => {
+    assert.throws(
+      () => redirect('/x'),
+      (error) => {
+        assert.equal(error.replace, true);
+        return true;
+      },
+    );
+  });
+});

--- a/packages/router/src/index.js
+++ b/packages/router/src/index.js
@@ -1,3 +1,4 @@
 export { createRouter, resolveRoute } from './router.js';
 export { compilePattern, matchRoute, parseQuery, buildQuery } from './match.js';
 export { interceptLinks } from './link.js';
+export { withGuards, redirect, RedirectError } from './guards.js';

--- a/packages/router/types/guards.d.ts
+++ b/packages/router/types/guards.d.ts
@@ -1,0 +1,54 @@
+import type { ResolvedRoute, Router } from './index.js';
+
+/** Mirrors the inline `options` type of `Router.navigate()`. */
+export interface NavigateOptions {
+  replace?: boolean;
+}
+
+export interface NavigationContext {
+  readonly to: ResolvedRoute;
+  readonly from: ResolvedRoute | null;
+  readonly options: NavigateOptions;
+}
+
+export type GuardOutcome =
+  | void
+  | undefined
+  | boolean
+  | string
+  | { readonly redirect: string; readonly replace?: boolean };
+
+export type NavigationGuard = (
+  context: NavigationContext,
+) => GuardOutcome | Promise<GuardOutcome>;
+
+export type AfterNavigationHandler = (
+  context: NavigationContext,
+) => void | Promise<void>;
+
+/** Thrown by {@link redirect} to short-circuit a guard with a redirect. */
+export class RedirectError extends Error {
+  readonly to: string;
+  readonly replace: boolean;
+  constructor(to: string, replace?: boolean);
+}
+
+/**
+ * Aborts the current guard and redirects navigation to `to`. Throws a
+ * {@link RedirectError}.
+ */
+export function redirect(to: string, replace?: boolean): never;
+
+export interface GuardedRouter extends Omit<Router, 'navigate'> {
+  navigate(to: string, options?: NavigateOptions): Promise<boolean>;
+  /** Registers a `beforeEach` guard. Returns a function that unregisters it. */
+  beforeEach(guard: NavigationGuard): () => void;
+  /** Registers an `afterEach` handler. Returns a function that unregisters it. */
+  afterEach(handler: AfterNavigationHandler): () => void;
+}
+
+/**
+ * Wraps a router instance with `beforeEach()` / `afterEach()` hooks. See the
+ * `@basenative/router/guards` module doc for guard order and redirect semantics.
+ */
+export function withGuards(router: Router): GuardedRouter;

--- a/packages/router/types/index.d.ts
+++ b/packages/router/types/index.d.ts
@@ -48,3 +48,61 @@ export function interceptLinks(
   router: Router,
   options?: { selector?: string },
 ): () => void;
+
+// --- Navigation Guards ---
+// Also available (and re-declared here since the main entry re-exports them
+// too) as the `@basenative/router/guards` subpath — see types/guards.d.ts.
+
+/** Mirrors the inline `options` type of `Router.navigate()`. */
+export interface NavigateOptions {
+  replace?: boolean;
+}
+
+export interface NavigationContext {
+  readonly to: ResolvedRoute;
+  readonly from: ResolvedRoute | null;
+  readonly options: NavigateOptions;
+}
+
+export type GuardOutcome =
+  | void
+  | undefined
+  | boolean
+  | string
+  | { readonly redirect: string; readonly replace?: boolean };
+
+export type NavigationGuard = (
+  context: NavigationContext,
+) => GuardOutcome | Promise<GuardOutcome>;
+
+export type AfterNavigationHandler = (
+  context: NavigationContext,
+) => void | Promise<void>;
+
+/** Thrown by {@link redirect} to short-circuit a guard with a redirect. */
+export class RedirectError extends Error {
+  readonly to: string;
+  readonly replace: boolean;
+  constructor(to: string, replace?: boolean);
+}
+
+/**
+ * Aborts the current guard and redirects navigation to `to`. Throws a
+ * {@link RedirectError}.
+ */
+export function redirect(to: string, replace?: boolean): never;
+
+export interface GuardedRouter extends Omit<Router, 'navigate'> {
+  navigate(to: string, options?: NavigateOptions): Promise<boolean>;
+  /** Registers a `beforeEach` guard. Returns a function that unregisters it. */
+  beforeEach(guard: NavigationGuard): () => void;
+  /** Registers an `afterEach` handler. Returns a function that unregisters it. */
+  afterEach(handler: AfterNavigationHandler): () => void;
+}
+
+/**
+ * Wraps a router instance with `beforeEach()` / `afterEach()` hooks so that
+ * navigation can be intercepted, redirected, or aborted before the URL
+ * changes. Opt-in: `createRouter()`'s own return value is unaffected.
+ */
+export function withGuards(router: Router): GuardedRouter;

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -9,12 +9,15 @@
       "default": "./src/index.js"
     },
     "./shared/expression": {
+      "types": "./types/shared/expression.d.ts",
       "default": "./src/shared/expression.js"
     },
     "./shared/escape": {
+      "types": "./types/shared/escape.d.ts",
       "default": "./src/shared/escape.js"
     },
     "./shared/directives": {
+      "types": "./types/shared/directives.d.ts",
       "default": "./src/shared/directives.js"
     }
   },

--- a/packages/runtime/types/exports.test.js
+++ b/packages/runtime/types/exports.test.js
@@ -1,0 +1,58 @@
+/**
+ * Guards types/index.d.ts (and each subpath's own .d.ts) against drifting from
+ * the actual module exports: every runtime export must have a declaration, and
+ * no declaration may name a symbol the module does not export. Modelled on
+ * packages/components/types/exports.test.js.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import * as runtime from '../src/index.js';
+import * as escape from '../src/shared/escape.js';
+import * as expression from '../src/shared/expression.js';
+import * as directives from '../src/shared/directives.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function declaredNames(relativeDtsPath) {
+  const dts = readFileSync(join(here, relativeDtsPath), 'utf8');
+  const names = new Set();
+  for (const m of dts.matchAll(/^export\s+(?:declare\s+)?(?:function|const|class)\s+([A-Za-z0-9_$]+)/gm)) {
+    names.add(m[1]);
+  }
+  return names;
+}
+
+const modules = [
+  { label: 'index.d.ts', dts: 'index.d.ts', moduleExports: runtime },
+  { label: 'shared/escape.d.ts', dts: 'shared/escape.d.ts', moduleExports: escape },
+  { label: 'shared/expression.d.ts', dts: 'shared/expression.d.ts', moduleExports: expression },
+  { label: 'shared/directives.d.ts', dts: 'shared/directives.d.ts', moduleExports: directives },
+];
+
+for (const { label, dts, moduleExports } of modules) {
+  test(`${label}: every runtime export has a declaration`, () => {
+    const declared = declaredNames(dts);
+    const actual = Object.keys(moduleExports).sort();
+    const missing = actual.filter((name) => !declared.has(name));
+    assert.deepEqual(missing, [], `${label} is missing declarations for: ${missing.join(', ')}`);
+  });
+
+  test(`${label}: every declaration names a real export`, () => {
+    const declared = declaredNames(dts);
+    const actual = Object.keys(moduleExports);
+    const phantom = [...declared].filter((name) => !actual.includes(name));
+    assert.deepEqual(phantom, [], `${label} declares symbols that are not exported: ${phantom.join(', ')}`);
+  });
+}
+
+test('sanity: the main entry point re-exports raw but not isRaw/unwrapRaw', () => {
+  assert.equal('raw' in runtime, true);
+  assert.equal('isRaw' in runtime, false);
+  assert.equal('unwrapRaw' in runtime, false);
+  assert.equal('isRaw' in escape, true);
+  assert.equal('unwrapRaw' in escape, true);
+});

--- a/packages/runtime/types/index.d.ts
+++ b/packages/runtime/types/index.d.ts
@@ -18,6 +18,11 @@ export function computed<T>(fn: () => T): Signal<T>;
 export function effect(fn: () => void | (() => void)): EffectHandle;
 
 /**
+ * Batches signal writes so subscribed effects run once after `fn` returns, instead of once per write.
+ */
+export function batch<T>(fn: () => T): T;
+
+/**
  * Hydrates a DOM subtree, activating template directives and reactive bindings.
  * Returns a dispose function to clean up all bindings.
  */
@@ -193,3 +198,140 @@ export function observeCLS(callback: (value: number) => void): (() => void) | nu
 export function observeFCP(callback: (value: number) => void): (() => void) | null;
 export function observeTTFB(callback: (value: number) => void): (() => void) | null;
 export function observeINP(callback: (value: number) => void): (() => void) | null;
+
+// --- Signal Write Observers ---
+// Distinct from the Plugin/PluginRegistry system above: this is a lower-level hook
+// notified synchronously on every signal write, independent of the directive/lifecycle
+// plugin API.
+
+export interface SignalPlugin {
+  /** Called synchronously after any signal's value changes. */
+  onSignalWrite?: (signal: Signal<unknown>, previousValue: unknown, nextValue: unknown) => void;
+}
+
+/**
+ * Registers a signal write observer. Returns a function that unregisters it.
+ */
+export function registerPlugin(plugin: SignalPlugin): () => void;
+
+// --- Output Escaping ---
+// Re-exported from ./shared/escape.js. The other functions in that module
+// (isRaw, unwrapRaw, escapeText, escapeAttr, isUrlAttribute, sanitizeUrl,
+// findInterpolations) are subpath-only — see @basenative/runtime/shared/escape.
+
+/** Marker produced by `raw()`; exempt from HTML escaping in `{{ }}` interpolation. */
+export interface RawHtml {
+  readonly value: string;
+}
+
+/**
+ * Marks `value` as trusted markup, exempt from HTML escaping. Does not exempt the
+ * value from the URL-scheme guard on href-style attribute bindings.
+ */
+export function raw(value: unknown): RawHtml;
+
+// --- Error Boundary ---
+
+export interface ErrorBoundaryOptions {
+  /** Called with the caught error. */
+  onError?: (error: Error) => void;
+  /** Fallback HTML string returned by getFallback(). */
+  fallback?: string;
+}
+
+export interface ErrorBoundary {
+  /** Runs `fn`, returning its result or `null` if it throws. */
+  try<T>(fn: () => T): T | null;
+  /** Returns the last caught error, or null if none has been caught. */
+  getError(): Error | null;
+  /** Returns whether an error has been caught. */
+  hasError(): boolean;
+  /** Returns the configured fallback HTML string, or '' if none was given. */
+  getFallback(): string;
+  /** Clears the caught error state. */
+  reset(): void;
+}
+
+/**
+ * Creates an error boundary that wraps template rendering, backing the `@catch` directive.
+ */
+export function createErrorBoundary(options?: ErrorBoundaryOptions): ErrorBoundary;
+
+/**
+ * Server-side error boundary for render(): runs `renderFn`, returning its HTML or a fallback comment/string on error.
+ */
+export function renderWithBoundary(
+  renderFn: () => string,
+  options?: { onError?: (error: Error) => void; fallback?: string },
+): string;
+
+// --- Devtools ---
+
+/**
+ * Enables devtools instrumentation and installs `globalThis.__BASENATIVE_DEVTOOLS__`.
+ */
+export function enableDevtools(): void;
+
+/** Disables devtools and clears all tracked signals, effects, and hydrations. */
+export function disableDevtools(): void;
+
+/** Returns whether devtools instrumentation is enabled. */
+export function isDevtoolsEnabled(): boolean;
+
+/** Registers a signal for devtools inspection; a no-op unless devtools are enabled. */
+export function trackSignal(accessor: Signal<unknown>, label?: string): number | undefined;
+
+/** Registers an effect for devtools inspection; a no-op unless devtools are enabled. */
+export function trackEffect(handle: EffectHandle, label?: string): number | undefined;
+
+/** Records a hydration event on the devtools timeline; a no-op unless devtools are enabled. */
+export function recordHydration(
+  root: Element | null | undefined,
+  details?: { directivesProcessed?: number; duration?: number },
+): void;
+
+// --- Debug Mode ---
+
+export interface DebugOptions {
+  /** Prefix for log messages, e.g. 'HomePage'. */
+  label?: string;
+  /** Custom logger (default: console). */
+  logger?: Pick<Console, 'debug' | 'info' | 'warn' | 'error'>;
+  /** Also log signal reads (very verbose, default: false). */
+  trackReads?: boolean;
+}
+
+export interface DebugStats {
+  signalsCreated: number;
+  effectsCreated: number;
+  signalWrites: number;
+  signalReads: number;
+  effectRuns: number;
+}
+
+/** Enables debug mode: wraps signal/effect helpers with verbose console logging. */
+export function enableDebug(options?: DebugOptions): void;
+
+/** Disables debug mode and resets accumulated stats. */
+export function disableDebug(): void;
+
+/** Returns whether debug mode is active. */
+export function isDebugEnabled(): boolean;
+
+/** Returns a copy of the accumulated debug statistics. */
+export function getDebugStats(): DebugStats;
+
+/** Wraps a signal with debug logging; the returned signal has an identical API. */
+export function debugSignal<T>(signal: Signal<T>, name?: string): Signal<T>;
+
+/** Wraps an effect with debug logging that reports execution count and timing. */
+export function debugEffect(fn: () => void | (() => void), name?: string): EffectHandle;
+
+/** Runs `fn`, logging its execution time in debug mode; returns `fn`'s result either way. */
+export function debugTime<T>(label: string, fn: () => T): T;
+
+/** Asserts a reactive invariant in debug mode; throws if `condition` is false. No-op when debug mode is off. */
+export function debugAssert(condition: boolean, message: string): void;
+
+/** Logs a signal's (or plain value's) current value under `name`. No-op when debug mode is off. */
+export function debugDeps(value: unknown, name?: string): void;

--- a/packages/runtime/types/shared/directives.d.ts
+++ b/packages/runtime/types/shared/directives.d.ts
@@ -1,0 +1,33 @@
+/**
+ * Types for `@basenative/runtime/shared/directives` — the registry `render()`/
+ * `hydrate()` consult for plugin-contributed directives (e.g. `@feature` from
+ * `@basenative/flags`, `@t` from `@basenative/i18n`). Also re-exported from the
+ * package root (see ../index.d.ts).
+ */
+
+export type DirectiveHandler = (
+  value: string,
+  ctx: Record<string, unknown>,
+  options?: Record<string, unknown>,
+) => unknown;
+
+export interface DirectiveDefinition {
+  on: 'template' | 'element';
+  server?: DirectiveHandler;
+  client?: DirectiveHandler;
+}
+
+/** Registers a directive under `@<name>`. Throws if the name is already registered. */
+export function registerDirective(
+  name: string,
+  config: { on?: 'template' | 'element'; server?: DirectiveHandler; client?: DirectiveHandler },
+): void;
+
+/** Removes a directive registration. */
+export function unregisterDirective(name: string): void;
+
+/** Returns the registration for `name`, or `undefined` if none exists. */
+export function getDirective(name: string): DirectiveDefinition | undefined;
+
+/** Returns the names of every currently registered directive. */
+export function listDirectives(): string[];

--- a/packages/runtime/types/shared/escape.d.ts
+++ b/packages/runtime/types/shared/escape.d.ts
@@ -1,0 +1,58 @@
+/**
+ * Types for `@basenative/runtime/shared/escape` — the output-escaping module shared
+ * by `hydrate()` and `@basenative/server`'s `render()`. `raw` is also re-exported
+ * from the package root (see ../index.d.ts); every other export here is subpath-only.
+ */
+
+/** Marker produced by `raw()`; exempt from HTML escaping in `{{ }}` interpolation. */
+export interface RawHtml {
+  readonly value: string;
+}
+
+/**
+ * Marks `value` as trusted markup, exempt from HTML escaping. Does not exempt the
+ * value from the URL-scheme guard on href-style attribute bindings.
+ */
+export function raw(value: unknown): RawHtml;
+
+/** Returns whether `value` was produced by `raw()`. */
+export function isRaw(value: unknown): value is RawHtml;
+
+/** Returns the underlying string of a raw value, or `value` unchanged otherwise. */
+export function unwrapRaw<T>(value: T): T extends RawHtml ? string : T;
+
+/** Escapes `value` for insertion into a text node: `&`, `<`, `>`. */
+export function escapeText(value: unknown): string;
+
+/** Escapes `value` for a double-quoted attribute value: escapeText plus `"` and `'`. */
+export function escapeAttr(value: unknown): string;
+
+/**
+ * Returns whether `name` (case-insensitive) is one of the attributes whose value is
+ * fetched or navigated to: href, src, action, formaction, data, poster, xlink:href,
+ * ping, background, srcdoc, codebase.
+ */
+export function isUrlAttribute(name: string): boolean;
+
+/**
+ * Strips control characters and whitespace, then returns `null` if what remains
+ * starts with a `javascript:`, `vbscript:`, `data:`, `blob:`, or `file:` scheme.
+ * Returns the original value unchanged otherwise.
+ */
+export function sanitizeUrl(value: unknown): string | null;
+
+/** One `{{ expression }}` interpolation located by `findInterpolations`. */
+export interface Interpolation {
+  /** Index of the opening `{{` in the source text. */
+  start: number;
+  /** Index just past the closing `}}` in the source text. */
+  end: number;
+  /** The trimmed expression source between the braces. */
+  expression: string;
+}
+
+/**
+ * Locates every `{{ expression }}` in `text`, scanning linearly with `indexOf`
+ * rather than a backtracking regex.
+ */
+export function findInterpolations(text: string): Interpolation[];

--- a/packages/runtime/types/shared/expression.d.ts
+++ b/packages/runtime/types/shared/expression.d.ts
@@ -1,0 +1,50 @@
+/**
+ * Types for `@basenative/runtime/shared/expression` — the CSP-safe expression
+ * evaluator used internally by both `hydrate()` (client) and `@basenative/server`'s
+ * `render()` (SSR). No `eval`, no `new Function`: expressions are tokenized and
+ * parsed into a small AST, then walked by an interpreter with an explicit
+ * operation allowlist.
+ */
+
+/** A successfully compiled expression, cached by trimmed source string. */
+export interface CompiledExpression {
+  source: string;
+  ast: unknown;
+}
+
+/** A compiled expression that failed to parse. */
+export interface FailedExpression {
+  source: string;
+  error: Error;
+}
+
+/** The `Symbol.for('basenative.scopeSlot')` used to tag scope slots. */
+export const SCOPE_SLOT: symbol;
+
+/**
+ * Returns whether `value` is a "scope slot" — an object tagged with `SCOPE_SLOT`
+ * and exposing a `.get()` method, used internally to thread `@for` loop variables
+ * through nested scopes.
+ */
+export function isScopeSlot(value: unknown): boolean;
+
+/**
+ * Parses `source` into `{ source, ast }`, or `{ source, error }` on a syntax
+ * error. Cached by trimmed source string.
+ */
+export function compileExpression(source: string): CompiledExpression | FailedExpression;
+
+/**
+ * Compiles (if `source` is a string) and evaluates an expression against a
+ * context object. Returns `undefined` and reports a diagnostic through
+ * `options.onDiagnostic` instead of throwing, on both a compile error and an
+ * evaluation-time error.
+ */
+export function evaluateExpression(
+  source: string | CompiledExpression | FailedExpression,
+  ctx?: Record<string, unknown>,
+  options?: { onDiagnostic?: (diagnostic: Record<string, unknown>) => void },
+): unknown;
+
+/** Empties the module-level compile cache. */
+export function clearExpressionCache(): void;


### PR DESCRIPTION
## Summary

Two upstream gaps surfaced by GreenPut's migration off its vendored BaseNative copy (GreenPut PR #89, `refactor/basenative-packages`).

### 1. `@basenative/runtime` types were missing 20 of 47 public exports

`types/index.d.ts` declared only 27 of the runtime's actual exports. Missing: `raw`, `isRaw`/`unwrapRaw` (subpath-only), `batch`, `registerPlugin`, and the entire error-boundary, devtools, and debug-mode APIs. GreenPut had to hand-write a module-augmentation shim (`libs/basenative/types/basenative-runtime.d.ts`) just to type `raw()`.

- Added all 20 missing declarations to `types/index.d.ts`, with one-line JSDoc, read from source.
- Added `types` conditions to the `./shared/expression`, `./shared/escape`, and `./shared/directives` subpath exports, each backed by a new standalone `.d.ts` (these were previously untyped for consumers).
- Added `packages/runtime/types/exports.test.js`, a drift guard (modelled on `packages/components/types/exports.test.js`) asserting the declared surface exactly matches the real one, for the root entry and all three subpaths.
- `packages/runtime`: 463 → 472 tests (`node --test`), all green.

**GreenPut can delete `libs/basenative/types/basenative-runtime.d.ts` once this ships.**

### 2. `@basenative/router` had no navigation guard API

GreenPut kept a parallel `libs/basenative/router-guards` package (`guards.ts` + 19 vitest specs) because the published router has no way to intercept, redirect, or abort navigation.

Implemented the same behavior upstream, opt-in, in `packages/router/src/guards.js`:

```js
withGuards(router: Router): GuardedRouter   // navigate() returns Promise<boolean>
redirect(to: string, replace = true): never // throws RedirectError
class RedirectError extends Error
```

- `beforeEach(guard)` / `afterEach(handler)` hooks; guards run sequentially in registration order against a preview of the destination route, and the first guard that aborts (returns `false`, a path string, `{ redirect }`, or throws `RedirectError`) stops the chain. Starting a new `navigate()` aborts one still running guards. Any other thrown error propagates rather than being treated as an abort.
- `createRouter()`'s own return value is untouched — guards are entirely opt-in.
- Exported from the package root and a new `./guards` subpath, both typed (`types/guards.d.ts` + additions to `types/index.d.ts`).
- Documented in `packages/router/README.md` and `docs/api/router.md`.
- All 19 specs from GreenPut's `guards.spec.ts` ported verbatim (same assertions) to `node:test` in `packages/router/src/guards.test.js`, using a `happy-dom` `Window` per test (already a workspace devDependency, used the same way in `packages/runtime/src/hydrate.test.js`) since `createRouter()` needs `location`/`history`/`window`.
- Zero new dependencies.
- `packages/router`: 52 → 71 tests (`node --test`), all green.

**GreenPut can delete `libs/basenative/router-guards` (and the `@greenput/router-guards` alias) once this ships.**

### Also included

- Regenerated `llms.txt`/`llms-full.txt` and `docs/package-inventory.md` (`node scripts/llms-txt.js && node scripts/package-inventory.js` from `packages/mcp`) to pick up the new router docs and current registry/publish state — both `--check` scripts pass.
- Two changesets: `@basenative/runtime` patch, `@basenative/router` minor.

## Test plan

- [x] `cd packages/runtime && node --test` — 472/472 passing (was 463)
- [x] `cd packages/router && node --test` — 71/71 passing (was 52)
- [x] `pnpm exec eslint src/` clean in both `packages/runtime` and `packages/router`
- [x] `node scripts/package-inventory.js --check` and `node scripts/llms-txt.js --check` both pass
- [x] Spot-checked `packages/server` (a runtime consumer) still passes after the `package.json` `exports` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)