### PR TITLE
fix(middleware): allow-list cookie names to the RFC 6265 token charset

### DIFF
--- a/.changeset/middleware-cookie-name-charset.md
+++ b/.changeset/middleware-cookie-name-charset.md
@@ -1,0 +1,5 @@
+---
+"@basenative/middleware": patch
+---
+
+The Express adapter's cookie parser now only accepts RFC 6265 token characters in cookie names; names containing separators, spaces or control characters are dropped instead of becoming properties.

--- a/packages/middleware/src/adapters/express.js
+++ b/packages/middleware/src/adapters/express.js
@@ -73,6 +73,9 @@ function createExpressContext(req, _res) {
   };
 }
 
+// RFC 6265 cookie-name = token (RFC 7230 tchar): no CTLs, separators or spaces.
+const COOKIE_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
 function parseCookieHeader(header) {
   if (!header) return {};
   // Cookie names come straight from the request header. A null-prototype
@@ -84,10 +87,11 @@ function parseCookieHeader(header) {
     if (eqIndex === -1) continue;
     const key = pair.slice(0, eqIndex).trim();
     const value = pair.slice(eqIndex + 1).trim();
-    // Explicit prototype-pollution guard on the exact key being written, in
-    // addition to the null-prototype object above: CodeQL's remote-property-
-    // injection check requires this guard shape immediately before the write.
-    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+    // Only RFC 6265 cookie-name tokens are accepted as property names; anything
+    // else (separators, control characters, `__proto__`-style names) is dropped
+    // rather than written. This is the allow-list check the property write
+    // depends on, in addition to the null-prototype object above.
+    if (!COOKIE_NAME.test(key) || key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
     result[key] = decodeURIComponent(value);
   }
   return result;

--- a/packages/middleware/src/middleware.test.js
+++ b/packages/middleware/src/middleware.test.js
@@ -572,6 +572,23 @@ describe('Express adapter', () => {
     assert.equal(Object.prototype.polluted, undefined);
   });
 
+  it('drops cookie names outside the RFC 6265 token charset and keeps valid ones', () => {
+    const req = {
+      method: 'GET',
+      originalUrl: '/test',
+      path: '/test',
+      headers: { cookie: 'bad name=1; bad;semi=2; "quoted"=3; ok_name-1.x=4; __proto__=5' },
+      cookies: undefined,
+      query: {},
+      body: undefined,
+      ip: '1.1.1.1',
+      params: {},
+    };
+    const ctx = createExpressContext(req, {});
+    assert.deepEqual(Object.keys(ctx.request.cookies), ['semi', 'ok_name-1.x']);
+    assert.equal(ctx.request.cookies['ok_name-1.x'], '4');
+  });
+
   it('toExpressMiddleware calls next when no body is set', async () => {
     const pipeline = createPipeline();
     pipeline.use(async (ctx, next) => { ctx.state.ran = true; await next(); });


### PR DESCRIPTION
## Why

CodeQL alert 34 (`js/remote-property-injection`, `packages/middleware/src/adapters/express.js`) still fires on `main` after #168: the cookie parser writes `result[key]` with a name taken from the request header.

## What

Cookie names are validated against the RFC 6265 token grammar (`^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$`) before the write; anything else is dropped. The null-prototype object and the explicit `__proto__`/`constructor`/`prototype` guard stay. New test covers spaces, separators, quoted names and a valid dotted name. Changeset: patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)