### PR TITLE
chore(llms-txt): ignore comment bodies when scanning exports; refresh the AI backlog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,22 +379,22 @@ The five epics that used to live here are done. Where each landed:
 | Feature flags on KV, `registerPlugin()` | `packages/flags/src/providers/kv.js`, `packages/runtime/src/signals.js` |
 | `@t` / `@feature` template directives | `packages/runtime/src/shared/directives.js` (`registerDirective` hook, consulted by `render.js`/`hydrate.js`), `packages/flags/src/directive.js`, `packages/i18n/src/directive.js` |
 | Eval harness hydrate stage (T3 stateful scoring) | `packages/evals/src/hydrate.js`, `after_set`/`hydrated_*` assertions in `packages/evals/src/assertions.js` (PR #155) |
+| CodeQL backlog (79 alerts → 0) + notify on the shared escaper | PRs #164/#165/#168/#172; `packages/notify/src/email.js` uses `@basenative/runtime/shared/escape` with `raw()` |
+| Documentation gaps (llms-full Gaps 77 → 0) | `docs/api/*.md` for every package; `scripts/llms-txt.js` masks comments before scanning exports |
+| Components design-system + a11y pass | `packages/components/src/{tokens,theme,components}.css`, tooltip `<button>` invoker, roving tabindex, calendar row fix |
+| Router navigation guards; complete runtime types | `packages/router/src/guards.js` (`withGuards`/`redirect`), `packages/runtime/types/**` + `types/exports.test.js` |
 
 An abandoned parallel builder implementation is preserved at tag `archive/feat-visual-builder-2026-04`; it is not a backlog item.
 
 ### Open — specified well enough to start without asking
 
-1. **Documentation drift**, recorded mechanically in the Gaps section of `llms-full.txt` (regenerate with `scripts/llms-txt.js`): ~30 undocumented `@basenative/components` exports; `createKVProvider` missing from `docs/api/flags.md`. (The runtime part of this item — `devtools`/`debug`/`lazy`/`vitals`/`plugins`/`error-boundary`/`batch`/`registerPlugin`/`shared/escape`/`shared/expression` exports missing from `docs/api/runtime.md` — shipped; see `docs/api/runtime.md` and `packages/runtime/README.md`.)
-2. **CodeQL backlog on `main`** (79 pre-existing alerts; a PR from `fix/codeql-backlog` is in flight — check it first): `packages/notify/src/email.js` interpolates `{{ }}` into HTML email with no escaping (same class as the SSR fix in `@basenative/server`); `packages/notify/src/transports/smtp.js` sets `rejectUnauthorized: false`; `packages/share/src/server.js` `shortId` has modulo bias; eleven file-system races in `cli`, `claude-config`, `doppler`; path injection in `examples/starter` and `scripts/audit`.
-3. **Escaping parity**: `packages/notify` should use `@basenative/runtime/shared/escape` rather than its own regex templating, once item 2 lands.
-4. **`.tabnine/agent/skills/`** is a committed third copy of the seven Nx skills now supplied by the `nx@nx-claude-plugins` plugin. Remove once the owner confirms nothing consumes it.
-
+1. **`.tabnine/agent/skills/`** is a committed third copy of the seven Nx skills now supplied by the `nx@nx-claude-plugins` plugin. Remove once the owner confirms nothing consumes it.
 
 ### Needs owner direction — do not guess
 
 - The eval corpus (`packages/evals/prompts/`, `fixtures/`) — PRD W2. Human-authored only.
 - The launch essay (PRD W5.4) — blocked on eval results that do not exist yet.
-- The registry question: 17 packages have never been published anywhere and none is at 1.0 (`docs/package-inventory.md`). Publish, or mark private, is a per-package product call.
+- The registry question: every non-private package is now published to GitHub Packages under the `basenative` org (37 in sync, 3 private on 2026-09-10 — `docs/package-inventory.md`). What remains is a product call: whether to mirror to npmjs, and which packages graduate to 1.0.
 
 ## General Guidelines for working with Nx
 

--- a/scripts/llms-txt.js
+++ b/scripts/llms-txt.js
@@ -194,6 +194,19 @@ function resolveModule(fromAbsFile, spec) {
 const fileExportCache = new Map();
 
 /**
+ * Blank out `/* … *\/` blocks and whole-line `//` comments, preserving length
+ * and newlines so every index still maps onto the original text. Strings are
+ * left alone (a `//` inside a URL string is not a comment) — only line
+ * comments that start a line are masked, which is where usage examples live.
+ */
+function maskComments(source) {
+  const blank = (m) => m.replace(/[^\n]/g, ' ');
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, blank)
+    .replace(/^[ \t]*\/\/[^\n]*/gm, blank);
+}
+
+/**
  * Extract exported symbols from a JS source file, following `export { x }
  * from './y.js'` and `export * as ns from './y.js'` one or more levels deep.
  * Returns [{ name, kind, params, doc, file }] — `file` cites the file where
@@ -205,6 +218,11 @@ function getFileExports(absFile, visiting = new Set()) {
   visiting.add(absFile);
 
   const content = readFileSync(absFile, 'utf8');
+  // Export patterns are matched against a copy with comment bodies blanked
+  // out (same length, so indices still address `content`): otherwise an
+  // `export const onRequestPost = …` inside a JSDoc usage example is reported
+  // as a real export and shows up as an undocumented gap.
+  const code = maskComments(content);
   const results = [];
   const consumedSpans = [];
 
@@ -212,7 +230,7 @@ function getFileExports(absFile, visiting = new Set()) {
   const isConsumed = (index) => consumedSpans.some(([s, e]) => index >= s && index < e);
 
   // export function / export async function
-  for (const m of content.matchAll(/export\s+(async\s+function|function)\s+([A-Za-z0-9_$]+)\s*\(/g)) {
+  for (const m of code.matchAll(/export\s+(async\s+function|function)\s+([A-Za-z0-9_$]+)\s*\(/g)) {
     const openIdx = m.index + m[0].length - 1;
     const params = balancedParams(content, openIdx);
     results.push({
@@ -226,7 +244,7 @@ function getFileExports(absFile, visiting = new Set()) {
   }
 
   // export class
-  for (const m of content.matchAll(/export\s+class\s+([A-Za-z0-9_$]+)/g)) {
+  for (const m of code.matchAll(/export\s+class\s+([A-Za-z0-9_$]+)/g)) {
     markConsumed(m);
     results.push({
       name: m[1],
@@ -238,7 +256,7 @@ function getFileExports(absFile, visiting = new Set()) {
   }
 
   // export const NAME = ...  (captures arrow-fn params, balanced, when present)
-  for (const m of content.matchAll(/export\s+const\s+([A-Za-z0-9_$]+)\s*=\s*/g)) {
+  for (const m of code.matchAll(/export\s+const\s+([A-Za-z0-9_$]+)\s*=\s*/g)) {
     markConsumed(m);
     const valueStart = m.index + m[0].length;
     let kind = 'const';
@@ -264,7 +282,7 @@ function getFileExports(absFile, visiting = new Set()) {
 
   // export default ...
   {
-    const m = content.match(/export\s+default\s+/);
+    const m = code.match(/export\s+default\s+/);
     if (m) {
       results.push({
         name: 'default',
@@ -277,7 +295,7 @@ function getFileExports(absFile, visiting = new Set()) {
   }
 
   // export * as ns from './x.js' — namespace re-export
-  for (const m of content.matchAll(/export\s*\*\s*as\s+([A-Za-z0-9_$]+)\s+from\s*['"]([^'"]+)['"]/g)) {
+  for (const m of code.matchAll(/export\s*\*\s*as\s+([A-Za-z0-9_$]+)\s+from\s*['"]([^'"]+)['"]/g)) {
     markConsumed(m);
     const target = resolveModule(absFile, m[2]);
     const inner = target ? getFileExports(target, visiting) : [];
@@ -292,14 +310,14 @@ function getFileExports(absFile, visiting = new Set()) {
   }
 
   // export * from './x.js' — flatten target's exports into this file
-  for (const m of content.matchAll(/export\s*\*\s*from\s*['"]([^'"]+)['"]/g)) {
+  for (const m of code.matchAll(/export\s*\*\s*from\s*['"]([^'"]+)['"]/g)) {
     markConsumed(m);
     const target = resolveModule(absFile, m[1]);
     if (target) results.push(...getFileExports(target, visiting));
   }
 
   // export { a, b as c } from './x.js'
-  for (const m of content.matchAll(/export\s*\{([\s\S]*?)\}\s*from\s*['"]([^'"]+)['"]/g)) {
+  for (const m of code.matchAll(/export\s*\{([\s\S]*?)\}\s*from\s*['"]([^'"]+)['"]/g)) {
     markConsumed(m);
     const target = resolveModule(absFile, m[2]);
     const inner = target ? getFileExports(target, visiting) : [];
@@ -315,7 +333,7 @@ function getFileExports(absFile, visiting = new Set()) {
 
   // local imports, used to resolve bare `export { a as b };` (no `from`)
   const imports = new Map(); // localName -> { file, originalName }
-  for (const m of content.matchAll(/import\s*\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g)) {
+  for (const m of code.matchAll(/import\s*\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g)) {
     const target = resolveModule(absFile, m[2]);
     for (const part of m[1].split(',').map((s) => s.trim()).filter(Boolean)) {
       const asMatch = part.match(/^([A-Za-z0-9_$]+)\s+as\s+([A-Za-z0-9_$]+)$/);
@@ -326,7 +344,7 @@ function getFileExports(absFile, visiting = new Set()) {
   }
 
   // bare export { a, b as c }; (no `from`) — only over content not already consumed above
-  for (const m of content.matchAll(/export\s*\{([\s\S]*?)\}\s*;/g)) {
+  for (const m of code.matchAll(/export\s*\{([\s\S]*?)\}\s*;/g)) {
     if (isConsumed(m.index)) continue;
     for (const part of m[1].split(',').map((s) => s.trim()).filter(Boolean)) {
       const asMatch = part.match(/^([A-Za-z0-9_$]+)\s+as\s+([A-Za-z0-9_$]+)$/);


### PR DESCRIPTION
## What

- `scripts/llms-txt.js`: the export scanner ran its regexes over raw file text, so `export const onRequestPost = …` inside JSDoc usage examples (admin, auth-webauthn) was reported as a real export and an undocumented gap. Comment bodies are now masked (length-preserving, whole-line `//` and `/* */`) for the matching pass only; JSDoc extraction still reads the original text at the same indices. Regenerated `llms-full.txt` drops the three phantom entries (admin 13 → 11 exports).
- `CLAUDE.md` "Next Steps / AI Backlog": moves tonight's shipped work into the do-not-rebuild table (CodeQL backlog #164/#165/#168/#172, notify on the shared escaper, docs gaps 77 → 0, components design-system + a11y, router guards, runtime types), leaves only the owner-gated `.tabnine` item open, and replaces the stale "17 unpublished packages" note with the current inventory (37 in sync, 3 private).

Will be rebased onto #174 (docs) once that merges, since both touch `llms-full.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)