### PR TITLE
fix: clear last 3 open CodeQL alerts (#140, #35, #34)

### DIFF
--- a/.changeset/middleware-cookie-proto-guard.md
+++ b/.changeset/middleware-cookie-proto-guard.md
@@ -1,0 +1,5 @@
+---
+"@basenative/middleware": patch
+---
+
+Fix CodeQL `js/remote-property-injection` (alert #34) by adding an explicit `__proto__`/`constructor`/`prototype` guard before writing parsed cookie names in the Express adapter's `parseCookieHeader`, alongside the existing null-prototype object.

--- a/.changeset/server-attr-quote-sink.md
+++ b/.changeset/server-attr-quote-sink.md
@@ -1,0 +1,5 @@
+---
+"@basenative/server": patch
+---
+
+Fix CodeQL `js/incomplete-html-attribute-sanitization` (alert #140) by applying a final, literal `"` → `&quot;` replace at the attribute serialisation sink in `render.js`, making the sink itself provably quote-free instead of relying on upstream escaping alone.

--- a/.changeset/upload-headers-map.md
+++ b/.changeset/upload-headers-map.md
@@ -1,0 +1,5 @@
+---
+"@basenative/upload": patch
+---
+
+Fix CodeQL `js/remote-property-injection` (alert #35) by storing parsed multipart header names in a `Map` instead of a plain object, eliminating the dynamic-property-write sink entirely for this internal, never-exposed header store.

--- a/.changeset/upload-proto-guard.md
+++ b/.changeset/upload-proto-guard.md
@@ -1,5 +1,0 @@
----
-"@basenative/upload": patch
----
-
-Fix CodeQL `js/remote-property-injection` (alert #35) by adding an explicit `__proto__`/`constructor`/`prototype` guard before writing parsed multipart header names into the headers object, alongside the existing null-prototype object.

--- a/.changeset/upload-proto-guard.md
+++ b/.changeset/upload-proto-guard.md
@@ -1,0 +1,5 @@
+---
+"@basenative/upload": patch
+---
+
+Fix CodeQL `js/remote-property-injection` (alert #35) by adding an explicit `__proto__`/`constructor`/`prototype` guard before writing parsed multipart header names into the headers object, alongside the existing null-prototype object.

--- a/packages/middleware/src/adapters/express.js
+++ b/packages/middleware/src/adapters/express.js
@@ -84,6 +84,10 @@ function parseCookieHeader(header) {
     if (eqIndex === -1) continue;
     const key = pair.slice(0, eqIndex).trim();
     const value = pair.slice(eqIndex + 1).trim();
+    // Explicit prototype-pollution guard on the exact key being written, in
+    // addition to the null-prototype object above: CodeQL's remote-property-
+    // injection check requires this guard shape immediately before the write.
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
     result[key] = decodeURIComponent(value);
   }
   return result;

--- a/packages/middleware/src/middleware.test.js
+++ b/packages/middleware/src/middleware.test.js
@@ -554,6 +554,24 @@ describe('Express adapter', () => {
     assert.equal(ctx.request.cookies.b, '2');
   });
 
+  it('ignores __proto__/constructor/prototype cookie names but still parses normal ones', () => {
+    const req = {
+      method: 'GET',
+      originalUrl: '/test',
+      path: '/test',
+      headers: { cookie: '__proto__=polluted; constructor=polluted; prototype=polluted; a=1' },
+      cookies: undefined,
+      query: {},
+      body: undefined,
+      ip: '1.1.1.1',
+      params: {},
+    };
+    const ctx = createExpressContext(req, {});
+    assert.equal(ctx.request.cookies.a, '1');
+    assert.equal({}.polluted, undefined);
+    assert.equal(Object.prototype.polluted, undefined);
+  });
+
   it('toExpressMiddleware calls next when no body is set', async () => {
     const pipeline = createPipeline();
     pipeline.use(async (ctx, next) => { ctx.state.ran = true; await next(); });

--- a/packages/server/src/escaping.test.js
+++ b/packages/server/src/escaping.test.js
@@ -56,6 +56,12 @@ describe('attribute escaping', () => {
       '<div title="&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;">x</div>'
     );
   });
+
+  it('escapes a bare double quote in a bound :attr value', () => {
+    // Pins the final quote-strip at the attribute serialisation sink itself
+    // (packages/server/src/render.js), not just the upstream escapeAttr() call.
+    assert.equal(render('<div :title="v">x</div>', { v: 'x"y' }), '<div title="x&quot;y">x</div>');
+  });
 });
 
 describe('URL scheme guard', () => {

--- a/packages/server/src/render.js
+++ b/packages/server/src/render.js
@@ -167,7 +167,16 @@ function processNode(node, ctx, options) {
     }
 
     node.rawAttrs = attrs
-      .map(attr => (attr.value !== '' ? `${attr.name}="${attr.value}"` : attr.name))
+      .map(attr => {
+        if (attr.value === '') return attr.name;
+        // Final belt-and-braces quote strip at the exact point of serialisation:
+        // every upstream path (escapeAttr, interpolate, or the static-text
+        // fallback) already removes quotes, but this makes the sink itself
+        // provably quote-free. Idempotent on already-escaped input since
+        // `&quot;` contains no `"`.
+        const safeValue = String(attr.value).replace(/"/g, '&quot;');
+        return `${attr.name}="${safeValue}"`;
+      })
       .join(' ');
   }
 

--- a/packages/upload/src/handler.js
+++ b/packages/upload/src/handler.js
@@ -22,7 +22,13 @@ export function parseMultipart(body, contentType) {
 
     for (const line of headerSection.split('\r\n')) {
       const match = line.match(/^([^:]+):\s*(.+)$/);
-      if (match) headers[match[1].toLowerCase()] = match[2];
+      if (!match) continue;
+      const key = match[1].toLowerCase();
+      // Explicit prototype-pollution guard on the exact key being written, in
+      // addition to the null-prototype object above: CodeQL's remote-property-
+      // injection check requires this guard shape immediately before the write.
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+      headers[key] = match[2];
     }
 
     const disposition = headers['content-disposition'] ?? '';

--- a/packages/upload/src/handler.js
+++ b/packages/upload/src/handler.js
@@ -15,30 +15,26 @@ export function parseMultipart(body, contentType) {
   return parts.map(part => {
     const [headerSection, ...bodyParts] = part.split('\r\n\r\n');
     const bodyContent = bodyParts.join('\r\n\r\n').replace(/\r\n$/, '');
-    // Header names come straight from the request body. A null-prototype
-    // object means a crafted name like `__proto__` becomes an inert own
-    // property instead of reaching Object.prototype.
-    const headers = Object.create(null);
+    // Header names come straight from the request body. A Map keyed by
+    // arbitrary strings (rather than a plain object written with a computed
+    // property name) has no prototype chain to pollute — `__proto__`,
+    // `constructor`, etc. are just ordinary map keys, and this object never
+    // leaves this function, so there is no public shape to preserve.
+    const headers = new Map();
 
     for (const line of headerSection.split('\r\n')) {
       const match = line.match(/^([^:]+):\s*(.+)$/);
-      if (!match) continue;
-      const key = match[1].toLowerCase();
-      // Explicit prototype-pollution guard on the exact key being written, in
-      // addition to the null-prototype object above: CodeQL's remote-property-
-      // injection check requires this guard shape immediately before the write.
-      if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
-      headers[key] = match[2];
+      if (match) headers.set(match[1].toLowerCase(), match[2]);
     }
 
-    const disposition = headers['content-disposition'] ?? '';
+    const disposition = headers.get('content-disposition') ?? '';
     const nameMatch = disposition.match(/name="([^"]+)"/);
     const filenameMatch = disposition.match(/filename="([^"]+)"/);
 
     return {
       name: nameMatch?.[1] ?? '',
       filename: filenameMatch?.[1] ?? null,
-      contentType: headers['content-type'] ?? 'application/octet-stream',
+      contentType: headers.get('content-type') ?? 'application/octet-stream',
       data: Buffer.from(bodyContent, 'binary'),
       size: Buffer.byteLength(bodyContent, 'binary'),
     };

--- a/packages/upload/src/upload.test.js
+++ b/packages/upload/src/upload.test.js
@@ -97,7 +97,7 @@ describe('parseMultipart', () => {
     assert.equal(parts[0].name, 'field');
   });
 
-  it('ignores __proto__/constructor/prototype header names but still parses normal ones', () => {
+  it('does not prototype-pollute on __proto__/constructor/prototype header names, and still parses normal ones', () => {
     const boundary = 'protobound';
     const body = `--${boundary}\r\n__proto__: polluted\r\nconstructor: polluted\r\nprototype: polluted\r\nContent-Disposition: form-data; name="field1"\r\nContent-Type: text/plain\r\n\r\nvalue1\r\n--${boundary}--`;
     const parts = parseMultipart(body, `multipart/form-data; boundary=${boundary}`);

--- a/packages/upload/src/upload.test.js
+++ b/packages/upload/src/upload.test.js
@@ -96,6 +96,17 @@ describe('parseMultipart', () => {
     assert.equal(parts.length, 1);
     assert.equal(parts[0].name, 'field');
   });
+
+  it('ignores __proto__/constructor/prototype header names but still parses normal ones', () => {
+    const boundary = 'protobound';
+    const body = `--${boundary}\r\n__proto__: polluted\r\nconstructor: polluted\r\nprototype: polluted\r\nContent-Disposition: form-data; name="field1"\r\nContent-Type: text/plain\r\n\r\nvalue1\r\n--${boundary}--`;
+    const parts = parseMultipart(body, `multipart/form-data; boundary=${boundary}`);
+    assert.equal(parts.length, 1);
+    assert.equal(parts[0].name, 'field1');
+    assert.equal(parts[0].contentType, 'text/plain');
+    assert.equal({}.polluted, undefined);
+    assert.equal(Object.prototype.polluted, undefined);
+  });
 });
 
 // ---- createLocalStorage ----


### PR DESCRIPTION
## Summary

Closes out the three remaining open CodeQL alerts on `main` after #164 and #165, bringing the main-branch scan to zero.

- **#140 `js/incomplete-html-attribute-sanitization`** (`packages/server/src/render.js:170`): the final attribute-serialisation sink now applies its own literal, un-chained `"` → `&quot;` replace on the exact value being interpolated, immediately at the point of serialisation — in addition to the existing `escapeAttr`/`interpolate`/static-text escaping paths. This makes the sink itself provably quote-free in a form CodeQL's sanitizer recognition accepts, and is idempotent on already-escaped input (`&quot;` contains no `"`), so behavior is unchanged. Pinned with a new test: `:title` bound to `x"y` renders `title="x&quot;y"`.
- **#34 `js/remote-property-injection`** (`packages/middleware/src/adapters/express.js`): added an explicit `__proto__`/`constructor`/`prototype` guard immediately before the write of a parsed cookie name in `parseCookieHeader`, alongside the existing null-prototype object from #164. This keeps the public shape consumers rely on (`req.cookies.name`) and CodeQL accepted the guard as a barrier — confirmed clean on this PR's analysis.
- **#35 `js/remote-property-injection`** (`packages/upload/src/handler.js`): the equivalent explicit guard (first commit) did *not* satisfy CodeQL here — the PR's own CodeQL run still flagged the write at the guard's new line. Since the per-part `headers` map is purely internal to `parseMultipart()` (never exposed to callers — only `name`/`filename`/`contentType` derived from it are returned), the second commit switches it to a `Map` instead, which removes the dynamic-property-write sink entirely (`Map#set()` is a method call, not a computed property write). Confirmed clean on this PR's analysis.

## Test plan

- [x] `node --test` in `packages/server`: 191 → 192 tests, all passing
- [x] `node --test` in `packages/upload`: 51 → 52 tests, all passing
- [x] `node --test` in `packages/middleware`: 65 → 66 tests, all passing
- [x] `eslint src/` clean in `server`, `upload`, `middleware`
- [x] Added `patch` changesets for `@basenative/server`, `@basenative/upload`, `@basenative/middleware`
- [x] CodeQL check on this PR (commit `07c2ecf`) is green, and `code-scanning/alerts?pr=168&state=open` returns an empty list — alerts #140, #35, #34 (and the transient new alert raised by the first commit's incomplete upload fix) do not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
