### PR TITLE
chore(examples): align the Workers example compatibility_date with the repo

### DIFF
--- a/examples/cloudflare-workers/wrangler.toml
+++ b/examples/cloudflare-workers/wrangler.toml
@@ -1,6 +1,6 @@
 name = "basenative-worker"
 main = "src/worker.js"
-compatibility_date = "2024-01-01"
+compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 
 [build]


### PR DESCRIPTION
`examples/cloudflare-workers/wrangler.toml` pinned `compatibility_date = "2024-01-01"`, which predates the `nodejs_compat` behaviour that resolves bare Node builtins (2024-09-23) and bit t4bs tonight (satori → harfbuzzjs `require("fs")`). Align it with the root `wrangler.toml` (2025-04-01) so the example reflects what we run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)